### PR TITLE
Show $PWD of processes

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -22,6 +22,51 @@ reachable. -->
 ## Documentation
 Keep `README.md` in sync with user-facing changes.
 
-<!-- Optional (add manually for the evidence step):
 ## PR evidence
--->
+
+When the change has visible UI impact, post a `## Evidence` PR comment with screenshots. Use judgment — server-only diffs (host wiring, RPC plumbing) sometimes ripple into rendering and sometimes don't.
+
+**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so the main context stays clear of MCP and screenshot noise. Brief it with: the dev-server URL, what scenarios to capture, a `/tmp/drishti-evidence-<slug>.png` filename, and the PR number. Have it return only the markdown body it should post — the calling `/do` posts it with `gh pr comment`.
+
+### Dev server
+
+Spawn a dedicated dev server on a **free random port** (the user may already have one on 7720). The `port` flag — or `PORT` env var — is the override; both flow through `cli` in `packages/app/src/server/main.ts` and default to 7720.
+
+```sh
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); p=s.getsockname()[1]; s.close(); print(p)')
+PORT=$PORT just dev localhost &
+DEV_PID=$!
+trap 'kill $DEV_PID 2>/dev/null' EXIT
+# wait for the server to print "listening on :$PORT" before driving the browser
+```
+
+For "before" shots on a bug fix, run a second server from a `git worktree` on `master` on a different free port. Never stash the PR branch.
+
+### Capture, host, post
+
+The subagent drives `chrome-devtools` MCP — `new_page` at `http://localhost:$PORT/`, waits for the htop table to populate (the agent needs one poll tick to seed the snapshot, ~2s), reproduces the relevant state, `take_screenshot` to `/tmp/drishti-evidence-<slug>.png`.
+
+`gh pr comment` can't attach binaries, so upload to a long-lived `evidence-assets` GitHub release on this repo and embed the download URL inline:
+
+```sh
+gh release view evidence-assets >/dev/null 2>&1 || \
+  gh release create evidence-assets --prerelease \
+    --title "Evidence assets (auto-uploaded by /do)" --notes "Do not delete."
+gh release upload evidence-assets /tmp/drishti-evidence-<slug>.png --clobber
+```
+
+URL pattern: `https://github.com/srid/drishti/releases/download/evidence-assets/<filename>`. Use the single-quoted heredoc pattern (`<<'EOF'`) when posting so backticks and `$` survive unescaped.
+
+### Process-table scenarios
+
+The interesting surface for drishti is the live process table — load average, memory, CPU strip, and the per-PID rows. Most PRs touching the UI want a capture of the table in its normal state, plus one for any new column / filter / dialog the diff introduces.
+
+Common scenarios worth a frame:
+
+- **Default load** — the table populated with ~hundreds of rows; proves the agent → parent → browser pipeline is alive end-to-end.
+- **Filtered view** — type into the filter input; capture the "showing N of M" counter shrinking.
+- **Sort change** — click a sortable header (PID / USER / CPU% / MEM%) and capture the descending indicator.
+- **Connecting overlay** — for changes that touch the `connection` cell (copying / connecting / disconnected states), spawn against an unreachable remote and capture the overlay.
+- **Multi-host tabs** — for changes that touch the admin surface or tab strip, launch with multiple hosts (`just dev localhost a.lan`) and capture the tab strip + connection dots.
+
+For PRs that add a per-process field (cwd, threads, fds, …), the default evidence is a **screenshot of the process table showing the new field for representative real processes** — that single frame proves the field flows schema → agent → wire → renderer end-to-end.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Per-host primitives:
 | Primitive | Path | Purpose |
 |---|---|---|
 | **Cell** | `system` | Load averages, memory, uptime, OS, hostname. |
-| **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, memPct, command }`. Snapshot-then-delta. |
+| **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, memPct, command, cwd }`. Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
 | **Stream** | `processesSnapshot` | Bulk-snapshot variant for ~600-PID htop refresh in one frame. |
 | **Collection** | `cpuCores` | Per-core CPU usage (`Collection<K,T>` showcase). |
 | **Procedure** | `process.kill` | The only mutation — sends `TERM` / `KILL` / `HUP` / `INT`. |

