### PR TITLE
Show absolute process memory; fix frozen header mem readout

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Per-host primitives:
 | Primitive | Path | Purpose |
 |---|---|---|
 | **Cell** | `system` | Load averages, memory, uptime, OS, hostname. |
-| **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, memPct, rssBytes, command, cwd }`. The table shows absolute resident memory (`rssBytes`, auto-scaled to MB/GB) rather than `memPct`. Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
+| **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, rssBytes, command, cwd }`. The table shows absolute resident memory (`rssBytes`, auto-scaled to MB/GB). Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
 | **Stream** | `processesSnapshot` | Bulk-snapshot variant for ~600-PID htop refresh in one frame. |
 | **Collection** | `cpuCores` | Per-core CPU usage (`Collection<K,T>` showcase). |
 | **Collection** | `networkInterfaces` | Per-NIC network I/O, keyed by interface name — `{ rxBytes, txBytes, rxRate, txRate }` (cumulative bytes since boot + bytes/sec throughput). `/proc/net/dev` on linux, `netstat -ib` on darwin; loopback filtered out. |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Per-host primitives:
 | Primitive | Path | Purpose |
 |---|---|---|
 | **Cell** | `system` | Load averages, memory, uptime, OS, hostname. |
-| **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, memPct, command, cwd }`. Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
+| **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, memPct, rssBytes, command, cwd }`. The table shows absolute resident memory (`rssBytes`, auto-scaled to MB/GB) rather than `memPct`. Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
 | **Stream** | `processesSnapshot` | Bulk-snapshot variant for ~600-PID htop refresh in one frame. |
 | **Collection** | `cpuCores` | Per-core CPU usage (`Collection<K,T>` showcase). |
 | **Collection** | `networkInterfaces` | Per-NIC network I/O, keyed by interface name — `{ rxBytes, txBytes, rxRate, txRate }` (cumulative bytes since boot + bytes/sec throughput). `/proc/net/dev` on linux, `netstat -ib` on darwin; loopback filtered out. |

