### PR TITLE
Add per-interface network I/O metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Host 1: drishti-agent     Host 2: drishti-agent     …
 Kernel
 ```
 
-Host identity lives only at the transport layer: each browser tab opens its own WebSocket to `/rpc/ws?host=<id>`; the parent dispatches to a per-host `RPCHandler` (built once per host from the same surface schema). The per-host `surface` schema (system / processes / cpuCores / connection cells) is scalar — no host dimension anywhere in the primitives.
+Host identity lives only at the transport layer: each browser tab opens its own WebSocket to `/rpc/ws?host=<id>`; the parent dispatches to a per-host `RPCHandler` (built once per host from the same surface schema). The per-host `surface` schema (system / processes / cpuCores / networkInterfaces / connection cells) is scalar — no host dimension anywhere in the primitives.
 
 A separate **admin surface** at `/rpc/ws?host=__admin__` exposes the *set* of hosts as a `Collection<string, HostEntry>` plus `addHost` / `removeHost` procedures. The tab strip subscribes to the collection; the `+` / `×` buttons call the procedures.
 
@@ -50,6 +50,7 @@ Per-host primitives:
 | **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, memPct, command, cwd }`. Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
 | **Stream** | `processesSnapshot` | Bulk-snapshot variant for ~600-PID htop refresh in one frame. |
 | **Collection** | `cpuCores` | Per-core CPU usage (`Collection<K,T>` showcase). |
+| **Collection** | `networkInterfaces` | Per-NIC network I/O, keyed by interface name — `{ rxBytes, txBytes, rxRate, txRate }` (cumulative bytes since boot + bytes/sec throughput). `/proc/net/dev` on linux, `netstat -ib` on darwin; loopback filtered out. |
 | **Procedure** | `process.kill` | The only mutation — sends `TERM` / `KILL` / `HUP` / `INT`. |
 
 Admin surface primitives:

--- a/packages/app/src/agent/main.ts
+++ b/packages/app/src/agent/main.ts
@@ -37,6 +37,8 @@ import {
   type CoreId,
   type CpuCore,
   DEFAULT_CONNECTION,
+  type IfaceName,
+  type NetInterface,
   type Pid,
   type Process,
   type ProcessesSnapshotMsg,
@@ -85,6 +87,11 @@ async function main(): Promise<void> {
   const cpuCoreSnapshot = new Map<CoreId, CpuCore>();
   for (const [core, value] of reader.readCpuCores())
     cpuCoreSnapshot.set(core, value);
+  // Seed the network baseline so the first published delta has a previous
+  // tick to rate against — this first read returns 0 bytes/sec everywhere.
+  const netSnapshot = new Map<IfaceName, NetInterface>();
+  for (const [iface, value] of await reader.readNetwork())
+    netSnapshot.set(iface, value);
 
   // Build the surface implementation. The `processes` collection's
   // `readAll` yields the current snapshot; `upsert`/`remove` are the
@@ -125,6 +132,15 @@ async function main(): Promise<void> {
         },
         remove: (key) => {
           cpuCoreSnapshot.delete(key);
+        },
+      },
+      networkInterfaces: {
+        readAll: () => netSnapshot,
+        upsert: (key, value) => {
+          netSnapshot.set(key, value);
+        },
+        remove: (key) => {
+          netSnapshot.delete(key);
         },
       },
     },