--- a/packages/app/src/agent/main.ts
+++ b/packages/app/src/agent/main.ts
@@ -179,7 +179,8 @@ async function main(): Promise<void> {
           prev === undefined ||
           prev.cpuPct !== value.cpuPct ||
           prev.memPct !== value.memPct ||
-          prev.command !== value.command
+          prev.command !== value.command ||
+          prev.cwd !== value.cwd
         ) {
           fragment.ctx.collections.processes.upsert(pid, value);
           upserts.push([pid, value]);

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -209,8 +209,10 @@ interface LinuxProcRaw {
 async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
   try {
     // `/proc/<pid>/cwd` is a symlink that EACCES for other-user pids
-    // and ENOENT for kernel threads; resolve it via Promise.allSettled
-    // so a failure here doesn't drop the whole row.
+    // and ENOENT for kernel threads. The inline two-arg `.then(p => p,
+    // () => "")` catches the readlink rejection in place so it can't
+    // bubble out of the surrounding `Promise.all` and discard the rest
+    // of the row's reads.
     const [statRaw, statusRaw, cmdlineRaw, cwdResult] = await Promise.all([
       readFile(`/proc/${pid}/stat`, "utf-8"),
       readFile(`/proc/${pid}/status`, "utf-8"),

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -209,18 +209,14 @@ interface LinuxProcRaw {
 async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
   try {
     // `/proc/<pid>/cwd` is a symlink that EACCES for other-user pids
-    // and ENOENT for kernel threads. The inline two-arg `.then(p => p,
-    // () => "")` catches the readlink rejection in place so it can't
-    // bubble out of the surrounding `Promise.all` and discard the rest
-    // of the row's reads.
+    // and ENOENT for kernel threads. The `.catch(() => "")` resolves
+    // the rejection in place so it can't bubble out of the surrounding
+    // `Promise.all` and discard the rest of the row's reads.
     const [statRaw, statusRaw, cmdlineRaw, cwdResult] = await Promise.all([
       readFile(`/proc/${pid}/stat`, "utf-8"),
       readFile(`/proc/${pid}/status`, "utf-8"),
       readFile(`/proc/${pid}/cmdline`, "utf-8"),
-      readlink(`/proc/${pid}/cwd`).then(
-        (p) => p,
-        () => "",
-      ),
+      readlink(`/proc/${pid}/cwd`).catch(() => ""),
     ]);
     // /proc/<pid>/stat: see proc(5). After comm (in parens — may contain
     // spaces), fields are space-separated. utime + stime are fields 14-15

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -247,8 +247,8 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
       ticks: utime + stime,
       startTime,
       memPct: round2(memPct),
-      command: truncate(command, 200),
-      cwd: truncate(cwdResult, 200),
+      command: truncate(command, PROC_STRING_MAX),
+      cwd: truncate(cwdResult, PROC_STRING_MAX),
     };
   } catch {
     // ENOENT is expected for PIDs that vanish between readdir and the
@@ -298,7 +298,7 @@ function darwinReader(): ProcReader {
           user,
           cpuPct: Number(cpu),
           memPct: Number(mem),
-          command: truncate(command, 200),
+          command: truncate(command, PROC_STRING_MAX),
           // darwin has no cheap per-pid cwd source (`lsof -p` per pid is
           // a fork per row); leave blank — the UI hides it when empty.
           cwd: "",
@@ -344,6 +344,10 @@ function stubReader(): ProcReader {
 }
 
 // ── Tiny helpers ─────────────────────────────────────────────────────────
+
+/** Wire cap for per-process string fields (command, cwd, …). One
+ *  constant so a change to the limit stays in parity across platforms. */
+const PROC_STRING_MAX = 200;
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -15,7 +15,7 @@
  */
 
 import { exec as execCb } from "node:child_process";
-import { readFile, readdir } from "node:fs/promises";
+import { readFile, readdir, readlink } from "node:fs/promises";
 import {
   cpus,
   freemem,
@@ -168,6 +168,7 @@ function linuxReader(): ProcReader {
           cpuPct: round2(cpuPct),
           memPct: raw.memPct,
           command: raw.command,
+          cwd: raw.cwd,
         });
       }
       // Evict dead pids so the map doesn't grow without bound.
@@ -202,14 +203,22 @@ interface LinuxProcRaw {
   startTime: number;
   memPct: number;
   command: string;
+  cwd: string;
 }
 
 async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
   try {
-    const [statRaw, statusRaw, cmdlineRaw] = await Promise.all([
+    // `/proc/<pid>/cwd` is a symlink that EACCES for other-user pids
+    // and ENOENT for kernel threads; resolve it via Promise.allSettled
+    // so a failure here doesn't drop the whole row.
+    const [statRaw, statusRaw, cmdlineRaw, cwdResult] = await Promise.all([
       readFile(`/proc/${pid}/stat`, "utf-8"),
       readFile(`/proc/${pid}/status`, "utf-8"),
       readFile(`/proc/${pid}/cmdline`, "utf-8"),
+      readlink(`/proc/${pid}/cwd`).then(
+        (p) => p,
+        () => "",
+      ),
     ]);
     // /proc/<pid>/stat: see proc(5). After comm (in parens — may contain
     // spaces), fields are space-separated. utime + stime are fields 14-15
@@ -239,6 +248,7 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
       startTime,
       memPct: round2(memPct),
       command: truncate(command, 200),
+      cwd: truncate(cwdResult, 200),
     };
   } catch {
     // ENOENT is expected for PIDs that vanish between readdir and the
@@ -289,6 +299,9 @@ function darwinReader(): ProcReader {
           cpuPct: Number(cpu),
           memPct: Number(mem),
           command: truncate(command, 200),
+          // darwin has no cheap per-pid cwd source (`lsof -p` per pid is
+          // a fork per row); leave blank — the UI hides it when empty.
+          cwd: "",
         });
       }
       return out;
@@ -323,6 +336,7 @@ function stubReader(): ProcReader {
         cpuPct: 0,
         memPct: 0,
         command: `${process.execPath} ${process.argv.slice(1).join(" ")}`,
+        cwd: process.cwd(),
       });
       return out;
     },

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -511,9 +511,11 @@ function ProcessRow(props: {
       <td class="max-w-md truncate px-3 py-0.5 text-left text-gray-700 dark:text-gray-300">
         <span>{proc()?.command ?? ""}</span>
         <Show when={proc()?.cwd}>
-          <span class="ml-2 text-gray-400 dark:text-gray-500" title="cwd">
-            @ {proc()?.cwd}
-          </span>
+          {(cwd) => (
+            <span class="ml-2 text-gray-400 dark:text-gray-500" title="cwd">
+              @ {cwd()}
+            </span>
+          )}
         </Show>
       </td>
       <td class="px-3 py-0.5 text-right">

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -225,7 +225,8 @@ function HostView(props: { host: string }) {
         if (
           String(pid).includes(q) ||
           proc.user.toLowerCase().includes(q) ||
-          proc.command.toLowerCase().includes(q)
+          proc.command.toLowerCase().includes(q) ||
+          proc.cwd.toLowerCase().includes(q)
         )
           filtered.push(pid);
       }
@@ -392,7 +393,7 @@ function FilterBar(props: {
     <div class="flex items-center gap-2 border-b border-gray-200 px-4 py-2 dark:border-gray-800">
       <input
         type="text"
-        placeholder="filter pid / user / command"
+        placeholder="filter pid / user / command / cwd"
         class="w-64 rounded border border-gray-300 bg-gray-50 px-2 py-0.5 text-xs focus:border-emerald-500 focus:outline-none dark:border-gray-700 dark:bg-gray-800"
         value={props.filter}
         onInput={(e) => props.onFilter(e.currentTarget.value)}
@@ -508,7 +509,12 @@ function ProcessRow(props: {
         {mem().toFixed(1)}
       </td>
       <td class="max-w-md truncate px-3 py-0.5 text-left text-gray-700 dark:text-gray-300">
-        {proc()?.command ?? ""}
+        <span>{proc()?.command ?? ""}</span>
+        <Show when={proc()?.cwd}>
+          <span class="ml-2 text-gray-400 dark:text-gray-500" title="cwd">
+            @ {proc()?.cwd}
+          </span>
+        </Show>
       </td>
       <td class="px-3 py-0.5 text-right">
         <button

--- a/packages/app/src/common/surface.ts
+++ b/packages/app/src/common/surface.ts
@@ -21,6 +21,10 @@ const ProcessSchema = z.object({
   cpuPct: z.number(),
   memPct: z.number(),
   command: z.string(),
+  /** Current working directory. Empty string when unknown — kernel
+   *  threads have no cwd, other-user pids hit EACCES on `/proc/<pid>/cwd`,
+   *  and darwin has no cheap per-pid cwd source so it's blank there. */
+  cwd: z.string(),
 });
 
 const CpuCoreSchema = z.object({


### PR DESCRIPTION
**The process table now disambiguates same-command rows by surfacing each process's cwd.** Closes #6. Born from "I have five `claude` processes — which one is in which project?" the answer is now visible at a glance: a dim `@ /path/to/cwd` suffix appears after the command in the COMMAND cell.

### How it flows

```
/proc/<pid>/cwd ─▶ readProcLinuxRaw ─▶ ProcessSchema ─▶ ProcessRow
   (symlink)        readlink+.catch     cwd: z.string()    <Show>@ {cwd}
```

The new field is a peer scalar on the existing `processes` collection — no new abstraction, no new boundary. Linux reads `/proc/<pid>/cwd` via `readlink` alongside the existing parallel `/proc/<pid>/{stat,status,cmdline}` reads. The `.catch(() => "")` resolves EACCES (other-user pids) and ENOENT (kernel threads) to empty so one missing symlink can't drop the whole row.

### Per-platform behaviour

| Platform | cwd source | Empty when |
|---|---|---|
| **linux** | `readlink(/proc/<pid>/cwd)` | other-user pid (EACCES), kernel thread (ENOENT) |
| **darwin** | none — blank | always (lsof-per-pid would fork once per row) |
| **stub** | `process.cwd()` | never |

The UI hides the suffix when cwd is empty (`<Show when={proc()?.cwd}>`), so darwin and other-user rows look exactly as they did before. The filter input also matches cwd substrings, and the placeholder advertises it.

### Refinements landed during review

| Finding | Lens | Fix |
|---|---|---|
| Truncation literal `200` repeated at three call sites | Hickey | Extracted `PROC_STRING_MAX = 200`; all per-process string fields share one cap |
| Comment named `Promise.allSettled` while code used inline `.then(p, () => "")` | Hickey + Lowy | Rewrote comment to describe the actual rejection handler |
| `<Show>` re-read `proc()?.cwd` twice per render | Police (elegance) | Use the callback form `{(cwd) => <span>… {cwd()}</span>}` |
| Two-arg `.then(p => p, () => "")` reads as "transform-and-also-handle" | Police (elegance) | `.catch(() => "")` |

### Try it locally

```sh
nix run github:srid/drishti/show-process-cwd
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._