--- a/packages/app/src/agent/main.ts
+++ b/packages/app/src/agent/main.ts
@@ -194,7 +194,6 @@ async function main(): Promise<void> {
         if (
           prev === undefined ||
           prev.cpuPct !== value.cpuPct ||
-          prev.memPct !== value.memPct ||
           prev.rssBytes !== value.rssBytes ||
           prev.command !== value.command ||
           prev.cwd !== value.cwd

--- a/packages/app/src/agent/main.ts
+++ b/packages/app/src/agent/main.ts
@@ -195,6 +195,7 @@ async function main(): Promise<void> {
           prev === undefined ||
           prev.cpuPct !== value.cpuPct ||
           prev.memPct !== value.memPct ||
+          prev.rssBytes !== value.rssBytes ||
           prev.command !== value.command ||
           prev.cwd !== value.cwd
         ) {

--- a/packages/app/src/agent/proc.test.ts
+++ b/packages/app/src/agent/proc.test.ts
@@ -61,16 +61,15 @@ describe("parseNetstatIb", () => {
 });
 
 describe("parsePsLine", () => {
-  // `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` — rss is in KB on macOS,
+  // `ps -axo pid=,user=,pcpu=,rss=,comm=` — rss is in KB on macOS,
   // comm is last/greedy (may contain spaces).
   it("parses rss (KB) into absolute resident bytes", () => {
-    const parsed = parsePsLine("  501 alice 12.5  3.2 348160 /usr/bin/foo");
+    const parsed = parsePsLine("  501 alice 12.5 348160 /usr/bin/foo");
     expect(parsed).not.toBeNull();
     const [pid, proc] = parsed!;
     expect(pid).toBe(501);
     expect(proc.user).toBe("alice");
     expect(proc.cpuPct).toBe(12.5);
-    expect(proc.memPct).toBe(3.2);
     // 348160 KB × 1024 = absolute bytes (≈ 356 MB).
     expect(proc.rssBytes).toBe(348160 * 1024);
     expect(proc.command).toBe("/usr/bin/foo");
@@ -78,7 +77,7 @@ describe("parsePsLine", () => {
   });
 
   it("keeps a command with embedded spaces intact (comm is the trailing field)", () => {
-    const [, proc] = parsePsLine("99 root 0.0 0.1 2048 com.apple.Some Helper")!;
+    const [, proc] = parsePsLine("99 root 0.0 2048 com.apple.Some Helper")!;
     expect(proc.command).toBe("com.apple.Some Helper");
     expect(proc.rssBytes).toBe(2048 * 1024);
   });

--- a/packages/app/src/agent/proc.test.ts
+++ b/packages/app/src/agent/proc.test.ts
@@ -4,6 +4,7 @@ import {
   type NetCounters,
   parseNetstatIb,
   parseProcNetDev,
+  parsePsLine,
 } from "./proc";
 
 describe("parseProcNetDev", () => {
@@ -56,6 +57,36 @@ describe("parseNetstatIb", () => {
   it("ignores non-<Link#> address-family rows (no double counting)", () => {
     const m = parseNetstatIb(sample);
     expect([...m.keys()].sort()).toEqual(["en0", "lo0"]);
+  });
+});
+
+describe("parsePsLine", () => {
+  // `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` — rss is in KB on macOS,
+  // comm is last/greedy (may contain spaces).
+  it("parses rss (KB) into absolute resident bytes", () => {
+    const parsed = parsePsLine("  501 alice 12.5  3.2 348160 /usr/bin/foo");
+    expect(parsed).not.toBeNull();
+    const [pid, proc] = parsed!;
+    expect(pid).toBe(501);
+    expect(proc.user).toBe("alice");
+    expect(proc.cpuPct).toBe(12.5);
+    expect(proc.memPct).toBe(3.2);
+    // 348160 KB × 1024 = absolute bytes (≈ 356 MB).
+    expect(proc.rssBytes).toBe(348160 * 1024);
+    expect(proc.command).toBe("/usr/bin/foo");
+    expect(proc.cwd).toBe("");
+  });
+
+  it("keeps a command with embedded spaces intact (comm is the trailing field)", () => {
+    const [, proc] = parsePsLine("99 root 0.0 0.1 2048 com.apple.Some Helper")!;
+    expect(proc.command).toBe("com.apple.Some Helper");
+    expect(proc.rssBytes).toBe(2048 * 1024);
+  });
+
+  it("returns null for blank or malformed lines", () => {
+    expect(parsePsLine("")).toBeNull();
+    expect(parsePsLine("   ")).toBeNull();
+    expect(parsePsLine("not a ps line")).toBeNull();
   });
 });
 

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -4,7 +4,7 @@
  *   - `linux`: parse `/proc/<pid>/{stat,status,cmdline}` + `/proc/meminfo`
  *     + `/proc/loadavg`. Pure file reads, universally readable by the
  *     running user.
- *   - `darwin`: shell out to `ps -axo pid=,user=,pcpu=,pmem=,comm=` and
+ *   - `darwin`: shell out to `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` and
  *     `sysctl -n vm.loadavg hw.memsize`. The `ps` command is in every
  *     base install; sysctl reads are unprivileged.
  *
@@ -315,6 +315,7 @@ function linuxReader(): ProcReader {
           user: raw.user,
           cpuPct: round2(cpuPct),
           memPct: raw.memPct,
+          rssBytes: raw.rssBytes,
           command: raw.command,
           cwd: raw.cwd,
         });
@@ -350,6 +351,8 @@ interface LinuxProcRaw {
    *  tombstone we use to detect PID recycling between polls. */
   startTime: number;
   memPct: number;
+  /** Resident set size in bytes (VmRSS × 1024). */
+  rssBytes: number;
   command: string;
   cwd: string;
 }
@@ -393,6 +396,7 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
       ticks: utime + stime,
       startTime,
       memPct: round2(memPct),
+      rssBytes: rssKb * 1024,
       command: truncate(command, PROC_STRING_MAX),
       cwd: truncate(cwdResult, PROC_STRING_MAX),
     };
@@ -407,8 +411,34 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
 
 // ── darwin: ps + sysctl reader ──────────────────────────────────────────
 
-// Compiled once — matches `ps -axo pid=,user=,pcpu=,pmem=,comm=` output lines.
-const PS_LINE_RE = /^(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(.*)$/;
+// Compiled once — matches `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` lines.
+// `comm` is greedy/last (it can contain spaces), so it stays the trailing
+// `(.*)`; the integer `rss` (KB) sits just before it.
+const PS_LINE_RE = /^(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(.*)$/;
+
+/** Parse one `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` line into a
+ *  `Process`. `rss` is in KB on macOS, so ×1024 for `rssBytes`. Returns
+ *  null for lines that don't match (blank/garbage) so the caller skips
+ *  them. Pure — no clock or platform state — to stay unit-testable. */
+export function parsePsLine(line: string): [Pid, Process] | null {
+  const m = line.trim().match(PS_LINE_RE);
+  if (!m) return null;
+  const [, pidStr, user, cpu, mem, rssKb, command] = m;
+  if (!pidStr || !user || !cpu || !mem || !rssKb || !command) return null;
+  return [
+    Number(pidStr),
+    {
+      user,
+      cpuPct: Number(cpu),
+      memPct: Number(mem),
+      rssBytes: Number(rssKb) * 1024,
+      command: truncate(command, PROC_STRING_MAX),
+      // darwin has no cheap per-pid cwd source (`lsof -p` per pid is a
+      // fork per row); leave blank — the UI hides it when empty.
+      cwd: "",
+    },
+  ];
+}
 
 function darwinReader(): ProcReader {
   const readCpuCores = createCpuCoresReader();
@@ -436,24 +466,13 @@ function darwinReader(): ProcReader {
       };
     },
     readProcesses: async () => {
-      const { stdout } = await exec("ps -axo pid=,user=,pcpu=,pmem=,comm=");
+      const { stdout } = await exec(
+        "ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=",
+      );
       const out = new Map<Pid, Process>();
       for (const line of stdout.split("\n")) {
-        const trimmed = line.trim();
-        if (trimmed.length === 0) continue;
-        const m = trimmed.match(PS_LINE_RE);
-        if (!m) continue;
-        const [, pidStr, user, cpu, mem, command] = m;
-        if (!pidStr || !user || !cpu || !mem || !command) continue;
-        out.set(Number(pidStr), {
-          user,
-          cpuPct: Number(cpu),
-          memPct: Number(mem),
-          command: truncate(command, PROC_STRING_MAX),
-          // darwin has no cheap per-pid cwd source (`lsof -p` per pid is
-          // a fork per row); leave blank — the UI hides it when empty.
-          cwd: "",
-        });
+        const parsed = parsePsLine(line);
+        if (parsed) out.set(parsed[0], parsed[1]);
       }
       return out;
     },
@@ -489,6 +508,7 @@ function stubReader(): ProcReader {
         user: process.env.USER ?? "unknown",
         cpuPct: 0,
         memPct: 0,
+        rssBytes: 0,
         command: `${process.execPath} ${process.argv.slice(1).join(" ")}`,
         cwd: process.cwd(),
       });

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -4,7 +4,7 @@
  *   - `linux`: parse `/proc/<pid>/{stat,status,cmdline}` + `/proc/meminfo`
  *     + `/proc/loadavg`. Pure file reads, universally readable by the
  *     running user.
- *   - `darwin`: shell out to `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` and
+ *   - `darwin`: shell out to `ps -axo pid=,user=,pcpu=,rss=,comm=` and
  *     `sysctl -n vm.loadavg hw.memsize`. The `ps` command is in every
  *     base install; sysctl reads are unprivileged.
  *
@@ -314,7 +314,6 @@ function linuxReader(): ProcReader {
         out.set(pid, {
           user: raw.user,
           cpuPct: round2(cpuPct),
-          memPct: raw.memPct,
           rssBytes: raw.rssBytes,
           command: raw.command,
           cwd: raw.cwd,
@@ -350,7 +349,6 @@ interface LinuxProcRaw {
   /** /proc/<pid>/stat field 22 — ticks-since-boot at fork; the
    *  tombstone we use to detect PID recycling between polls. */
   startTime: number;
-  memPct: number;
   /** Resident set size in bytes (VmRSS × 1024). */
   rssBytes: number;
   command: string;
@@ -383,8 +381,6 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
     const userMatch = statusRaw.match(/^Uid:\s+(\d+)/m);
     const uid =
       userMatch && userMatch[1] !== undefined ? Number(userMatch[1]) : 0;
-    const total = totalmem();
-    const memPct = total > 0 ? (100 * rssKb * 1024) / total : 0;
     const command =
       cmdlineRaw.length > 0
         ? cmdlineRaw.replace(/\0/g, " ").trim()
@@ -395,7 +391,6 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
       user: uid === 0 ? "root" : String(uid),
       ticks: utime + stime,
       startTime,
-      memPct: round2(memPct),
       rssBytes: rssKb * 1024,
       command: truncate(command, PROC_STRING_MAX),
       cwd: truncate(cwdResult, PROC_STRING_MAX),
@@ -411,26 +406,25 @@ async function readProcLinuxRaw(pid: number): Promise<LinuxProcRaw | null> {
 
 // ── darwin: ps + sysctl reader ──────────────────────────────────────────
 
-// Compiled once — matches `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` lines.
+// Compiled once — matches `ps -axo pid=,user=,pcpu=,rss=,comm=` lines.
 // `comm` is greedy/last (it can contain spaces), so it stays the trailing
 // `(.*)`; the integer `rss` (KB) sits just before it.
-const PS_LINE_RE = /^(\d+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(.*)$/;
+const PS_LINE_RE = /^(\d+)\s+(\S+)\s+([\d.]+)\s+(\d+)\s+(.*)$/;
 
-/** Parse one `ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=` line into a
+/** Parse one `ps -axo pid=,user=,pcpu=,rss=,comm=` line into a
  *  `Process`. `rss` is in KB on macOS, so ×1024 for `rssBytes`. Returns
  *  null for lines that don't match (blank/garbage) so the caller skips
  *  them. Pure — no clock or platform state — to stay unit-testable. */
 export function parsePsLine(line: string): [Pid, Process] | null {
   const m = line.trim().match(PS_LINE_RE);
   if (!m) return null;
-  const [, pidStr, user, cpu, mem, rssKb, command] = m;
-  if (!pidStr || !user || !cpu || !mem || !rssKb || !command) return null;
+  const [, pidStr, user, cpu, rssKb, command] = m;
+  if (!pidStr || !user || !cpu || !rssKb || !command) return null;
   return [
     Number(pidStr),
     {
       user,
       cpuPct: Number(cpu),
-      memPct: Number(mem),
       rssBytes: Number(rssKb) * 1024,
       command: truncate(command, PROC_STRING_MAX),
       // darwin has no cheap per-pid cwd source (`lsof -p` per pid is a
@@ -466,9 +460,7 @@ function darwinReader(): ProcReader {
       };
     },
     readProcesses: async () => {
-      const { stdout } = await exec(
-        "ps -axo pid=,user=,pcpu=,pmem=,rss=,comm=",
-      );
+      const { stdout } = await exec("ps -axo pid=,user=,pcpu=,rss=,comm=");
       const out = new Map<Pid, Process>();
       for (const line of stdout.split("\n")) {
         const parsed = parsePsLine(line);
@@ -507,7 +499,6 @@ function stubReader(): ProcReader {
       out.set(process.pid, {
         user: process.env.USER ?? "unknown",
         cpuPct: 0,
-        memPct: 0,
         rssBytes: 0,
         command: `${process.execPath} ${process.argv.slice(1).join(" ")}`,
         cwd: process.cwd(),

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -385,7 +385,7 @@ function HostView(props: { host: string }) {
   // tick allocate fresh row identities, so the whole table was torn down
   // and rebuilt per snapshot (43 k tr add/remove vs 28 text changes in
   // 6 s, observed). Field reads moved into <ProcessRow> below so per-cell
-  // reactivity updates only the changed cpuPct/memPct text nodes.
+  // reactivity updates only the changed cpuPct/rssBytes text nodes.
   const visiblePids = createMemo<Pid[]>(() => {
     const q = filter().trim().toLowerCase();
     const pids = allPids();

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -468,7 +468,7 @@ function pidComparator(
   if (key === "cpu")
     return (a, b) => procs[b]!.cpuPct - procs[a]!.cpuPct || a - b;
   if (key === "mem")
-    return (a, b) => procs[b]!.memPct - procs[a]!.memPct || a - b;
+    return (a, b) => procs[b]!.rssBytes - procs[a]!.rssBytes || a - b;
   if (key === "user")
     return (a, b) => procs[a]!.user.localeCompare(procs[b]!.user) || a - b;
   return (a, b) => a - b;
@@ -479,14 +479,15 @@ function Header(props: {
   connection: ReturnType<() => typeof DEFAULT_CONNECTION>;
   count: number;
 }) {
-  // Pure derivations cached once per render — props.system is a reactive
-  // read that re-runs this component body when it changes, so these are
-  // computed once per system tick, not once per JSX expression.
-  const pct = memPct(props.system);
-  const gb = memGb(props.system);
+  // The component body runs ONCE at mount — when props.system is still
+  // DEFAULT_SYSTEM (memUsed/memTotal 0). Derive through createMemo so these
+  // re-run on every system tick; a plain const would freeze the header's
+  // memory readout at "0.0/0.0 GB (0%)" forever. Mirrors HostCard.
+  const pct = createMemo(() => memPct(props.system));
+  const gb = createMemo(() => memGb(props.system));
   return (
     <div class="border-b border-gray-200 dark:border-gray-800">
-      <UsageBar pct={pct} />
+      <UsageBar pct={pct()} />
       <div class="flex items-center justify-between px-4 py-2">
         <div class="flex items-center gap-3">
           <span class="font-semibold">drishti</span>
@@ -521,10 +522,10 @@ function Header(props: {
           </span>
         </span>
         <span>
-          mem <span class="font-semibold">{gb.used}</span>
-          <span class="text-gray-400">/{gb.total} GB</span>
+          mem <span class="font-semibold">{gb().used}</span>
+          <span class="text-gray-400">/{gb().total} GB</span>
           <span class="ml-1 text-gray-400">
-            ({pct.toFixed(0)}%)
+            ({pct().toFixed(0)}%)
           </span>
         </span>
         <span>
@@ -615,7 +616,7 @@ function ProcessTable(props: {
               onClick={() => props.onSort("cpu")}
             />
             <SortableTh
-              label="MEM%"
+              label="MEM"
               align="right"
               active={props.sortKey === "mem"}
               onClick={() => props.onSort("mem")}
@@ -654,7 +655,7 @@ function ProcessRow(props: {
 }) {
   const proc = () => props.processes[props.pid];
   const cpu = () => proc()?.cpuPct ?? 0;
-  const mem = () => proc()?.memPct ?? 0;
+  const rssBytes = () => proc()?.rssBytes ?? 0;
   return (
     <tr class="border-b border-gray-100 hover:bg-gray-50 dark:border-gray-800/50 dark:hover:bg-gray-800/40">
       <td class="px-3 py-0.5 text-right tabular-nums">{props.pid}</td>
@@ -664,10 +665,8 @@ function ProcessRow(props: {
       >
         {cpu().toFixed(1)}
       </td>
-      <td
-        class={`px-3 py-0.5 text-right tabular-nums ${processPctColor(mem())}`}
-      >
-        {mem().toFixed(1)}
+      <td class="px-3 py-0.5 text-right tabular-nums text-gray-700 dark:text-gray-300">
+        {formatBytes(rssBytes())}
       </td>
       <td class="max-w-md truncate px-3 py-0.5 text-left text-gray-700 dark:text-gray-300">
         <span>{proc()?.command ?? ""}</span>

--- a/packages/app/src/common/surface.ts
+++ b/packages/app/src/common/surface.ts
@@ -20,6 +20,10 @@ const ProcessSchema = z.object({
   user: z.string(),
   cpuPct: z.number(),
   memPct: z.number(),
+  /** Resident set size in bytes — the absolute physical memory the
+   *  process occupies. The headline memory number the UI shows (more
+   *  actionable than memPct); memPct stays for sorting/ratio context. */
+  rssBytes: z.number(),
   command: z.string(),
   /** Current working directory. Empty string when unknown — kernel
    *  threads have no cwd, other-user pids hit EACCES on `/proc/<pid>/cwd`,

--- a/packages/app/src/common/surface.ts
+++ b/packages/app/src/common/surface.ts
@@ -19,10 +19,9 @@ const PidSchema = z.number().int().nonnegative();
 const ProcessSchema = z.object({
   user: z.string(),
   cpuPct: z.number(),
-  memPct: z.number(),
   /** Resident set size in bytes — the absolute physical memory the
-   *  process occupies. The headline memory number the UI shows (more
-   *  actionable than memPct); memPct stays for sorting/ratio context. */
+   *  process occupies. The headline memory number the UI shows; a ratio
+   *  view can derive `rssBytes / system.memTotal` at the call site. */
   rssBytes: z.number(),
   command: z.string(),
   /** Current working directory. Empty string when unknown — kernel


### PR DESCRIPTION
The per-host detail header had a frozen memory readout. SolidJS runs a component body exactly once, at mount — and at that moment `system` is still `DEFAULT_SYSTEM` (`memUsed`/`memTotal` both 0). The `Header` derived `pct`/`gb` as plain consts from that initial value, so **the memory line stayed pinned at `0.0/0.0 GB (0%)` for the life of the view**, even as load, uptime, OS, and hostname updated (those are read inline in JSX, so they stayed reactive). The fleet `HostCard` already does this correctly with `createMemo`; this change mirrors it in the header and replaces the misleading comment that claimed the body re-runs on prop change.

Alongside the fix, the per-process **MEM%** column is replaced with absolute resident memory — **MEM** — auto-scaled to MB/GB (`1.2 GB`, `340 MB`) via the existing decimal `formatBytes` helper. A percent-of-total is rarely what you want when triaging a host; the absolute footprint is.

### What changed in the wire surface

The process schema's `memPct` field is **replaced** by `rssBytes` (resident set size, in bytes) — not duplicated. One domain concept, one field, consumed end-to-end:

| Layer | Before | After |
| --- | --- | --- |
| `ProcessSchema` (common) | `memPct: number` | `rssBytes: number` |
| linux reader | `100 × VmRSS·1024 / memTotal` | `VmRSS·1024` (kB → bytes) |
| darwin `ps` format | `…,pcpu=,pmem=,comm=` | `…,pcpu=,rss=,comm=` (rss is kB → bytes) |
| sort + delta diff | by `memPct` | by `rssBytes` |
| table cell | `mem.toFixed(1)` % | `formatBytes(rssBytes)` |

Keeping darwin and linux _in parity_ drove the design: both platforms now report exactly the absolute bytes the UI renders, and the dead `pmem=` column / linux percentage computation are gone rather than left to drift. The darwin parse path is extracted into a pure, exported `parsePsLine` so the format change sits behind one regex and one test.

## Testing
- `just typecheck` — clean
- `bun test packages/app` — 45 pass (3 new `parsePsLine` cases: rss→bytes, space-bearing commands, malformed lines)
- `just fmt-check` — clean

### Try it locally

```sh
nix run github:srid/drishti/mem
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._