@@ -209,6 +225,19 @@ async function main(): Promise<void> {
       for (const core of cpuCoreSnapshot.keys()) {
         if (!nextCores.has(core))
           fragment.ctx.collections.cpuCores.remove(core);
+      }
+
+      // Per-NIC network I/O — same Collection<K,T> publish shape as
+      // cpuCores. Throughput shifts almost every tick, so unconditional
+      // upserts are simplest; evict interfaces that vanished (NIC down /
+      // hot-unplug) so stale rows don't linger in the browser.
+      const nextNet = await reader.readNetwork();
+      for (const [iface, value] of nextNet) {
+        fragment.ctx.collections.networkInterfaces.upsert(iface, value);
+      }
+      for (const iface of netSnapshot.keys()) {
+        if (!nextNet.has(iface))
+          fragment.ctx.collections.networkInterfaces.remove(iface);
       }
     } catch (err) {
       log(`tick error: ${(err as Error).message}`);

--- a/packages/app/src/agent/proc.test.ts
+++ b/packages/app/src/agent/proc.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import {
+  computeNetThroughput,
+  type NetCounters,
+  parseNetstatIb,
+  parseProcNetDev,
+} from "./proc";
+
+describe("parseProcNetDev", () => {
+  // Real /proc/net/dev shape: two header lines, then `name: rx_bytes
+  // rx_packets …(8 rx fields)… tx_bytes tx_packets …`.
+  const sample = [
+    "Inter-|   Receive                                                |  Transmit",
+    " face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed",
+    "    lo:  123456    789    0    0    0     0          0         0   123456     789    0    0    0     0       0          0",
+    "  eth0: 1000000   5000    0    0    0     0          0         0   2000000    6000    0    0    0     0       0          0",
+    "",
+  ].join("\n");
+
+  it("reads receive bytes (field 1) and transmit bytes (field 9) per interface", () => {
+    const m = parseProcNetDev(sample);
+    expect(m.get("eth0")).toEqual({ rxBytes: 1000000, txBytes: 2000000 });
+  });
+
+  it("parses every interface faithfully, including loopback (filtering is the reader's job)", () => {
+    const m = parseProcNetDev(sample);
+    expect(m.get("lo")).toEqual({ rxBytes: 123456, txBytes: 123456 });
+    expect([...m.keys()].sort()).toEqual(["eth0", "lo"]);
+  });
+
+  it("skips the two header lines (no colon)", () => {
+    const m = parseProcNetDev(sample);
+    expect(m.has("face")).toBe(false);
+    expect(m.has("Inter-")).toBe(false);
+  });
+});
+
+describe("parseNetstatIb", () => {
+  // darwin `netstat -ib`: one <Link#N> aggregate row per interface, plus
+  // address-family rows we ignore. The lo0 row has no MAC (Address blank),
+  // the en0 row does — exercising the count-from-the-right column logic.
+  const sample = [
+    "Name  Mtu   Network       Address            Ipkts Ierrs     Ibytes    Opkts Oerrs     Obytes  Coll",
+    "lo0   16384 <Link#1>                          100     0      12000      100     0      12000     0",
+    "en0   1500  <Link#2>    a1:b2:c3:d4:e5:f6    5000     0    8000000     4000     0    3000000     0",
+    "en0   1500  192.168.1     192.168.1.5         5000     0    8000000     4000     0    3000000     0",
+    "",
+  ].join("\n");
+
+  it("reads Ibytes/Obytes from the <Link#> row regardless of the Address column", () => {
+    const m = parseNetstatIb(sample);
+    expect(m.get("en0")).toEqual({ rxBytes: 8000000, txBytes: 3000000 });
+    expect(m.get("lo0")).toEqual({ rxBytes: 12000, txBytes: 12000 });
+  });
+
+  it("ignores non-<Link#> address-family rows (no double counting)", () => {
+    const m = parseNetstatIb(sample);
+    expect([...m.keys()].sort()).toEqual(["en0", "lo0"]);
+  });
+});
+
+describe("computeNetThroughput", () => {
+  const prev: Map<string, NetCounters> = new Map([
+    ["eth0", { rxBytes: 1000, txBytes: 2000 }],
+  ]);
+
+  it("derives bytes/sec from the counter delta over the window", () => {
+    const cur: Map<string, NetCounters> = new Map([
+      ["eth0", { rxBytes: 3000, txBytes: 5000 }],
+    ]);
+    expect(computeNetThroughput(prev, cur, 2).get("eth0")).toEqual({
+      rxBytes: 3000,
+      txBytes: 5000,
+      rxRate: 1000,
+      txRate: 1500,
+    });
+  });
+
+  it("reports 0 rate on the first tick (winSec <= 0)", () => {
+    const cur: Map<string, NetCounters> = new Map([
+      ["eth0", { rxBytes: 3000, txBytes: 5000 }],
+    ]);
+    const nic = computeNetThroughput(prev, cur, 0).get("eth0");
+    expect(nic?.rxRate).toBe(0);
+    expect(nic?.txRate).toBe(0);
+  });
+
+  it("reports 0 rate for an interface with no previous counters", () => {
+    const cur: Map<string, NetCounters> = new Map([
+      ["wlan0", { rxBytes: 9999, txBytes: 8888 }],
+    ]);
+    const nic = computeNetThroughput(prev, cur, 2).get("wlan0");
+    expect(nic).toEqual({
+      rxBytes: 9999,
+      txBytes: 8888,
+      rxRate: 0,
+      txRate: 0,
+    });
+  });
+
+  it("clamps a counter that ran backwards (reset / hot-swap) to 0", () => {
+    const cur: Map<string, NetCounters> = new Map([
+      ["eth0", { rxBytes: 100, txBytes: 50 }],
+    ]);
+    const nic = computeNetThroughput(prev, cur, 2).get("eth0");
+    expect(nic?.rxRate).toBe(0);
+    expect(nic?.txRate).toBe(0);
+  });
+});

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -29,6 +29,8 @@ import { promisify } from "node:util";
 import type {
   CoreId,
   CpuCore,
+  IfaceName,
+  NetInterface,
   Pid,
   Process,
   SystemInfo,
@@ -49,6 +51,11 @@ export interface ProcReader {
    *  yet). Universally available via `node:os.cpus()` — same shape on
    *  linux and darwin. */
   readCpuCores: () => Map<CoreId, CpuCore>;
+  /** Per-NIC cumulative bytes + throughput. Like `readCpuCores`, the
+   *  rate is a delta against the previous call — the first call seeds the
+   *  baseline and reports 0 bytes/sec. Async because the source is a file
+   *  read (linux) or a subprocess (darwin). Empty on unknown platforms. */
+  readNetwork: () => Promise<Map<IfaceName, NetInterface>>;
 }
 
 /** Closure that retains the previous `cpus()` snapshot for delta-busy
@@ -87,6 +94,136 @@ function createCpuCoresReader(): () => Map<CoreId, CpuCore> {
   };
 }
 
+// ── Network I/O reading ─────────────────────────────────────────────────
+
+/** Cumulative byte counters for one interface — the raw observation a
+ *  platform parser yields, before throughput is derived. */
+export interface NetCounters {
+  rxBytes: number;
+  txBytes: number;
+}
+
+/** Loopback carries intra-host traffic, not network I/O, and is always
+ *  busy — every comparable monitor (rtop, htop, glances) hides it. Filter
+ *  it in the reader (not the parser) so the parsers stay faithful to their
+ *  source. `lo` on linux, `lo0` on darwin. */
+function isLoopback(name: string): boolean {
+  return name === "lo" || name === "lo0";
+}
+
+/** Parse `/proc/net/dev`. Each data line is `name: rx_bytes rx_packets …
+ *  (8 receive fields) tx_bytes tx_packets …` — so receive bytes are the
+ *  first number after the colon and transmit bytes the ninth. The two
+ *  header lines have no colon and are skipped. Split on the first colon:
+ *  modern interface names (`eth0`, `enp3s0`, `wlan0`, `eth0.100`) contain
+ *  no colon; deprecated `eth0:0` IP aliases are the rare exception and
+ *  would mis-split, but those no longer appear as separate `/proc/net/dev`
+ *  rows on current kernels. */
+export function parseProcNetDev(content: string): Map<string, NetCounters> {
+  const out = new Map<string, NetCounters>();
+  for (const line of content.split("\n")) {
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const name = line.slice(0, colon).trim();
+    if (name.length === 0) continue;
+    const nums = line
+      .slice(colon + 1)
+      .trim()
+      .split(/\s+/)
+      .map(Number);
+    const rxBytes = nums[0];
+    const txBytes = nums[8];
+    if (rxBytes === undefined || txBytes === undefined) continue;
+    if (Number.isNaN(rxBytes) || Number.isNaN(txBytes)) continue;
+    out.set(name, { rxBytes, txBytes });
+  }
+  return out;
+}
+
+/** Parse `netstat -ib` (darwin). Each interface has several rows (one per
+ *  address family); the `<Link#N>` row is the link-layer aggregate — the
+ *  one whose byte counters cover the whole interface — so we read only
+ *  those. The optional Address (MAC) column shifts the absolute field
+ *  positions, so count from the right, where the layout is stable:
+ *  `… Ibytes Opkts Oerrs Obytes Coll` → Ibytes is 5th-from-last, Obytes
+ *  is 2nd-from-last. */
+export function parseNetstatIb(content: string): Map<string, NetCounters> {
+  const out = new Map<string, NetCounters>();
+  for (const line of content.split("\n")) {
+    if (!line.includes("<Link#")) continue;
+    const cols = line.trim().split(/\s+/);
+    const name = cols[0];
+    const rxBytes = Number(cols[cols.length - 5]);
+    const txBytes = Number(cols[cols.length - 2]);
+    if (name === undefined || name.length === 0) continue;
+    if (Number.isNaN(rxBytes) || Number.isNaN(txBytes)) continue;
+    // First-occurrence wins — one <Link#> row per interface, but guard
+    // against a malformed dump repeating a name.
+    if (!out.has(name)) out.set(name, { rxBytes, txBytes });
+  }
+  return out;
+}
+
+/** Derive per-interface throughput from two cumulative-counter snapshots
+ *  and the seconds between them. Pure — the clock lives in the caller so
+ *  this stays unit-testable. `winSec <= 0` (the first tick) yields 0
+ *  rates. Counters that ran backwards (counter reset, NIC hot-swap, pid
+ *  recycling of the name) clamp to 0 rather than report a negative or
+ *  absurd spike. */
+export function computeNetThroughput(
+  prev: Map<string, NetCounters>,
+  cur: Map<string, NetCounters>,
+  winSec: number,
+): Map<IfaceName, NetInterface> {
+  const out = new Map<IfaceName, NetInterface>();
+  for (const [name, c] of cur) {
+    const p = prev.get(name);
+    let rxRate = 0;
+    let txRate = 0;
+    if (p && winSec > 0) {
+      rxRate = Math.max(0, (c.rxBytes - p.rxBytes) / winSec);
+      txRate = Math.max(0, (c.txBytes - p.txBytes) / winSec);
+    }
+    out.set(name, {
+      rxBytes: c.rxBytes,
+      txBytes: c.txBytes,
+      rxRate: Math.round(rxRate),
+      txRate: Math.round(txRate),
+    });
+  }
+  return out;
+}
+
+/** Closure wrapping `computeNetThroughput` with the previous snapshot and
+ *  wall clock — the same rate-from-delta shape `createCpuCoresReader`
+ *  uses, but async since the raw counters come from a file read or
+ *  subprocess. `readRaw` already excludes loopback. */
+function createNetReader(
+  readRaw: () => Promise<Map<string, NetCounters>>,
+): () => Promise<Map<IfaceName, NetInterface>> {
+  let prev = new Map<string, NetCounters>();
+  let prevMs = 0;
+  return async () => {
+    const cur = await readRaw();
+    const nowMs = Date.now();
+    const winSec = prevMs > 0 ? (nowMs - prevMs) / 1000 : 0;
+    const out = computeNetThroughput(prev, cur, winSec);
+    prev = cur;
+    prevMs = nowMs;
+    return out;
+  };
+}
+
+function filterLoopback(
+  counters: Map<string, NetCounters>,
+): Map<string, NetCounters> {
+  const out = new Map<string, NetCounters>();
+  for (const [name, c] of counters) {
+    if (!isLoopback(name)) out.set(name, c);
+  }
+  return out;
+}
+
 export function createProcReader(): ProcReader {
   const plat = platform();
   if (plat === "linux") return linuxReader();
@@ -98,6 +235,11 @@ export function createProcReader(): ProcReader {
 
 function linuxReader(): ProcReader {
   const readCpuCores = createCpuCoresReader();
+  const readNetwork = createNetReader(async () =>
+    filterLoopback(
+      parseProcNetDev(await readFile("/proc/net/dev", "utf-8")),
+    ),
+  );
   // Per-PID previous tick reading so we can compute "% of one core
   // during the last poll window" — the metric `top`/`htop` show.
   // Without this delta, dividing lifetime ticks by lifetime uptime
@@ -112,6 +254,7 @@ function linuxReader(): ProcReader {
   return {
     os: "linux",
     readCpuCores,
+    readNetwork,
     readSystem: async () => {
       const [loadAvgs, mem, up] = await Promise.all([
         readFile("/proc/loadavg", "utf-8").then((s) =>
@@ -264,9 +407,14 @@ const PS_LINE_RE = /^(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(.*)$/;
 
 function darwinReader(): ProcReader {
   const readCpuCores = createCpuCoresReader();
+  const readNetwork = createNetReader(async () => {
+    const { stdout } = await exec("netstat -ib");
+    return filterLoopback(parseNetstatIb(stdout));
+  });
   return {
     os: "darwin",
     readCpuCores,
+    readNetwork,
     readSystem: async () => {
       // os.loadavg() works on darwin; sysctl fallback only needed for
       // very old node versions.
@@ -314,6 +462,9 @@ function stubReader(): ProcReader {
   return {
     os: "unknown",
     readCpuCores,
+    // No universal network-counter source off linux/darwin — report no
+    // interfaces rather than guess.
+    readNetwork: async () => new Map<IfaceName, NetInterface>(),
     readSystem: async () => {
       const la = loadavg();
       return {

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -201,15 +201,20 @@ export function computeNetThroughput(
 function createNetReader(
   readRaw: () => Promise<Map<string, NetCounters>>,
 ): () => Promise<Map<IfaceName, NetInterface>> {
-  let prev = new Map<string, NetCounters>();
-  let prevMs = 0;
+  // The previous counters and when they were sampled are one concept —
+  // they must advance together every tick. Holding them as a single record
+  // (rather than two `let`s) makes the swap atomic, so a future edit can't
+  // update the counters while forgetting the timestamp.
+  let prev: { counters: Map<string, NetCounters>; takenMs: number } = {
+    counters: new Map(),
+    takenMs: 0,
+  };
   return async () => {
-    const cur = await readRaw();
-    const nowMs = Date.now();
-    const winSec = prevMs > 0 ? (nowMs - prevMs) / 1000 : 0;
-    const out = computeNetThroughput(prev, cur, winSec);
-    prev = cur;
-    prevMs = nowMs;
+    const counters = await readRaw();
+    const takenMs = Date.now();
+    const winSec = prev.takenMs > 0 ? (takenMs - prev.takenMs) / 1000 : 0;
+    const out = computeNetThroughput(prev.counters, counters, winSec);
+    prev = { counters, takenMs };
     return out;
   };
 }

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -32,6 +32,8 @@ import {
   type CpuCore,
   DEFAULT_CONNECTION,
   DEFAULT_SYSTEM,
+  type IfaceName,
+  type NetInterface,
   type Pid,
   type Process,
   type SystemInfo,
@@ -39,7 +41,14 @@ import {
 import { STATE } from "./connectionColors";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";
-import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
+import {
+  averageCoreUsage,
+  formatBytes,
+  formatThroughput,
+  formatUptime,
+  memGb,
+  memPct,
+} from "./metrics";
 import { coreUsageColor, processPctColor, usageBarColor } from "./usageColors";
 import { TabStrip } from "./TabStrip";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
@@ -358,6 +367,16 @@ function HostView(props: { host: string }) {
     [...cores.keys()].sort((a, b) => a - b),
   );
 
+  const nics = app.collections.networkInterfaces.use({
+    onError: (err) =>
+      console.error("networkInterfaces subscription failed", err),
+  });
+  // Stable, name-sorted identity array so <For> reuses NetCell DOM across
+  // ticks instead of churning rows (same reasoning as coreIds / visiblePids).
+  const ifaceNames = createMemo<IfaceName[]>(() =>
+    [...nics.keys()].sort((a, b) => a.localeCompare(b)),
+  );
+
   // `<For>` keys by reference identity (=== on array elements). Primitive
   // PIDs make a memo that returns the SAME numbers ([…1234, 1235…]) reuse
   // every existing row DOM — Solid only mounts new PIDs and unmounts gone
@@ -412,6 +431,10 @@ function HostView(props: { host: string }) {
         fallback={<ConnectingOverlay state={currentConnection().state} />}
       >
         <CpuStrip coreIds={coreIds()} getCore={(id) => cores.byKey(id)?.()} />
+        <NetStrip
+          ifaceNames={ifaceNames()}
+          getNic={(name) => nics.byKey(name)?.()}
+        />
         <FilterBar
           filter={filter()}
           onFilter={setFilter}
@@ -725,6 +748,59 @@ function CpuCoreCell(props: { id: CoreId; get: () => CpuCore | undefined }) {
       </div>
       <span class="w-10 shrink-0 text-right tabular-nums text-gray-700 dark:text-gray-300">
         {pct().toFixed(0)}%
+      </span>
+    </div>
+  );
+}
+
+// Per-NIC network I/O strip — the throughput counterpart to CpuStrip.
+// Mounts once per interface; each NetCell tracks only its own rx/tx
+// fields, so a busy NIC's rate updates without re-rendering its siblings.
+function NetStrip(props: {
+  ifaceNames: readonly IfaceName[];
+  getNic: (name: IfaceName) => NetInterface | undefined;
+}) {
+  return (
+    <Show when={props.ifaceNames.length > 0}>
+      <div class="border-b border-gray-200 px-4 py-2 dark:border-gray-800">
+        <div class="mb-1 text-xs uppercase tracking-wide text-gray-500">
+          network ({props.ifaceNames.length})
+        </div>
+        <div class="grid grid-cols-1 gap-x-4 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
+          <For each={props.ifaceNames}>
+            {(name) => <NetCell name={name} get={() => props.getNic(name)} />}
+          </For>
+        </div>
+      </div>
+    </Show>
+  );
+}
+
+function NetCell(props: {
+  name: IfaceName;
+  get: () => NetInterface | undefined;
+}) {
+  const nic = createMemo(() => props.get());
+  const rxRate = () => nic()?.rxRate ?? 0;
+  const txRate = () => nic()?.txRate ?? 0;
+  const rxTotal = () => nic()?.rxBytes ?? 0;
+  const txTotal = () => nic()?.txBytes ?? 0;
+  return (
+    <div class="flex items-center gap-2 text-xs">
+      <span class="w-20 shrink-0 truncate text-gray-500" title={props.name}>
+        {props.name}
+      </span>
+      <span
+        class="tabular-nums text-emerald-600 dark:text-emerald-400"
+        title={`${formatBytes(rxTotal())} received total`}
+      >
+        ↓ {formatThroughput(rxRate())}
+      </span>
+      <span
+        class="tabular-nums text-indigo-600 dark:text-indigo-400"
+        title={`${formatBytes(txTotal())} transmitted total`}
+      >
+        ↑ {formatThroughput(txRate())}
       </span>
     </div>
   );

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -799,8 +799,6 @@ function NetCell(props: {
   const nic = createMemo(() => props.get());
   const rxRate = () => nic()?.rxRate ?? 0;
   const txRate = () => nic()?.txRate ?? 0;
-  const rxTotal = () => nic()?.rxBytes ?? 0;
-  const txTotal = () => nic()?.txBytes ?? 0;
   return (
     <div class="flex items-center gap-2 text-xs">
       <span class="w-20 shrink-0 truncate text-gray-500" title={props.name}>
@@ -808,13 +806,13 @@ function NetCell(props: {
       </span>
       <span
         class="tabular-nums text-emerald-600 dark:text-emerald-400"
-        title={`${formatBytes(rxTotal())} received total`}
+        title={`${formatBytes(nic()?.rxBytes ?? 0)} received total`}
       >
         ↓ {formatThroughput(rxRate())}
       </span>
       <span
         class="tabular-nums text-indigo-600 dark:text-indigo-400"
-        title={`${formatBytes(txTotal())} transmitted total`}
+        title={`${formatBytes(nic()?.txBytes ?? 0)} transmitted total`}
       >
         ↑ {formatThroughput(txRate())}
       </span>

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -21,6 +21,7 @@ import {
   createMemo,
   createSignal,
   For,
+  type JSX,
   on,
   onCleanup,
   Show,
@@ -714,23 +715,43 @@ function SortableTh(props: {
   );
 }
 
+// Shared chrome for the per-key metric strips (CPU cores, NICs): the
+// hide-when-empty guard, the bordered section, the uppercase label+count
+// header, and the responsive grid that <For>s over a stable key array. The
+// cells differ per metric, so the caller supplies both the items and the
+// per-item renderer; only the grid columns vary between strips.
+function MetricStrip<T>(props: {
+  label: string;
+  items: readonly T[];
+  gridClass: string;
+  children: (item: T) => JSX.Element;
+}) {
+  return (
+    <Show when={props.items.length > 0}>
+      <div class="border-b border-gray-200 px-4 py-2 dark:border-gray-800">
+        <div class="mb-1 text-xs uppercase tracking-wide text-gray-500">
+          {props.label} ({props.items.length})
+        </div>
+        <div class={`grid ${props.gridClass}`}>
+          <For each={props.items}>{(item) => props.children(item)}</For>
+        </div>
+      </div>
+    </Show>
+  );
+}
+
 function CpuStrip(props: {
   coreIds: readonly CoreId[];
   getCore: (id: CoreId) => CpuCore | undefined;
 }) {
   return (
-    <Show when={props.coreIds.length > 0}>
-      <div class="border-b border-gray-200 px-4 py-2 dark:border-gray-800">
-        <div class="mb-1 text-xs uppercase tracking-wide text-gray-500">
-          CPU cores ({props.coreIds.length})
-        </div>
-        <div class="grid grid-cols-4 gap-2 md:grid-cols-8">
-          <For each={props.coreIds}>
-            {(id) => <CpuCoreCell id={id} get={() => props.getCore(id)} />}
-          </For>
-        </div>
-      </div>
-    </Show>
+    <MetricStrip
+      label="CPU cores"
+      items={props.coreIds}
+      gridClass="grid-cols-4 gap-2 md:grid-cols-8"
+    >
+      {(id) => <CpuCoreCell id={id} get={() => props.getCore(id)} />}
+    </MetricStrip>
   );
 }
 
@@ -761,18 +782,13 @@ function NetStrip(props: {
   getNic: (name: IfaceName) => NetInterface | undefined;
 }) {
   return (
-    <Show when={props.ifaceNames.length > 0}>
-      <div class="border-b border-gray-200 px-4 py-2 dark:border-gray-800">
-        <div class="mb-1 text-xs uppercase tracking-wide text-gray-500">
-          network ({props.ifaceNames.length})
-        </div>
-        <div class="grid grid-cols-1 gap-x-4 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
-          <For each={props.ifaceNames}>
-            {(name) => <NetCell name={name} get={() => props.getNic(name)} />}
-          </For>
-        </div>
-      </div>
-    </Show>
+    <MetricStrip
+      label="network"
+      items={props.ifaceNames}
+      gridClass="grid-cols-1 gap-x-4 gap-y-1 sm:grid-cols-2 lg:grid-cols-3"
+    >
+      {(name) => <NetCell name={name} get={() => props.getNic(name)} />}
+    </MetricStrip>
   );
 }
 

--- a/packages/app/src/client/metrics.test.ts
+++ b/packages/app/src/client/metrics.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import type { SystemInfo } from "../common/surface";
-import { averageCoreUsage, formatUptime, memGb, memPct } from "./metrics";
+import {
+  averageCoreUsage,
+  formatBytes,
+  formatThroughput,
+  formatUptime,
+  memGb,
+  memPct,
+} from "./metrics";
 
 function sys(over: Partial<SystemInfo> = {}): SystemInfo {
   return {
@@ -45,6 +52,26 @@ describe("formatUptime", () => {
 
   it("shows minutes under an hour", () => {
     expect(formatUptime(42 * 60 + 30)).toBe("42m");
+  });
+});
+
+describe("formatBytes", () => {
+  it("shows whole bytes below a kilobyte", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(812)).toBe("812 B");
+  });
+
+  it("scales through decimal units with one decimal", () => {
+    expect(formatBytes(1500)).toBe("1.5 KB");
+    expect(formatBytes(1_200_000)).toBe("1.2 MB");
+    expect(formatBytes(3_400_000_000)).toBe("3.4 GB");
+  });
+});
+
+describe("formatThroughput", () => {
+  it("appends a per-second suffix to the byte size", () => {
+    expect(formatThroughput(0)).toBe("0 B/s");
+    expect(formatThroughput(1_200_000)).toBe("1.2 MB/s");
   });
 });
 

--- a/packages/app/src/client/metrics.test.ts
+++ b/packages/app/src/client/metrics.test.ts
@@ -66,6 +66,11 @@ describe("formatBytes", () => {
     expect(formatBytes(1_200_000)).toBe("1.2 MB");
     expect(formatBytes(3_400_000_000)).toBe("3.4 GB");
   });
+
+  it("promotes to the next unit when rounding hits the boundary", () => {
+    // 999_999 → 999.999 KB; .toFixed(1) would render "1000.0 KB".
+    expect(formatBytes(999_999)).toBe("1.0 MB");
+  });
 });
 
 describe("formatThroughput", () => {

--- a/packages/app/src/client/metrics.ts
+++ b/packages/app/src/client/metrics.ts
@@ -51,6 +51,13 @@ export function formatBytes(bytes: number): string {
     value /= 1000;
     unit++;
   }
+  // Rounding to one decimal can push the value back up to 1000 (e.g.
+  // 999_999 → 999.999 KB → "1000.0 KB"); promote one more unit so it reads
+  // "1.0 MB". Guard against the top unit, which has nowhere to promote to.
+  if (unit < BYTE_UNITS.length - 1 && Number(value.toFixed(1)) >= 1000) {
+    value /= 1000;
+    unit++;
+  }
   return `${value.toFixed(1)} ${BYTE_UNITS[unit]}`;
 }
 

--- a/packages/app/src/client/metrics.ts
+++ b/packages/app/src/client/metrics.ts
@@ -36,6 +36,29 @@ export function formatUptime(uptimeSec: number): string {
   return `${m}m`;
 }
 
+// Decimal (1000-based) units, matching the GB convention `memGb` uses —
+// kept consistent so memory and network sizes read the same way.
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+
+/** Human-friendly byte size: "0 B", "812 B", "1.2 MB", "3.4 GB". Whole
+ *  bytes below 1 KB, one decimal above. Decimal units (÷1000), not binary,
+ *  to match `memGb`. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1000) return `${Math.round(bytes)} B`;
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1000 && unit < BYTE_UNITS.length - 1) {
+    value /= 1000;
+    unit++;
+  }
+  return `${value.toFixed(1)} ${BYTE_UNITS[unit]}`;
+}
+
+/** Throughput rendered as a per-second byte rate, e.g. "1.2 MB/s". */
+export function formatThroughput(bytesPerSec: number): string {
+  return `${formatBytes(bytesPerSec)}/s`;
+}
+
 /** Mean busy-percentage across the supplied per-core usages — the single
  *  "host CPU%" number the fleet card shows in place of the full per-core
  *  strip. Zero for a host with no reported cores (e.g. not yet

--- a/packages/app/src/common/surface.ts
+++ b/packages/app/src/common/surface.ts
@@ -34,6 +34,25 @@ const CpuCoreSchema = z.object({
   speedMHz: z.number(),
   model: z.string(),
 });
+
+/** Per-network-interface I/O. Keyed by NIC name (`eth0`, `en0`, …) in the
+ *  `networkInterfaces` collection. Both a level (cumulative bytes since
+ *  boot) and a rate (bytes/sec over the last poll window) — throughput is
+ *  the headline number; the cumulative totals are the "how much has this
+ *  link carried" context. Loopback is filtered out at the agent: it's
+ *  intra-host traffic, not network I/O, and would otherwise dominate the
+ *  list with constant noise. */
+const NetInterfaceSchema = z.object({
+  /** Cumulative bytes received since boot. */
+  rxBytes: z.number(),
+  /** Cumulative bytes transmitted since boot. */
+  txBytes: z.number(),
+  /** Receive throughput in bytes/sec over the last poll window. 0 on the
+   *  first tick (no previous counters to delta against yet). */
+  rxRate: z.number(),
+  /** Transmit throughput in bytes/sec over the last poll window. */
+  txRate: z.number(),
+});
 const SystemSchema = z.object({
   /** 1-minute, 5-minute, 15-minute load averages. */
   loadAvg: z.tuple([z.number(), z.number(), z.number()]),
@@ -130,6 +149,13 @@ export const surface = defineSurface({
       keySchema: z.number().int().nonnegative(),
       schema: CpuCoreSchema,
     },
+    /** Per-NIC network I/O — small-N keyed by interface name, the same
+     *  `Collection<K,T>` shape as `cpuCores`. Each interface is
+     *  independently observable; the UI renders one rx/tx row per NIC. */
+    networkInterfaces: {
+      keySchema: z.string(),
+      schema: NetInterfaceSchema,
+    },
   },
   streams: {
     processesSnapshot: {
@@ -156,6 +182,8 @@ export type Pid = SF["collections"]["processes"]["Key"];
 export type Process = SF["collections"]["processes"]["Value"];
 export type CoreId = SF["collections"]["cpuCores"]["Key"];
 export type CpuCore = SF["collections"]["cpuCores"]["Value"];
+export type IfaceName = SF["collections"]["networkInterfaces"]["Key"];
+export type NetInterface = SF["collections"]["networkInterfaces"]["Value"];
 export type SystemInfo = SF["cells"]["system"]["Value"];
 export type ConnectionInfo = SF["cells"]["connection"]["Value"];
 export type ConnectionState = ConnectionInfo["state"];

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -151,6 +151,14 @@ export function buildRouter(opts: BuildRouterOptions) {
     },
   });
 
+  // Compile-time guard for the least-privilege narrowing: the real
+  // fragment must satisfy the pumps' write-only view. Stated here (not only
+  // implied by the bridgeAgentToParent call) so a refactor of that call
+  // can't quietly drop the check — a surface collection rename surfaces as
+  // an error on this line.
+  const _pumpCtx: FragmentCtx = fragment;
+  void _pumpCtx;
+
   // ── Mirror session connection state → parent's `connection` cell ──
   session.onState((s) => {
     fragment.ctx.cells.connection.set({ state: s.connection });
@@ -177,11 +185,14 @@ export function buildRouter(opts: BuildRouterOptions) {
   return { router, session };
 }
 
-/** The subset of `implementSurface(...).ctx` the bridge pumps actually
- *  call. Keep this in sync with the surface's cells/collections —
- *  every cell/collection actually written from a pump must appear
- *  here, otherwise the pumps compile against a narrower-than-real
- *  type and a typo / missing-write goes undetected. */
+/** The write-side methods the bridge pumps are allowed to touch — a
+ *  deliberate least-privilege narrowing of `implementSurface(...).ctx`,
+ *  not the full ctx. Pumps only ever mirror remote data inward, so they
+ *  get `set` / `upsert` / `remove`; `readAll` and the underlying stores
+ *  stay out of reach. This is a boundary, not a maintenance chore: the
+ *  `_pumpCtx` guard below assigns the real fragment to this type, so a
+ *  collection renamed or retyped on the surface becomes a compile error
+ *  here rather than silent drift. */
 type FragmentCtx = {
   ctx: {
     cells: {

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -38,6 +38,8 @@ import {
   type CpuCore,
   DEFAULT_CONNECTION,
   DEFAULT_SYSTEM,
+  type IfaceName,
+  type NetInterface,
   type Pid,
   type Process,
   type ProcessesSnapshotMsg,
@@ -64,6 +66,7 @@ export function buildRouter(opts: BuildRouterOptions) {
   });
   const processCache = new Map<Pid, Process>();
   const coreCache = new Map<CoreId, CpuCore>();
+  const netCache = new Map<IfaceName, NetInterface>();
   // Local snapshot bus — every msg the parent receives from the
   // agent's snapshot stream is also re-published here so the parent's
   // own `processesSnapshot` source (consumed by the browser) can
@@ -105,6 +108,15 @@ export function buildRouter(opts: BuildRouterOptions) {
         },
         remove: (key) => {
           coreCache.delete(key);
+        },
+      },
+      networkInterfaces: {
+        readAll: () => netCache,
+        upsert: (key, value) => {
+          netCache.set(key, value);
+        },
+        remove: (key) => {
+          netCache.delete(key);
         },
       },
     },
@@ -185,6 +197,10 @@ type FragmentCtx = {
         upsert: (k: CoreId, v: CpuCore) => void;
         remove: (k: CoreId) => void;
       };
+      networkInterfaces: {
+        upsert: (k: IfaceName, v: NetInterface) => void;
+        remove: (k: IfaceName) => void;
+      };
     };
   };
 };
@@ -226,6 +242,7 @@ async function bridgeAgentToParent(
       pumpSystemCell(client, session, fragment),
       pumpProcessesSnapshot(client, fragment, processCache, browserSnapshotBus),
       pumpCpuCores(client, fragment),
+      pumpNetworkInterfaces(client, fragment),
     ]);
     log("bridge: pumps ended (link likely died) — awaiting next client");
   }
@@ -251,6 +268,28 @@ function pumpCpuCores(
     onUpsert: (key, value) =>
       fragment.ctx.collections.cpuCores.upsert(key, value),
     onRemove: (key) => fragment.ctx.collections.cpuCores.remove(key),
+  });
+}
+
+/** Mirror the agent's `networkInterfaces` collection — same
+ *  `mirrorRemoteCollection` shape as cpuCores, keyed by NIC name. */
+function pumpNetworkInterfaces(
+  client: DrishtiAgent,
+  fragment: FragmentCtx,
+): Promise<void> {
+  return mirrorRemoteCollection<IfaceName, NetInterface>({
+    label: "networkInterfaces",
+    log,
+    keys: client.surface.networkInterfaces.keys({}) as Promise<
+      AsyncIterable<readonly IfaceName[]>
+    >,
+    get: (key, signal) =>
+      client.surface.networkInterfaces.get({ key }, { signal }) as Promise<
+        AsyncIterable<NetInterface>
+      >,
+    onUpsert: (key, value) =>
+      fragment.ctx.collections.networkInterfaces.upsert(key, value),
+    onRemove: (key) => fragment.ctx.collections.networkInterfaces.remove(key),
   });
 }
 


### PR DESCRIPTION
**drishti showed CPU, memory, load, command, and cwd — but zero network.** This adds a live per-NIC view: receive/transmit throughput (bytes/sec) plus cumulative totals, for every interface, flowing through the same reactive transport as the rest of the surface. It closes the most-validated gap in the feature plan (rtop, drishti's closest agentless peer, defines its value around exactly this).

### How it fits together

A new `networkInterfaces` collection — keyed by NIC name — rides the existing agent → parent → browser pipeline, modeled cell-for-cell on the `cpuCores` collection that was already there:

```
/proc/net/dev (linux) ─┐
netstat -ib  (darwin) ─┼─▶ ProcReader.readNetwork ─▶ networkInterfaces ─▶ parent mirror ─▶ NetStrip
(unknown OS → empty)  ─┘   (rate-from-delta closure)   Collection<name,…>   pumpNetwork…     (one rx/tx row per NIC)
```

Throughput is a *rate*, so the agent retains the previous tick's cumulative counters and derives bytes/sec from the delta — the same shape the per-core CPU reader uses. The parsing and the rate math are pure, exported functions (`parseProcNetDev`, `parseNetstatIb`, `computeNetThroughput`), so the part that's wrong at runtime if a formula slips is unit-tested directly.

### Notable decisions

- **Loopback is filtered at the reader, not the parser.** The parsers stay faithful to their source (a test asserts `lo` is parsed); "what the app wants to show" is a separate policy applied after. `lo`/`lo0` carry intra-host traffic, not network I/O, and would otherwise dominate the list.
- **Counters that run backwards clamp to 0** — a NIC reset or hot-swap reports no throughput rather than a negative or absurd spike.
- **`netstat -ib` columns are counted from the right**, because the optional MAC-address column shifts absolute field positions; the byte counters are stable relative to the end of the line.

### Refinements during structural review

The Hickey/Lowy + code-police passes landed five follow-up commits. The load-bearing one was a real bug:

| What was off | Fix |
| --- | --- |
| `formatBytes(999_999)` rendered `"1000.0 KB"` — the unit was chosen *before* rounding to one decimal | Promote one more unit when rounding hits the boundary; added a regression test |
| `CpuStrip`/`NetStrip` duplicated byte-identical strip chrome | Extracted a generic `MetricStrip<T>`; both are now thin wrappers |
| `createNetReader` held the previous counters and their timestamp as two separate `let`s | Collapsed into one record so the per-tick swap is atomic |
| `FragmentCtx` was documented as a "keep in sync" chore | Reframed as a deliberate least-privilege narrowing with a compile-time drift guard |

### Try it locally

```sh
nix run github:srid/drishti/feat/network-io
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._