### PR TITLE
Give every host its own shareable URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ nix run github:srid/drishti -- localhost a.lan b.lan   # multiple hosts (tabbed 
 
 Open <http://localhost:7720>. The UI opens on the **fleet** tab — a single overview pane with one live summary card per host (connection state, CPU, memory, load average, uptime); click a card (or a host's tab) to drill into that host's full htop. Each host also has its own tab with a live connection-state dot.
 
-Every view has its own URL, so you can bookmark or share a link straight to a host: selecting a host updates the address to <http://localhost:7720/?host=user@host> (the fleet overview is the bare <http://localhost:7720/>). Opening such a link lands directly on that host, and the browser's back/forward buttons walk your selection history.
+Every view has its own URL, so you can bookmark or share a link straight to a host: selecting a host updates the address to <http://localhost:7720/?host=user@host> (the fleet overview is the bare <http://localhost:7720/>). Opening such a link, or reloading the page, lands directly on that host.
 
 Use the `+ add host` button in the tab strip to add hosts at runtime; the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ nix run github:srid/drishti -- user@host               # one remote
 nix run github:srid/drishti -- localhost a.lan b.lan   # multiple hosts (tabbed UI)
 ```
 
-Open <http://localhost:7720>. The UI opens on the **fleet** tab — a single overview pane with one live summary card per host (connection state, CPU, memory, load average, uptime); click a card (or a host's tab) to drill into that host's full htop. Each host also has its own tab with a live connection-state dot. Use the `+ add host` button in the tab strip to add hosts at runtime; the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
+Open <http://localhost:7720>. The UI opens on the **fleet** tab — a single overview pane with one live summary card per host (connection state, CPU, memory, load average, uptime); click a card (or a host's tab) to drill into that host's full htop. Each host also has its own tab with a live connection-state dot.
+
+Every view has its own URL, so you can bookmark or share a link straight to a host: selecting a host updates the address to <http://localhost:7720/?host=user@host> (the fleet overview is the bare <http://localhost:7720/>). Opening such a link lands directly on that host, and the browser's back/forward buttons walk your selection history.
+
+Use the `+ add host` button in the tab strip to add hosts at runtime; the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
 
 Requirements:
 

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -23,6 +23,7 @@ import {
   For,
   on,
   onCleanup,
+  onMount,
   Show,
 } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
@@ -38,6 +39,7 @@ import {
 } from "../common/surface";
 import { STATE } from "./connectionColors";
 import type { View } from "./view";
+import { searchForView, viewFromSearch } from "./urlState";
 import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
 import { coreUsageColor, processPctColor, usageBarColor } from "./usageColors";
 import { TabStrip } from "./TabStrip";
@@ -78,8 +80,32 @@ export default function App() {
 
   // The fleet overview is the default landing view — the "single pane of
   // glass" across every host. `view` holds the user's intent; the host
-  // set it resolves against is owned by the admin collection.
-  const [view, setView] = createSignal<View>({ kind: "fleet" });
+  // set it resolves against is owned by the admin collection. The initial
+  // intent is read from the URL so a shared/bookmarked `?host=…` link opens
+  // straight on that host (it resolves once the admin collection arrives).
+  const [view, setView] = createSignal<View>(
+    viewFromSearch(window.location.search),
+  );
+
+  // Mirror the selected view into the browser URL so every host — and the
+  // fleet overview — has a shareable address, and `pushState` makes the back
+  // button walk the selection history. Bound to `view` (intent), not
+  // `resolvedView`: while the admin collection is still loading a deep-linked
+  // host isn't in the set yet, and binding to the resolved value would rewrite
+  // the URL to fleet before the host arrives. The guard skips redundant
+  // entries — including the no-op first run, where the URL already matches.
+  createEffect(() => {
+    const search = searchForView(view());
+    if (search !== window.location.search) {
+      window.history.pushState(null, "", `${window.location.pathname}${search}`);
+    }
+  });
+  // Reflect back/forward navigation back into the view intent.
+  onMount(() => {
+    const onPopState = () => setView(viewFromSearch(window.location.search));
+    window.addEventListener("popstate", onPopState);
+    onCleanup(() => window.removeEventListener("popstate", onPopState));
+  });
   // Resolve intent against the live host set: a host view whose host has
   // been removed falls back to the fleet overview rather than a blank
   // pane, and the fleet view always resolves to itself.
@@ -107,8 +133,11 @@ export default function App() {
   const onRemove = async (host: string) => {
     try {
       await admin.rpc.surface.hosts.remove({ host });
-      // No manual view reset needed: resolvedView falls back to fleet
-      // once the host leaves the collection.
+      // Drop the intent if the removed host was the selected one, so the
+      // URL clears to the fleet path. (`resolvedView` already falls the
+      // pane back to fleet; resetting the intent keeps the address in sync.)
+      const v = view();
+      if (v.kind === "host" && v.host === host) setView({ kind: "fleet" });
     } catch (err) {
       console.error(`remove ${host} failed`, err);
     }

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -23,7 +23,6 @@ import {
   For,
   on,
   onCleanup,
-  onMount,
   Show,
 } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
@@ -88,23 +87,24 @@ export default function App() {
   );
 
   // Mirror the selected view into the browser URL so every host — and the
-  // fleet overview — has a shareable address, and `pushState` makes the back
-  // button walk the selection history. Bound to `view` (intent), not
-  // `resolvedView`: while the admin collection is still loading a deep-linked
-  // host isn't in the set yet, and binding to the resolved value would rewrite
-  // the URL to fleet before the host arrives. The guard skips redundant
-  // entries — including the no-op first run, where the URL already matches.
+  // fleet overview — has a shareable, bookmarkable address. `replaceState`
+  // (not `pushState`) keeps the URL reflecting the current view without
+  // growing the history stack: programmatic corrections — a removed host
+  // resetting to fleet, or a malformed `?host=` normalising away — would
+  // otherwise litter the back button with entries that all resolve to fleet.
+  // Bound to `view` (intent), not `resolvedView`: while the admin collection
+  // is still loading a deep-linked host isn't in the set yet, and binding to
+  // the resolved value would rewrite the URL to fleet before the host arrives.
+  // The guard skips redundant writes, including the no-op first run.
   createEffect(() => {
     const search = searchForView(view());
     if (search !== window.location.search) {
-      window.history.pushState(null, "", `${window.location.pathname}${search}`);
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${search}`,
+      );
     }
