### PR TITLE
Add a fleet overview — every host's health on one pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ nix run github:srid/drishti -- user@host               # one remote
 nix run github:srid/drishti -- localhost a.lan b.lan   # multiple hosts (tabbed UI)
 ```
 
-Open <http://localhost:7720>. The UI shows one tab per host with a live connection-state dot; click a tab to view its htop. Use the `+ add host` button in the tab strip to add hosts at runtime; the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
+Open <http://localhost:7720>. The UI opens on the **fleet** tab — a single overview pane with one live summary card per host (connection state, CPU, memory, load average, uptime); click a card (or a host's tab) to drill into that host's full htop. Each host also has its own tab with a live connection-state dot. Use the `+ add host` button in the tab strip to add hosts at runtime; the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
 
 Requirements:
 

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -34,18 +34,20 @@ import {
   DEFAULT_SYSTEM,
   type Pid,
   type Process,
+  type SystemInfo,
 } from "../common/surface";
+import { DOT_BG, isPendingState, STATE_TEXT } from "./connectionColors";
+import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
 import { TabStrip } from "./TabStrip";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
 
-const STATE_COLOR: Record<ConnectionState, string> = {
-  connected: "text-emerald-500",
-  disconnected: "text-red-500",
-  copying: "text-amber-500",
-  connecting: "text-amber-500",
-};
-
 type SortKey = "cpu" | "mem" | "pid" | "user";
+
+// What the main pane shows: the aggregate fleet overview, or one host's
+// full htop body. Modelled as a sum so "which host" only exists in the
+// branch where a host is selected — there's no nullable host floating
+// alongside a separate "is fleet" flag to keep consistent.
+type View = { kind: "fleet" } | { kind: "host"; host: string };
 
 export default function App() {
   const admin = adminClient();
@@ -78,22 +80,28 @@ export default function App() {
     }),
   );
 
-  const [activeHost, setActiveHost] = createSignal<string | null>(null);
-  // Keep the active host in sync with the host set: pick the first if
-  // none is selected yet, or fall back when the active one is removed.
-  const resolvedActive = createMemo<string | null>(() => {
-    const list = hostList();
-    const current = activeHost();
-    if (list.length === 0) return null;
-    if (current !== null && list.includes(current)) return current;
-    return list[0] ?? null;
+  // The fleet overview is the default landing view — the "single pane of
+  // glass" across every host. `view` holds the user's intent; the host
+  // set it resolves against is owned by the admin collection.
+  const [view, setView] = createSignal<View>({ kind: "fleet" });
+  // Resolve intent against the live host set: a host view whose host has
+  // been removed falls back to the fleet overview rather than a blank
+  // pane, and the fleet view always resolves to itself.
+  const resolvedView = createMemo<View>(() => {
+    const v = view();
+    if (v.kind === "host" && hostList().includes(v.host)) return v;
+    return { kind: "fleet" };
+  });
+  const selectedHost = createMemo<string | null>(() => {
+    const v = resolvedView();
+    return v.kind === "host" ? v.host : null;
   });
 
   const onAdd = async (host: string): Promise<string | null> => {
     try {
       const res = await admin.rpc.surface.hosts.add({ host });
       if (!res.ok) return res.error ?? "add failed";
-      setActiveHost(host);
+      setView({ kind: "host", host });
       return null;
     } catch (err) {
       return (err as Error).message;
@@ -103,7 +111,8 @@ export default function App() {
   const onRemove = async (host: string) => {
     try {
       await admin.rpc.surface.hosts.remove({ host });
-      if (activeHost() === host) setActiveHost(null);
+      // No manual view reset needed: resolvedView falls back to fleet
+      // once the host leaves the collection.
     } catch (err) {
       console.error(`remove ${host} failed`, err);
     }
@@ -114,24 +123,149 @@ export default function App() {
       <div class="mx-auto max-w-6xl overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
         <TabStrip
           hosts={hostList()}
-          active={resolvedActive()}
-          onSelect={(h) => setActiveHost(h)}
+          active={selectedHost()}
+          fleetActive={resolvedView().kind === "fleet"}
+          onSelectFleet={() => setView({ kind: "fleet" })}
+          onSelect={(h) => setView({ kind: "host", host: h })}
           onAdd={onAdd}
           onRemove={onRemove}
         />
         <Show
-          when={resolvedActive()}
+          when={hostList().length > 0}
           fallback={
             <div class="px-4 py-12 text-center text-gray-500 dark:text-gray-400">
               <div class="mb-2 text-lg">No hosts configured</div>
               <div class="text-xs">Use the + button above to add one.</div>
             </div>
           }
-          keyed
         >
-          {(host) => <HostView host={host} />}
+          <Show
+            when={selectedHost()}
+            fallback={
+              <FleetView
+                hosts={hostList()}
+                onSelect={(h) => setView({ kind: "host", host: h })}
+              />
+            }
+            keyed
+          >
+            {(host) => <HostView host={host} />}
+          </Show>
         </Show>
       </div>
+    </div>
+  );
+}
+
+// ── Fleet overview: every host as a live summary card ──────────────────
+
+// The aggregate "pane of glass". Each card subscribes to its host's
+// `system` / `connection` cells and `cpuCores` collection — the same
+// per-host sockets the tab chips already keep warm — so opening the
+// overview costs subscriptions, not new connections. Clicking a card
+// drills into that host's full htop body.
+function FleetView(props: {
+  hosts: readonly string[];
+  onSelect: (host: string) => void;
+}) {
+  return (
+    <div class="grid grid-cols-1 gap-3 p-4 sm:grid-cols-2 lg:grid-cols-3">
+      <For each={props.hosts}>
+        {(host) => (
+          <HostCard host={host} onSelect={() => props.onSelect(host)} />
+        )}
+      </For>
+    </div>
+  );
+}
+
+function HostCard(props: { host: string; onSelect: () => void }) {
+  const app = surfaceForHost(props.host);
+  const system = app.cells.system.use({});
+  const connection = app.cells.connection.use({});
+  const cores = app.collections.cpuCores.use({
+    onError: (err) => console.error("cpuCores subscription failed", err),
+  });
+
+  const sys = createMemo<SystemInfo>(() => system.value() ?? DEFAULT_SYSTEM);
+  const state = createMemo<ConnectionState>(
+    () => (connection.value() ?? DEFAULT_CONNECTION).state,
+  );
+  const cpuPct = createMemo(() =>
+    averageCoreUsage(
+      [...cores.keys()].map((id) => cores.byKey(id)?.()?.usagePct ?? 0),
+    ),
+  );
+  const mem = createMemo(() => memPct(sys()));
+
+  return (
+    <button
+      type="button"
+      onClick={props.onSelect}
+      class="flex flex-col gap-2 rounded border border-gray-200 bg-gray-50 p-3 text-left transition-colors hover:border-indigo-400 hover:bg-white dark:border-gray-800 dark:bg-gray-900/40 dark:hover:border-indigo-500 dark:hover:bg-gray-900"
+    >
+      <div class="flex items-center gap-2">
+        <span
+          class={`inline-block h-2 w-2 shrink-0 rounded-full ${DOT_BG[state()]} ${isPendingState(state()) ? "animate-pulse" : ""}`}
+        />
+        <span class="truncate font-semibold" title={props.host}>
+          {props.host}
+        </span>
+        <span class={`ml-auto shrink-0 text-xs ${STATE_TEXT[state()]}`}>
+          {state()}
+        </span>
+      </div>
+
+      <Show
+        when={state() === "connected"}
+        fallback={
+          <div class="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
+            {state() === "copying"
+              ? "provisioning agent…"
+              : state() === "connecting"
+                ? "connecting…"
+                : "no data"}
+          </div>
+        }
+      >
+        <CardMetric
+          label="cpu"
+          pct={cpuPct()}
+          detail={`${cpuPct().toFixed(0)}% · ${[...cores.keys()].length} cores`}
+        />
+        <CardMetric
+          label="mem"
+          pct={mem()}
+          detail={`${memGb(sys()).used}/${memGb(sys()).total} GB · ${mem().toFixed(0)}%`}
+        />
+        <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400">
+          <span>
+            load{" "}
+            <span class="font-semibold text-gray-700 dark:text-gray-300">
+              {sys().loadAvg[0].toFixed(2)}
+            </span>{" "}
+            {sys().loadAvg[1].toFixed(2)} {sys().loadAvg[2].toFixed(2)}
+          </span>
+          <span>
+            up {formatUptime(sys().uptime)} · {sys().os}
+          </span>
+        </div>
+      </Show>
+    </button>
+  );
+}
+
+// One labelled metric row inside a host card: a label, a usage bar, and
+// a detail string. Reuses the same UsageBar as the per-host header so the
+// >85% red / >65% amber thresholds stay single-sourced.
+function CardMetric(props: { label: string; pct: number; detail: string }) {
+  return (
+    <div class="flex flex-col gap-0.5">
+      <div class="flex justify-between text-xs">
+        <span class="uppercase tracking-wide text-gray-500">{props.label}</span>
+        <span class="text-gray-500 dark:text-gray-400">{props.detail}</span>
+      </div>
+      <UsageBar pct={props.pct} />
     </div>
   );
 }
@@ -298,26 +432,9 @@ function Header(props: {
   connection: ReturnType<() => typeof DEFAULT_CONNECTION>;
   count: number;
 }) {
-  const memPct = () => {
-    const total = props.system.memTotal;
-    return total > 0 ? (100 * props.system.memUsed) / total : 0;
-  };
-  const memGb = () => ({
-    used: (props.system.memUsed / 1e9).toFixed(1),
-    total: (props.system.memTotal / 1e9).toFixed(1),
-  });
-  const uptimeFmt = () => {
-    const u = props.system.uptime;
-    const d = Math.floor(u / 86400);
-    const h = Math.floor((u % 86400) / 3600);
-    const m = Math.floor((u % 3600) / 60);
-    if (d > 0) return `${d}d ${h}h`;
-    if (h > 0) return `${h}h ${m}m`;
-    return `${m}m`;
-  };
   return (
     <div class="border-b border-gray-200 dark:border-gray-800">
-      <UsageBar pct={memPct()} />
+      <UsageBar pct={memPct(props.system)} />
       <div class="flex items-center justify-between px-4 py-2">
         <div class="flex items-center gap-3">
           <span class="font-semibold">drishti</span>
@@ -326,7 +443,7 @@ function Header(props: {
             <span class="text-gray-500">host:</span>{" "}
             <span class="font-semibold">{props.system.hostname || "—"}</span>
           </span>
-          <span class={STATE_COLOR[props.connection.state]}>
+          <span class={STATE_TEXT[props.connection.state]}>
             ● {props.connection.state}
           </span>
           <span class="text-gray-500">·</span>
@@ -352,12 +469,15 @@ function Header(props: {
           </span>
         </span>
         <span>
-          mem <span class="font-semibold">{memGb().used}</span>
-          <span class="text-gray-400">/{memGb().total} GB</span>
-          <span class="ml-1 text-gray-400">({memPct().toFixed(0)}%)</span>
+          mem <span class="font-semibold">{memGb(props.system).used}</span>
+          <span class="text-gray-400">/{memGb(props.system).total} GB</span>
+          <span class="ml-1 text-gray-400">
+            ({memPct(props.system).toFixed(0)}%)
+          </span>
         </span>
         <span>
-          uptime <span class="font-semibold">{uptimeFmt()}</span>
+          uptime{" "}
+          <span class="font-semibold">{formatUptime(props.system.uptime)}</span>
         </span>
         <span>
           os <span class="font-semibold">{props.system.os}</span>

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -37,20 +37,13 @@ import {
   type SystemInfo,
 } from "../common/surface";
 import { STATE } from "./connectionColors";
+import type { View } from "./view";
 import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
 import { coreUsageColor, processPctColor, usageBarColor } from "./usageColors";
 import { TabStrip } from "./TabStrip";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
 
 type SortKey = "cpu" | "mem" | "pid" | "user";
-
-// What the main pane shows: the aggregate fleet overview, or one host's
-// full htop body. Modelled as a sum so "which host" only exists in the
-// branch where a host is selected — there's no nullable host floating
-// alongside a separate "is fleet" flag to keep consistent. Exported so
-// the tab strip highlights the active tab from this one value rather
-// than a flattened (fleetActive, activeHost) pair that can disagree.
-export type View = { kind: "fleet" } | { kind: "host"; host: string };
 
 export default function App() {
   const admin = adminClient();

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -36,7 +36,13 @@ import {
   type Process,
   type SystemInfo,
 } from "../common/surface";
-import { DOT_BG, isPendingState, STATE_TEXT } from "./connectionColors";
+import {
+  DOT_BG,
+  isPendingState,
+  STATE_LABEL,
+  STATE_MESSAGE,
+  STATE_TEXT,
+} from "./connectionColors";
 import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
 import { TabStrip } from "./TabStrip";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
@@ -221,11 +227,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
         when={state() === "connected"}
         fallback={
           <div class="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
-            {state() === "copying"
-              ? "provisioning agent…"
-              : state() === "connecting"
-                ? "connecting…"
-                : "no data"}
+            {STATE_LABEL[state()]}
           </div>
         }
       >
@@ -526,16 +528,10 @@ function FilterBar(props: {
   );
 }
 
-function ConnectingOverlay(props: { state: string }) {
-  const msg = () =>
-    ({
-      copying: "Copying agent to remote…",
-      connecting: "Connecting…",
-      disconnected: "Disconnected. Retrying…",
-    })[props.state] ?? "Initializing…";
+function ConnectingOverlay(props: { state: ConnectionState }) {
   return (
     <div class="px-4 py-12 text-center text-gray-600 dark:text-gray-400">
-      <div class="mb-2 text-lg">{msg()}</div>
+      <div class="mb-2 text-lg">{STATE_MESSAGE[props.state]}</div>
       <div class="text-xs">
         First connect provisions the agent closure via <code>nix copy</code>.
         Subsequent connects reuse it.

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -205,6 +205,10 @@ function HostCard(props: { host: string; onSelect: () => void }) {
     ),
   );
   const mem = createMemo(() => memPct(sys()));
+  const memText = createMemo(() => {
+    const gb = memGb(sys());
+    return `${gb.used}/${gb.total} GB · ${mem().toFixed(0)}%`;
+  });
 
   return (
     <button
@@ -237,11 +241,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
           pct={cpuPct()}
           detail={`${cpuPct().toFixed(0)}% · ${[...cores.keys()].length} cores`}
         />
-        <CardMetric
-          label="mem"
-          pct={mem()}
-          detail={`${memGb(sys()).used}/${memGb(sys()).total} GB · ${mem().toFixed(0)}%`}
-        />
+        <CardMetric label="mem" pct={mem()} detail={memText()} />
         <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400">
           <span>
             load{" "}

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -186,6 +186,9 @@ function HostCard(props: { host: string; onSelect: () => void }) {
   const state = createMemo<ConnectionState>(
     () => (connection.value() ?? DEFAULT_CONNECTION).state,
   );
+  // coreCount and cpuPct share a single cores.keys() iteration so the
+  // detail string in CardMetric doesn't need a second spread.
+  const coreCount = createMemo(() => [...cores.keys()].length);
   const cpuPct = createMemo(() =>
     averageCoreUsage(
       [...cores.keys()].map((id) => cores.byKey(id)?.()?.usagePct ?? 0),
@@ -226,7 +229,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
         <CardMetric
           label="cpu"
           pct={cpuPct()}
-          detail={`${cpuPct().toFixed(0)}% · ${[...cores.keys()].length} cores`}
+          detail={`${cpuPct().toFixed(0)}% · ${coreCount()} cores`}
         />
         <CardMetric label="mem" pct={mem()} detail={memText()} />
         <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400">
@@ -423,9 +426,14 @@ function Header(props: {
   connection: ReturnType<() => typeof DEFAULT_CONNECTION>;
   count: number;
 }) {
+  // Pure derivations cached once per render — props.system is a reactive
+  // read that re-runs this component body when it changes, so these are
+  // computed once per system tick, not once per JSX expression.
+  const pct = memPct(props.system);
+  const gb = memGb(props.system);
   return (
     <div class="border-b border-gray-200 dark:border-gray-800">
-      <UsageBar pct={memPct(props.system)} />
+      <UsageBar pct={pct} />
       <div class="flex items-center justify-between px-4 py-2">
         <div class="flex items-center gap-3">
           <span class="font-semibold">drishti</span>
@@ -460,10 +468,10 @@ function Header(props: {
           </span>
         </span>
         <span>
-          mem <span class="font-semibold">{memGb(props.system).used}</span>
-          <span class="text-gray-400">/{memGb(props.system).total} GB</span>
+          mem <span class="font-semibold">{gb.used}</span>
+          <span class="text-gray-400">/{gb.total} GB</span>
           <span class="ml-1 text-gray-400">
-            ({memPct(props.system).toFixed(0)}%)
+            ({pct.toFixed(0)}%)
           </span>
         </span>
         <span>

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -36,13 +36,7 @@ import {
   type Process,
   type SystemInfo,
 } from "../common/surface";
-import {
-  DOT_BG,
-  isPendingState,
-  STATE_LABEL,
-  STATE_MESSAGE,
-  STATE_TEXT,
-} from "./connectionColors";
+import { STATE } from "./connectionColors";
 import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
 import { coreUsageColor, processPctColor, usageBarColor } from "./usageColors";
 import { TabStrip } from "./TabStrip";
@@ -218,12 +212,12 @@ function HostCard(props: { host: string; onSelect: () => void }) {
     >
       <div class="flex items-center gap-2">
         <span
-          class={`inline-block h-2 w-2 shrink-0 rounded-full ${DOT_BG[state()]} ${isPendingState(state()) ? "animate-pulse" : ""}`}
+          class={`inline-block h-2 w-2 shrink-0 rounded-full ${STATE[state()].dotBg} ${STATE[state()].pending ? "animate-pulse" : ""}`}
         />
         <span class="truncate font-semibold" title={props.host}>
           {props.host}
         </span>
-        <span class={`ml-auto shrink-0 text-xs ${STATE_TEXT[state()]}`}>
+        <span class={`ml-auto shrink-0 text-xs ${STATE[state()].text}`}>
           {state()}
         </span>
       </div>
@@ -232,7 +226,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
         when={state() === "connected"}
         fallback={
           <div class="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
-            {STATE_LABEL[state()]}
+            {STATE[state()].label}
           </div>
         }
       >
@@ -447,7 +441,7 @@ function Header(props: {
             <span class="text-gray-500">host:</span>{" "}
             <span class="font-semibold">{props.system.hostname || "—"}</span>
           </span>
-          <span class={STATE_TEXT[props.connection.state]}>
+          <span class={STATE[props.connection.state].text}>
             ● {props.connection.state}
           </span>
           <span class="text-gray-500">·</span>
@@ -527,7 +521,7 @@ function FilterBar(props: {
 function ConnectingOverlay(props: { state: ConnectionState }) {
   return (
     <div class="px-4 py-12 text-center text-gray-600 dark:text-gray-400">
-      <div class="mb-2 text-lg">{STATE_MESSAGE[props.state]}</div>
+      <div class="mb-2 text-lg">{STATE[props.state].message}</div>
       <div class="text-xs">
         First connect provisions the agent closure via <code>nix copy</code>.
         Subsequent connects reuse it.

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -46,8 +46,10 @@ type SortKey = "cpu" | "mem" | "pid" | "user";
 // What the main pane shows: the aggregate fleet overview, or one host's
 // full htop body. Modelled as a sum so "which host" only exists in the
 // branch where a host is selected — there's no nullable host floating
-// alongside a separate "is fleet" flag to keep consistent.
-type View = { kind: "fleet" } | { kind: "host"; host: string };
+// alongside a separate "is fleet" flag to keep consistent. Exported so
+// the tab strip highlights the active tab from this one value rather
+// than a flattened (fleetActive, activeHost) pair that can disagree.
+export type View = { kind: "fleet" } | { kind: "host"; host: string };
 
 export default function App() {
   const admin = adminClient();
@@ -123,8 +125,7 @@ export default function App() {
       <div class="mx-auto max-w-6xl overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
         <TabStrip
           hosts={hostList()}
-          active={selectedHost()}
-          fleetActive={resolvedView().kind === "fleet"}
+          activeTab={resolvedView()}
           onSelectFleet={() => setView({ kind: "fleet" })}
           onSelect={(h) => setView({ kind: "host", host: h })}
           onAdd={onAdd}

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -44,6 +44,7 @@ import {
   STATE_TEXT,
 } from "./connectionColors";
 import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
+import { coreUsageColor, processPctColor, usageBarColor } from "./usageColors";
 import { TabStrip } from "./TabStrip";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
 
@@ -491,15 +492,10 @@ function Header(props: {
 }
 
 function UsageBar(props: { pct: number }) {
-  const colour = () => {
-    if (props.pct > 85) return "bg-red-500";
-    if (props.pct > 65) return "bg-amber-500";
-    return "bg-emerald-500";
-  };
   return (
     <div class="h-1 w-full bg-gray-100 dark:bg-gray-800">
       <div
-        class={`h-full transition-all ${colour()}`}
+        class={`h-full transition-all ${usageBarColor(props.pct)}`}
         style={{ width: `${Math.min(100, props.pct).toFixed(1)}%` }}
       />
     </div>
@@ -616,12 +612,12 @@ function ProcessRow(props: {
       <td class="px-3 py-0.5 text-right tabular-nums">{props.pid}</td>
       <td class="px-3 py-0.5 text-left">{proc()?.user ?? ""}</td>
       <td
-        class={`px-3 py-0.5 text-right tabular-nums ${pctClass(cpu())}`}
+        class={`px-3 py-0.5 text-right tabular-nums ${processPctColor(cpu())}`}
       >
         {cpu().toFixed(1)}
       </td>
       <td
-        class={`px-3 py-0.5 text-right tabular-nums ${pctClass(mem())}`}
+        class={`px-3 py-0.5 text-right tabular-nums ${processPctColor(mem())}`}
       >
         {mem().toFixed(1)}
       </td>
@@ -671,12 +667,6 @@ function SortableTh(props: {
   );
 }
 
-function pctClass(pct: number): string {
-  if (pct > 50) return "font-semibold text-red-500";
-  if (pct > 10) return "text-amber-500";
-  return "text-gray-700 dark:text-gray-400";
-}
-
 function CpuStrip(props: {
   coreIds: readonly CoreId[];
   getCore: (id: CoreId) => CpuCore | undefined;
@@ -700,18 +690,12 @@ function CpuStrip(props: {
 function CpuCoreCell(props: { id: CoreId; get: () => CpuCore | undefined }) {
   const core = createMemo(() => props.get());
   const pct = () => core()?.usagePct ?? 0;
-  const barColor = createMemo(() => {
-    const p = pct();
-    if (p > 80) return "bg-red-500";
-    if (p > 50) return "bg-amber-500";
-    return "bg-emerald-500";
-  });
   return (
     <div class="flex items-center gap-1 text-xs">
       <span class="w-6 shrink-0 text-gray-500 tabular-nums">c{props.id}</span>
       <div class="h-2 flex-1 overflow-hidden rounded bg-gray-100 dark:bg-gray-800">
         <div
-          class={`h-full transition-all ${barColor()}`}
+          class={`h-full transition-all ${coreUsageColor(pct())}`}
           style={{ width: `${Math.min(100, pct()).toFixed(1)}%` }}
         />
       </div>

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -15,24 +15,25 @@
 
 import { createMemo, createSignal, For, Show } from "solid-js";
 import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
+import { DOT_BG, isPendingState } from "./connectionColors";
 import { surfaceForHost } from "./wire";
-
-const DOT_BG: Record<ConnectionState, string> = {
-  connected: "bg-emerald-500",
-  disconnected: "bg-red-500",
-  copying: "bg-amber-500",
-  connecting: "bg-amber-500",
-};
 
 export function TabStrip(props: {
   hosts: readonly string[];
   active: string | null;
+  fleetActive: boolean;
+  onSelectFleet: () => void;
   onSelect: (h: string) => void;
   onAdd: (h: string) => Promise<string | null>;
   onRemove: (h: string) => Promise<void>;
 }) {
   return (
     <div class="flex flex-wrap items-stretch border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/60">
+      <FleetTab
+        active={props.fleetActive}
+        count={props.hosts.length}
+        onSelect={props.onSelectFleet}
+      />
       <For each={props.hosts}>
         {(host) => (
           <TabChip
@@ -45,6 +46,34 @@ export function TabStrip(props: {
       </For>
       <AddHostForm onAdd={props.onAdd} />
     </div>
+  );
+}
+
+// The leftmost chip: a fixed "fleet" tab that shows the aggregate
+// overview of every host at once. It carries no connection dot of its
+// own (it has no single host) — just a host count — and can't be closed.
+function FleetTab(props: {
+  active: boolean;
+  count: number;
+  onSelect: () => void;
+}) {
+  const baseClasses =
+    "flex items-center gap-2 border-r border-gray-200 px-3 py-1.5 text-xs dark:border-gray-800";
+  const inactiveClasses =
+    "text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800/60";
+  const activeClasses =
+    "bg-white text-gray-900 shadow-[inset_0_-2px_0_0_theme(colors.indigo.500)] dark:bg-gray-900 dark:text-gray-100";
+  return (
+    <button
+      type="button"
+      class={`${baseClasses} ${props.active ? activeClasses : inactiveClasses}`}
+      onClick={props.onSelect}
+      title="Fleet overview — all hosts at a glance"
+    >
+      <span aria-hidden="true">▦</span>
+      <span class="font-semibold">fleet</span>
+      <span class="text-gray-400">({props.count})</span>
+    </button>
   );
 }
 
@@ -77,7 +106,7 @@ function TabChip(props: {
         title={`${props.host} — ${state()}`}
       >
         <span
-          class={`inline-block h-2 w-2 rounded-full ${DOT_BG[state()]} ${state() === "copying" || state() === "connecting" ? "animate-pulse" : ""}`}
+          class={`inline-block h-2 w-2 rounded-full ${DOT_BG[state()]} ${isPendingState(state()) ? "animate-pulse" : ""}`}
         />
         <span class="font-semibold">{props.host}</span>
       </button>

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -14,8 +14,8 @@
  */
 
 import { createMemo, createSignal, For, Show } from "solid-js";
-import type { View } from "./App";
 import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
+import type { View } from "./view";
 import { STATE } from "./connectionColors";
 import { surfaceForHost } from "./wire";
 

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -16,7 +16,7 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
 import type { View } from "./App";
 import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
-import { DOT_BG, isPendingState } from "./connectionColors";
+import { STATE } from "./connectionColors";
 import { surfaceForHost } from "./wire";
 
 // Shared chip chrome — the fleet tab and the host chips are the same
@@ -104,7 +104,7 @@ function TabChip(props: {
         title={`${props.host} — ${state()}`}
       >
         <span
-          class={`inline-block h-2 w-2 rounded-full ${DOT_BG[state()]} ${isPendingState(state()) ? "animate-pulse" : ""}`}
+          class={`inline-block h-2 w-2 rounded-full ${STATE[state()].dotBg} ${STATE[state()].pending ? "animate-pulse" : ""}`}
         />
         <span class="font-semibold">{props.host}</span>
       </button>

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -19,6 +19,16 @@ import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
 import { DOT_BG, isPendingState } from "./connectionColors";
 import { surfaceForHost } from "./wire";
 
+// Shared chip chrome — the fleet tab and the host chips are the same
+// visual control, so the class strings live in one place rather than
+// being copied into each component.
+const TAB_BASE =
+  "flex items-center gap-2 border-r border-gray-200 px-3 py-1.5 text-xs dark:border-gray-800";
+const TAB_INACTIVE =
+  "text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800/60";
+const TAB_ACTIVE =
+  "bg-white text-gray-900 shadow-[inset_0_-2px_0_0_theme(colors.indigo.500)] dark:bg-gray-900 dark:text-gray-100";
+
 export function TabStrip(props: {
   hosts: readonly string[];
   activeTab: View;
@@ -59,16 +69,10 @@ function FleetTab(props: {
   count: number;
   onSelect: () => void;
 }) {
-  const baseClasses =
-    "flex items-center gap-2 border-r border-gray-200 px-3 py-1.5 text-xs dark:border-gray-800";
-  const inactiveClasses =
-    "text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800/60";
-  const activeClasses =
-    "bg-white text-gray-900 shadow-[inset_0_-2px_0_0_theme(colors.indigo.500)] dark:bg-gray-900 dark:text-gray-100";
   return (
     <button
       type="button"
-      class={`${baseClasses} ${props.active ? activeClasses : inactiveClasses}`}
+      class={`${TAB_BASE} ${props.active ? TAB_ACTIVE : TAB_INACTIVE}`}
       onClick={props.onSelect}
       title="Fleet overview — all hosts at a glance"
     >
@@ -91,16 +95,8 @@ function TabChip(props: {
     () => (connection.value() ?? DEFAULT_CONNECTION).state,
   );
 
-  const baseClasses =
-    "flex items-center gap-2 border-r border-gray-200 px-3 py-1.5 text-xs dark:border-gray-800";
-  const inactiveClasses =
-    "text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800/60";
-  const activeClasses =
-    "bg-white text-gray-900 shadow-[inset_0_-2px_0_0_theme(colors.indigo.500)] dark:bg-gray-900 dark:text-gray-100";
   return (
-    <div
-      class={`${baseClasses} ${props.active ? activeClasses : inactiveClasses}`}
-    >
+    <div class={`${TAB_BASE} ${props.active ? TAB_ACTIVE : TAB_INACTIVE}`}>
       <button
         type="button"
         class="flex items-center gap-2"

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -14,14 +14,14 @@
  */
 
 import { createMemo, createSignal, For, Show } from "solid-js";
+import type { View } from "./App";
 import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
 import { DOT_BG, isPendingState } from "./connectionColors";
 import { surfaceForHost } from "./wire";
 
 export function TabStrip(props: {
   hosts: readonly string[];
-  active: string | null;
-  fleetActive: boolean;
+  activeTab: View;
   onSelectFleet: () => void;
   onSelect: (h: string) => void;
   onAdd: (h: string) => Promise<string | null>;
@@ -30,7 +30,7 @@ export function TabStrip(props: {
   return (
     <div class="flex flex-wrap items-stretch border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/60">
       <FleetTab
-        active={props.fleetActive}
+        active={props.activeTab.kind === "fleet"}
         count={props.hosts.length}
         onSelect={props.onSelectFleet}
       />
@@ -38,7 +38,9 @@ export function TabStrip(props: {
         {(host) => (
           <TabChip
             host={host}
-            active={props.active === host}
+            active={
+              props.activeTab.kind === "host" && props.activeTab.host === host
+            }
             onSelect={() => props.onSelect(host)}
             onClose={() => props.onRemove(host)}
           />

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -1,48 +1,55 @@
 /**
- * Connection-state → Tailwind colour maps, single-sourced so the header
- * text (`STATE_TEXT`), the tab-strip dots, and the fleet-card dots
- * (`DOT_BG`) can't drift apart. Both are total over `ConnectionState`,
- * so adding a state is a compile error until every surface is updated.
+ * Per-connection-state presentation, single-sourced. Each state maps to
+ * one `StatePresentation` row rather than living as five parallel
+ * `Record<ConnectionState, …>` maps — `Record` totality already forces
+ * every state to be present, but one map also forces every *aspect*
+ * (dot colour, text colour, terse label, verbose message, pending flag)
+ * to be filled in together, so they can't drift and adding a state is a
+ * single row, not five edits.
  */
 
 import type { ConnectionState } from "../common/surface";
 
-/** Text colour for an inline "● connected" style label. */
-export const STATE_TEXT: Record<ConnectionState, string> = {
-  connected: "text-emerald-500",
-  disconnected: "text-red-500",
-  copying: "text-amber-500",
-  connecting: "text-amber-500",
+type StatePresentation = {
+  /** Status-dot background colour. */
+  dotBg: string;
+  /** Inline "● connected" text colour. */
+  text: string;
+  /** Terse label — the fleet card's tight fallback. */
+  label: string;
+  /** Verbose status line — the full-pane connecting overlay. */
+  message: string;
+  /** Work-in-progress state whose dot should pulse. */
+  pending: boolean;
 };
 
-/** Background colour for a status dot. */
-export const DOT_BG: Record<ConnectionState, string> = {
-  connected: "bg-emerald-500",
-  disconnected: "bg-red-500",
-  copying: "bg-amber-500",
-  connecting: "bg-amber-500",
-};
-
-/** Whether a dot for this state should pulse (work-in-progress states). */
-export function isPendingState(state: ConnectionState): boolean {
-  return state === "copying" || state === "connecting";
-}
-
-/** Compact status label — the fleet card's tight fallback. Total over
- *  `ConnectionState`, so the card can't silently fall through to a stale
- *  default when a new state is added to the schema. */
-export const STATE_LABEL: Record<ConnectionState, string> = {
-  connected: "connected",
-  copying: "provisioning agent…",
-  connecting: "connecting…",
-  disconnected: "no data",
-};
-
-/** Verbose status line — the full-pane connecting overlay, where there's
- *  room for a more reassuring phrasing than the card's terse label. */
-export const STATE_MESSAGE: Record<ConnectionState, string> = {
-  connected: "Connected.",
-  copying: "Copying agent to remote…",
-  connecting: "Connecting…",
-  disconnected: "Disconnected. Retrying…",
+export const STATE: Record<ConnectionState, StatePresentation> = {
+  connected: {
+    dotBg: "bg-emerald-500",
+    text: "text-emerald-500",
+    label: "connected",
+    message: "Connected.",
+    pending: false,
+  },
+  connecting: {
+    dotBg: "bg-amber-500",
+    text: "text-amber-500",
+    label: "connecting…",
+    message: "Connecting…",
+    pending: true,
+  },
+  copying: {
+    dotBg: "bg-amber-500",
+    text: "text-amber-500",
+    label: "provisioning agent…",
+    message: "Copying agent to remote…",
+    pending: true,
+  },
+  disconnected: {
+    dotBg: "bg-red-500",
+    text: "text-red-500",
+    label: "no data",
+    message: "Disconnected. Retrying…",
+    pending: false,
+  },
 };

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -1,0 +1,29 @@
+/**
+ * Connection-state → Tailwind colour maps, single-sourced so the header
+ * text (`STATE_TEXT`), the tab-strip dots, and the fleet-card dots
+ * (`DOT_BG`) can't drift apart. Both are total over `ConnectionState`,
+ * so adding a state is a compile error until every surface is updated.
+ */
+
+import type { ConnectionState } from "../common/surface";
+
+/** Text colour for an inline "● connected" style label. */
+export const STATE_TEXT: Record<ConnectionState, string> = {
+  connected: "text-emerald-500",
+  disconnected: "text-red-500",
+  copying: "text-amber-500",
+  connecting: "text-amber-500",
+};
+
+/** Background colour for a status dot. */
+export const DOT_BG: Record<ConnectionState, string> = {
+  connected: "bg-emerald-500",
+  disconnected: "bg-red-500",
+  copying: "bg-amber-500",
+  connecting: "bg-amber-500",
+};
+
+/** Whether a dot for this state should pulse (work-in-progress states). */
+export function isPendingState(state: ConnectionState): boolean {
+  return state === "copying" || state === "connecting";
+}

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -27,3 +27,22 @@ export const DOT_BG: Record<ConnectionState, string> = {
 export function isPendingState(state: ConnectionState): boolean {
   return state === "copying" || state === "connecting";
 }
+
+/** Compact status label — the fleet card's tight fallback. Total over
+ *  `ConnectionState`, so the card can't silently fall through to a stale
+ *  default when a new state is added to the schema. */
+export const STATE_LABEL: Record<ConnectionState, string> = {
+  connected: "connected",
+  copying: "provisioning agent…",
+  connecting: "connecting…",
+  disconnected: "no data",
+};
+
+/** Verbose status line — the full-pane connecting overlay, where there's
+ *  room for a more reassuring phrasing than the card's terse label. */
+export const STATE_MESSAGE: Record<ConnectionState, string> = {
+  connected: "Connected.",
+  copying: "Copying agent to remote…",
+  connecting: "Connecting…",
+  disconnected: "Disconnected. Retrying…",
+};

--- a/packages/app/src/client/metrics.test.ts
+++ b/packages/app/src/client/metrics.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import type { SystemInfo } from "../common/surface";
+import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
+
+function sys(over: Partial<SystemInfo> = {}): SystemInfo {
+  return {
+    loadAvg: [0, 0, 0],
+    memUsed: 0,
+    memTotal: 0,
+    uptime: 0,
+    os: "linux",
+    hostname: "h",
+    pollIntervalMs: 1000,
+    ...over,
+  };
+}
+
+describe("memPct", () => {
+  it("computes used/total as a percentage", () => {
+    expect(memPct(sys({ memUsed: 4e9, memTotal: 16e9 }))).toBe(25);
+  });
+
+  it("returns 0 when total is unknown (no divide-by-zero)", () => {
+    expect(memPct(sys({ memUsed: 4e9, memTotal: 0 }))).toBe(0);
+  });
+});
+
+describe("memGb", () => {
+  it("formats bytes to one-decimal gigabytes", () => {
+    expect(memGb(sys({ memUsed: 4.2e9, memTotal: 16e9 }))).toEqual({
+      used: "4.2",
+      total: "16.0",
+    });
+  });
+});
+
+describe("formatUptime", () => {
+  it("shows days and hours past a day", () => {
+    expect(formatUptime(2 * 86400 + 3 * 3600 + 4 * 60)).toBe("2d 3h");
+  });
+
+  it("shows hours and minutes under a day", () => {
+    expect(formatUptime(5 * 3600 + 12 * 60)).toBe("5h 12m");
+  });
+
+  it("shows minutes under an hour", () => {
+    expect(formatUptime(42 * 60 + 30)).toBe("42m");
+  });
+});
+
+describe("averageCoreUsage", () => {
+  it("averages the per-core usages", () => {
+    expect(averageCoreUsage([10, 20, 30, 40])).toBe(25);
+  });
+
+  it("returns 0 for no cores (never NaN)", () => {
+    expect(averageCoreUsage([])).toBe(0);
+  });
+});

--- a/packages/app/src/client/metrics.ts
+++ b/packages/app/src/client/metrics.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure metric derivations shared by the per-host header and the fleet
+ * overview cards. Kept free of Solid and DOM so the aggregation maths
+ * (the part that's wrong at runtime if the formula slips) is unit
+ * testable in isolation — `import type` erases the surface dependency so
+ * `bun test` never loads zod / @kolu/surface.
+ */
+
+import type { SystemInfo } from "../common/surface";
+
+/** Memory used as a percentage of total. Zero when total is unknown
+ *  (a freshly-connected host whose first `system` tick hasn't landed),
+ *  so callers never divide by zero. */
+export function memPct(system: SystemInfo): number {
+  return system.memTotal > 0 ? (100 * system.memUsed) / system.memTotal : 0;
+}
+
+/** Used / total memory in gigabytes, formatted to one decimal — the
+ *  string form the header and the fleet cards both render. */
+export function memGb(system: SystemInfo): { used: string; total: string } {
+  return {
+    used: (system.memUsed / 1e9).toFixed(1),
+    total: (system.memTotal / 1e9).toFixed(1),
+  };
+}
+
+/** Coarse, human-friendly uptime: days+hours, hours+minutes, or minutes.
+ *  Matches the granularity htop-style headers show — nobody reads
+ *  seconds-of-uptime at a glance. */
+export function formatUptime(uptimeSec: number): string {
+  const d = Math.floor(uptimeSec / 86400);
+  const h = Math.floor((uptimeSec % 86400) / 3600);
+  const m = Math.floor((uptimeSec % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+/** Mean busy-percentage across the supplied per-core usages — the single
+ *  "host CPU%" number the fleet card shows in place of the full per-core
+ *  strip. Zero for a host with no reported cores (e.g. not yet
+ *  connected), never NaN. */
+export function averageCoreUsage(usages: readonly number[]): number {
+  if (usages.length === 0) return 0;
+  let sum = 0;
+  for (const u of usages) sum += u;
+  return sum / usages.length;
+}

--- a/packages/app/src/client/metrics.ts
+++ b/packages/app/src/client/metrics.ts
@@ -42,7 +42,5 @@ export function formatUptime(uptimeSec: number): string {
  *  connected), never NaN. */
 export function averageCoreUsage(usages: readonly number[]): number {
   if (usages.length === 0) return 0;
-  let sum = 0;
-  for (const u of usages) sum += u;
-  return sum / usages.length;
+  return usages.reduce((s, u) => s + u, 0) / usages.length;
 }

--- a/packages/app/src/client/usageColors.test.ts
+++ b/packages/app/src/client/usageColors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { coreUsageColor, processPctColor, usageBarColor } from "./usageColors";
+
+describe("usageBarColor", () => {
+  it("is emerald at/under 65, amber above, red above 85", () => {
+    expect(usageBarColor(65)).toBe("bg-emerald-500");
+    expect(usageBarColor(66)).toBe("bg-amber-500");
+    expect(usageBarColor(85)).toBe("bg-amber-500");
+    expect(usageBarColor(86)).toBe("bg-red-500");
+  });
+});
+
+describe("coreUsageColor", () => {
+  it("runs hotter — amber above 50, red above 80", () => {
+    expect(coreUsageColor(50)).toBe("bg-emerald-500");
+    expect(coreUsageColor(51)).toBe("bg-amber-500");
+    expect(coreUsageColor(80)).toBe("bg-amber-500");
+    expect(coreUsageColor(81)).toBe("bg-red-500");
+  });
+});
+
+describe("processPctColor", () => {
+  it("tints text — neutral, amber above 10, red above 50", () => {
+    expect(processPctColor(10)).toBe("text-gray-700 dark:text-gray-400");
+    expect(processPctColor(11)).toBe("text-amber-500");
+    expect(processPctColor(50)).toBe("text-amber-500");
+    expect(processPctColor(51)).toBe("font-semibold text-red-500");
+  });
+});

--- a/packages/app/src/client/usageColors.ts
+++ b/packages/app/src/client/usageColors.ts
@@ -1,0 +1,32 @@
+/**
+ * Usage-percentage → Tailwind colour, single-sourced so the emerald /
+ * amber / red palette can't drift between the memory bar, the per-core
+ * bars, and the per-process columns. The *thresholds* differ per surface
+ * (a core at 80% is hot; memory at 80% is merely amber), but the palette
+ * is one decision — `severityBg` owns it.
+ */
+
+function severityBg(pct: number, amberAbove: number, redAbove: number): string {
+  if (pct > redAbove) return "bg-red-500";
+  if (pct > amberAbove) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+/** Memory / overall usage bar fill — amber past 65%, red past 85%. */
+export function usageBarColor(pct: number): string {
+  return severityBg(pct, 65, 85);
+}
+
+/** Per-core CPU bar fill — runs hotter, so amber past 50%, red past 80%. */
+export function coreUsageColor(pct: number): string {
+  return severityBg(pct, 50, 80);
+}
+
+/** Per-process CPU%/MEM% text colour. Distinct from the bars: it tints
+ *  text (not background) and leans on a neutral resting colour rather
+ *  than emerald, since a table of mostly-idle rows shouldn't glow green. */
+export function processPctColor(pct: number): string {
+  if (pct > 50) return "font-semibold text-red-500";
+  if (pct > 10) return "text-amber-500";
+  return "text-gray-700 dark:text-gray-400";
+}

--- a/packages/app/src/client/usageColors.ts
+++ b/packages/app/src/client/usageColors.ts
@@ -6,20 +6,22 @@
  * is one decision — `severityBg` owns it.
  */
 
-function severityBg(pct: number, amberAbove: number, redAbove: number): string {
-  if (pct > redAbove) return "bg-red-500";
-  if (pct > amberAbove) return "bg-amber-500";
+// Named thresholds so a caller can't silently invert severity by
+// swapping two positional numbers (`severityBg(pct, 85, 65)`).
+function severityBg(pct: number, at: { amber: number; red: number }): string {
+  if (pct > at.red) return "bg-red-500";
+  if (pct > at.amber) return "bg-amber-500";
   return "bg-emerald-500";
 }
 
 /** Memory / overall usage bar fill — amber past 65%, red past 85%. */
 export function usageBarColor(pct: number): string {
-  return severityBg(pct, 65, 85);
+  return severityBg(pct, { amber: 65, red: 85 });
 }
 
 /** Per-core CPU bar fill — runs hotter, so amber past 50%, red past 80%. */
 export function coreUsageColor(pct: number): string {
-  return severityBg(pct, 50, 80);
+  return severityBg(pct, { amber: 50, red: 80 });
 }
 
 /** Per-process CPU%/MEM% text colour. Distinct from the bars: it tints

--- a/packages/app/src/client/view.ts
+++ b/packages/app/src/client/view.ts
@@ -1,0 +1,12 @@
+/**
+ * What the main pane shows: the aggregate fleet overview, or one host's
+ * full htop body. Modelled as a sum so "which host" only exists in the
+ * branch where a host is selected — there's no nullable host floating
+ * alongside a separate "is fleet" flag to keep consistent.
+ *
+ * Lives in its own module (not `App.tsx`) so both the root `App`, which
+ * owns the selected-view state, and the leaf `TabStrip`, which highlights
+ * the active tab, depend *downward* on this shared type rather than the
+ * leaf importing from the root.
+ */
+export type View = { kind: "fleet" } | { kind: "host"; host: string };


### PR DESCRIPTION
**drishti now opens on a fleet overview: one live summary card per configured host — connection state, CPU (mean across cores), memory, load average, uptime, OS — in a single pane.** Until now the only way to read N hosts was to click through N tabs; the aggregate "single pane of glass" is the most-validated value proposition for multi-host monitors, and drishti already had every piece needed to build it. Clicking a card (or a host tab) drills into that host's full htop body.

The whole feature is **pure client-side aggregation** — no schema, agent, or server changes. Each card subscribes to the host's existing `system`/`connection` cells and `cpuCores` collection over the *same per-host socket the tab chips already keep warm*, so the overview costs subscriptions, not new connections.

```
fleet tab ─▶ FleetView ─▶ HostCard × N
                              │  surfaceForHost(h)  (cached socket)
                              ▼
                  system · connection · cpuCores   ──reactive──▶ live card