-  });
-  // Reflect back/forward navigation back into the view intent.
-  onMount(() => {
-    const onPopState = () => setView(viewFromSearch(window.location.search));
-    window.addEventListener("popstate", onPopState);
-    onCleanup(() => window.removeEventListener("popstate", onPopState));
   });
   // Resolve intent against the live host set: a host view whose host has
   // been removed falls back to the fleet overview rather than a blank

--- a/packages/app/src/client/urlState.test.ts
+++ b/packages/app/src/client/urlState.test.ts
@@ -24,6 +24,11 @@ describe("viewFromSearch", () => {
       host: "user@a.lan",
     });
   });
+
+  it("falls back to fleet for a blank or whitespace-only host", () => {
+    expect(viewFromSearch("?host=")).toEqual({ kind: "fleet" });
+    expect(viewFromSearch("?host=%20")).toEqual({ kind: "fleet" });
+  });
 });
 
 describe("searchForView", () => {

--- a/packages/app/src/client/urlState.test.ts
+++ b/packages/app/src/client/urlState.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import type { View } from "./view";
+import { searchForView, viewFromSearch } from "./urlState";
+
+describe("viewFromSearch", () => {
+  it("reads the fleet overview from an empty search", () => {
+    expect(viewFromSearch("")).toEqual({ kind: "fleet" });
+  });
+
+  it("ignores unrelated params and stays on fleet", () => {
+    expect(viewFromSearch("?foo=bar")).toEqual({ kind: "fleet" });
+  });
+
+  it("reads a selected host from the host param", () => {
+    expect(viewFromSearch("?host=localhost")).toEqual({
+      kind: "host",
+      host: "localhost",
+    });
+  });
+
+  it("decodes ssh targets with @ and other reserved chars", () => {
+    expect(viewFromSearch("?host=user%40a.lan")).toEqual({
+      kind: "host",
+      host: "user@a.lan",
+    });
+  });
+});
+
+describe("searchForView", () => {
+  it("encodes the fleet overview as the bare path (empty search)", () => {
+    expect(searchForView({ kind: "fleet" })).toBe("");
+  });
+
+  it("encodes a host into the host param", () => {
+    expect(searchForView({ kind: "host", host: "localhost" })).toBe(
+      "?host=localhost",
+    );
+  });
+
+  it("URL-encodes ssh targets so @ survives", () => {
+    expect(searchForView({ kind: "host", host: "user@a.lan" })).toBe(
+      "?host=user%40a.lan",
+    );
+  });
+});
+
+describe("round-trip", () => {
+  it("recovers every view from its own serialization", () => {
+    const views: View[] = [
+      { kind: "fleet" },
+      { kind: "host", host: "localhost" },
+      { kind: "host", host: "user@a.lan" },
+      { kind: "host", host: "[::1]" },
+    ];
+    for (const view of views) {
+      expect(viewFromSearch(searchForView(view))).toEqual(view);
+    }
+  });
+});

--- a/packages/app/src/client/urlState.ts
+++ b/packages/app/src/client/urlState.ts
@@ -1,0 +1,30 @@
+/**
+ * Serializes the {@link View} sum to and from the browser URL so every host
+ * — and the fleet overview — has a shareable, bookmarkable address.
+ *
+ * The `View` signal in `App` is the source of truth; the URL is just its
+ * projection. A selected host lives in the `?host=` query param, URL-encoded
+ * so arbitrary ssh targets (`user@host`, `[::1]`, …) round-trip intact. The
+ * bare path (no `host` param) is the fleet overview. Query params — not path
+ * segments — keep reload working with zero server routing: every address
+ * still resolves to `/`, which already serves the SPA.
+ *
+ * The two functions are pure (they take a search string rather than reading
+ * `window.location`) so they unit-test without a DOM, matching the
+ * `metrics` / `usageColors` pattern. Call sites pass `window.location.search`.
+ */
+import type { View } from "./view";
+
+const HOST_PARAM = "host";
+
+/** Parse a `location.search` string into the view it encodes. */
+export function viewFromSearch(search: string): View {
+  const host = new URLSearchParams(search).get(HOST_PARAM);
+  return host ? { kind: "host", host } : { kind: "fleet" };
+}
+
+/** The `location.search` string (`""` or `"?host=…"`) that encodes a view. */
+export function searchForView(view: View): string {
+  if (view.kind === "fleet") return "";
+  return `?${new URLSearchParams({ [HOST_PARAM]: view.host }).toString()}`;
+}

--- a/packages/app/src/client/urlState.ts
+++ b/packages/app/src/client/urlState.ts
@@ -19,7 +19,10 @@ const HOST_PARAM = "host";
 
 /** Parse a `location.search` string into the view it encodes. */
 export function viewFromSearch(search: string): View {
-  const host = new URLSearchParams(search).get(HOST_PARAM);
+  // Trim and treat blank as absent: a malformed `?host=` or `?host=%20`
+  // (no real ssh target is whitespace) normalises to the fleet overview
+  // rather than a host view that can never resolve and sticks in the URL.
+  const host = new URLSearchParams(search).get(HOST_PARAM)?.trim();
   return host ? { kind: "host", host } : { kind: "fleet" };
 }
 


### PR DESCRIPTION
**Every view now has an address.** Selecting a host writes it into the browser URL as `?host=<ssh-target>` (the fleet overview is the bare `/`), so you can bookmark a host, paste a link in chat, or reload and land right back on the host you were watching — previously the app always reopened on the fleet tab regardless of where you'd navigated.

The existing `View` sum (`{kind:"fleet"} | {kind:"host";host}`) was already the perfect thing to serialize, so no router library was added. A small pure module does the encoding both ways; `App.tsx` just wires it to the view signal.

```
URL (?host=…)  ◀──replaceState──  view signal  ──init/restore──▶  URL
                                      │
                                 resolvedView ──▶ pane (fleet | host htop)
```

### How it works

- **`urlState.ts`** — two pure functions, `viewFromSearch` / `searchForView`, that round-trip a `View` through a `location.search` string. ssh targets are URL-encoded, so `user@host` survives intact. Unit-tested in isolation (no DOM), matching the `metrics` / `usageColors` pattern.
- **`App.tsx`** — the `view` signal initializes from the URL (a deep-linked host resolves once the admin collection arrives), and a `createEffect` mirrors changes back via `replaceState`. The URL binds to *intent*, not `resolvedView`, so a still-loading deep-link isn't rewritten to fleet before its host shows up.

### Edge cases handled

| Case | Behavior |
| --- | --- |
| Removing the host you're viewing | Intent resets to fleet so the URL clears, not just the pane |
| Malformed `?host=` / `?host=%20` | Trims to blank → falls back to fleet instead of sticking forever |
| Deep-link to a host still loading | URL preserved as intent; resolves when the admin collection arrives |

> _`replaceState` (not `pushState`) keeps the URL reflecting the current view without growing the back-button stack with programmatic corrections._

### Try it locally

```sh
nix run github:srid/drishti/url
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._