```

### What you see

- **fleet tab** (leftmost, default landing view) — a responsive grid of host cards; a per-host connection dot pulses while provisioning/connecting
- **per-card metrics** — CPU and memory usage bars, load average, uptime, OS, core count
- **not-connected cards** — show a terse status (`provisioning agent…` / `connecting…` / `no data`) instead of stale zeros
- **click to drill in** — a card or a host tab switches to that host's existing process table; removing the active host falls back to the fleet view rather than a blank pane

### Structure

The view selection is modelled as a sum — `View = {kind:"fleet"} | {kind:"host"; host}` (in its own `view.ts`) — so "which host" only exists in the branch where a host is selected. Two new Solid-free, unit-tested helper modules carry the reused logic:

| Module | Owns |
| --- | --- |
| `metrics.ts` | `memPct` / `memGb` / `formatUptime` / `averageCoreUsage` — derivations the per-host header and the fleet cards share |
| `usageColors.ts` | the emerald/amber/red usage palette, single-sourced across the memory bar, per-core bars, and process columns |
| `connectionColors.ts` | one `STATE` map: dot colour, text colour, terse label, verbose message, and pending flag per `ConnectionState` |

> _Structural review (hickey + lowy, with a cross-validation pass) drove the helper extractions and the `View` placement — see the analysis comment below._

### Try it locally

```sh
nix run github:srid/drishti/feat/fleet-dashboard -- localhost a.lan b.lan
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._