### PR TITLE
Persist per-host view prefs and add a light/dark toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Every view has its own URL, so you can bookmark or share a link straight to a ho
 
 Use the `+ add host` button in the tab strip to add hosts at runtime; the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
 
+Your in-browser reading preferences stick across reloads via `localStorage`: the **chart window** (1m / 5m / 15m / 30m), the **process sort column**, and the **process filter** are remembered **per host**, so each tab reopens the way you left it. A **light/dark toggle** (top-right of the tab strip) overrides the OS theme and is remembered globally; until you touch it, the theme follows your system preference.
+
 Requirements:
 
 - The remote host must be `ssh`-reachable with **passwordless** auth and a working **`nix-daemon`** that **trusts your user** (`trusted-users` in `nix.conf`) — drishti provisions the agent by shipping its `.drv` to the remote with `nix copy --derivation` and realising it there.

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -25,6 +25,7 @@ import {
   on,
   onCleanup,
   Show,
+  type Signal,
 } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 import {
@@ -65,11 +66,37 @@ import {
 } from "../common/history";
 import { TabStrip } from "./TabStrip";
 import { prefKey, readPref, writePref } from "./localStorageState";
-import { applyTheme, initialTheme, otherTheme, type Theme } from "./theme";
+import {
+  applyTheme,
+  initialTheme,
+  otherTheme,
+  THEME_KEY,
+  type Theme,
+} from "./theme";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
 
 const SORT_KEYS = ["cpu", "mem", "pid", "user"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
+
+// Bind a per-host preference to a signal: seed from localStorage and mirror
+// every change back, keyed by host (`defer` skips the redundant write of the
+// just-read seed). Computing the storage key once is the point — it removes
+// the hazard of the seed-read and the write-back drifting to different keys.
+// This is the signal-is-truth / store-is-projection shape of urlState's URL
+// mirror, against a private store (localStorage) instead of the shareable
+// one (the URL). It lives here, not in the framework-free localStorageState.ts
+// (HostView is its only caller), so that module keeps its pure-I/O boundary.
+function createPersistedSignal<T extends string>(
+  pref: string,
+  host: string,
+  fallback: T,
+  accept?: (raw: string) => boolean,
+): Signal<T> {
+  const key = prefKey(pref, host);
+  const [value, setValue] = createSignal<T>(readPref(key, fallback, accept));
+  createEffect(on(value, (v) => writePref(key, v), { defer: true }));
+  return [value, setValue];
+}
 
 export default function App() {
   const admin = adminClient();
@@ -149,11 +176,23 @@ export default function App() {
   // index.html already applied; toggling flips the attribute and persists
   // the choice. `applyTheme` is the single writer of both DOM and storage.
   const [theme, setTheme] = createSignal<Theme>(initialTheme());
-  const toggleTheme = () => {
-    const next = otherTheme(theme());
-    applyTheme(next);
-    setTheme(next);
-  };
+  // The signal is the source of truth; this effect projects it to the DOM
+  // (via theme.ts, which owns the attribute/element detail) and persists
+  // the choice — the same signal-is-truth / store-is-projection shape as
+  // the per-host pref effects below. `defer` skips the redundant first
+  // write: the pre-paint bootstrap in index.html already applied the
+  // initial theme and storage already holds it.
+  createEffect(
+    on(
+      theme,
+      (t) => {
+        applyTheme(t);
+        writePref(THEME_KEY, t);
+      },
+      { defer: true },
+    ),
+  );
+  const toggleTheme = () => setTheme(otherTheme(theme()));
 
   const onAdd = async (host: string): Promise<string | null> => {
     try {
@@ -380,29 +419,17 @@ function HostView(props: { host: string }) {
   // Per-host UI preferences, persisted to localStorage and keyed by host.
   // These signals live in this keyed component, so each host restores its
   // own filter/sort/window on reload or tab switch — per-host scope falls
-  // out of where the state already lives. Each effect mirrors changes back
-  // to storage (`defer` skips the redundant write of the just-read seed),
-  // the same signal-is-truth / store-is-projection shape as App's URL
-  // mirror — just a private store (localStorage) instead of the shareable
-  // one (the URL).
-  const [filter, setFilter] = createSignal(
-    readPref(prefKey("filter", props.host), ""),
+  // out of where the state already lives.
+  const [filter, setFilter] = createPersistedSignal<string>(
+    "filter",
+    props.host,
+    "",
   );
-  createEffect(
-    on(filter, (v) => writePref(prefKey("filter", props.host), v), {
-      defer: true,
-    }),
-  );
-
-  const [sortKey, setSortKey] = createSignal<SortKey>(
-    readPref<SortKey>(prefKey("sort", props.host), "cpu", (raw) =>
-      (SORT_KEYS as readonly string[]).includes(raw),
-    ),
-  );
-  createEffect(
-    on(sortKey, (v) => writePref(prefKey("sort", props.host), v), {
-      defer: true,
-    }),
+  const [sortKey, setSortKey] = createPersistedSignal<SortKey>(
+    "sort",
+    props.host,
+    "cpu",
+    (raw) => (SORT_KEYS as readonly string[]).includes(raw),
   );
 
   const currentSystem = createMemo(() => system.value() ?? DEFAULT_SYSTEM);
@@ -473,18 +500,13 @@ function HostView(props: { host: string }) {
   // every fresh mount), then one delta per tick. `pushSample` bounds the
   // locally-accumulated deltas to the same retention as the server ring.
   const [history, setHistory] = createSignal<MetricSample[]>([]);
-  const [historyWindow, setHistoryWindow] = createSignal<HistoryWindowKey>(
-    readPref(
-      prefKey("window", props.host),
+  const [historyWindow, setHistoryWindow] =
+    createPersistedSignal<HistoryWindowKey>(
+      "window",
+      props.host,
       DEFAULT_HISTORY_WINDOW,
       isHistoryWindowKey,
-    ),
-  );
-  createEffect(
-    on(historyWindow, (v) => writePref(prefKey("window", props.host), v), {
-      defer: true,
-    }),
-  );
+    );
   const windowMs = createMemo(() => windowMsFor(historyWindow()));
 
   // Reuses `ctl` — the metricHistory and processesSnapshot streams share

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -57,15 +57,19 @@ import {
   HISTORY_RETENTION_MS,
   HISTORY_WINDOWS,
   type HistoryWindowKey,
+  isHistoryWindowKey,
   polylinePoints,
   pushSample,
   windowMsFor,
   windowSlice,
 } from "../common/history";
 import { TabStrip } from "./TabStrip";
+import { prefKey, readPref, writePref } from "./localStorageState";
+import { applyTheme, initialTheme, otherTheme, type Theme } from "./theme";
 import { adminClient, disposeHostSurface, surfaceForHost } from "./wire";
 
-type SortKey = "cpu" | "mem" | "pid" | "user";
+const SORT_KEYS = ["cpu", "mem", "pid", "user"] as const;
+type SortKey = (typeof SORT_KEYS)[number];
 
 export default function App() {
   const admin = adminClient();
@@ -140,6 +144,17 @@ export default function App() {
     return v.kind === "host" ? v.host : null;
   });
 
+  // Theme is global app chrome (like `view`), so it lives here, not per
+  // host. The signal seeds from the attribute the pre-paint bootstrap in
+  // index.html already applied; toggling flips the attribute and persists
+  // the choice. `applyTheme` is the single writer of both DOM and storage.
+  const [theme, setTheme] = createSignal<Theme>(initialTheme());
+  const toggleTheme = () => {
+    const next = otherTheme(theme());
+    applyTheme(next);
+    setTheme(next);
+  };
+
   const onAdd = async (host: string): Promise<string | null> => {
     try {
       const res = await admin.rpc.surface.hosts.add({ host });
@@ -174,6 +189,8 @@ export default function App() {
           onSelect={(h) => setView({ kind: "host", host: h })}
           onAdd={onAdd}
           onRemove={onRemove}
+          theme={theme()}
+          onToggleTheme={toggleTheme}
         />
         <Show
           when={hostList().length > 0}
@@ -360,8 +377,33 @@ function HostView(props: { host: string }) {
     }
   })();
 
-  const [filter, setFilter] = createSignal("");
-  const [sortKey, setSortKey] = createSignal<SortKey>("cpu");
+  // Per-host UI preferences, persisted to localStorage and keyed by host.
+  // These signals live in this keyed component, so each host restores its
+  // own filter/sort/window on reload or tab switch — per-host scope falls
+  // out of where the state already lives. Each effect mirrors changes back
+  // to storage (`defer` skips the redundant write of the just-read seed),
+  // the same signal-is-truth / store-is-projection shape as App's URL
+  // mirror — just a private store (localStorage) instead of the shareable
+  // one (the URL).
+  const [filter, setFilter] = createSignal(
+    readPref(prefKey("filter", props.host), ""),
+  );
+  createEffect(
+    on(filter, (v) => writePref(prefKey("filter", props.host), v), {
+      defer: true,
+    }),
+  );
+
+  const [sortKey, setSortKey] = createSignal<SortKey>(
+    readPref<SortKey>(prefKey("sort", props.host), "cpu", (raw) =>
+      (SORT_KEYS as readonly string[]).includes(raw),
+    ),
+  );
+  createEffect(
+    on(sortKey, (v) => writePref(prefKey("sort", props.host), v), {
+      defer: true,
+    }),
+  );
 
   const currentSystem = createMemo(() => system.value() ?? DEFAULT_SYSTEM);
   const currentConnection = createMemo(
@@ -431,8 +473,18 @@ function HostView(props: { host: string }) {
   // every fresh mount), then one delta per tick. `pushSample` bounds the
   // locally-accumulated deltas to the same retention as the server ring.
   const [history, setHistory] = createSignal<MetricSample[]>([]);
-  const [historyWindow, setHistoryWindow] =
-    createSignal<HistoryWindowKey>(DEFAULT_HISTORY_WINDOW);
+  const [historyWindow, setHistoryWindow] = createSignal<HistoryWindowKey>(
+    readPref(
+      prefKey("window", props.host),
+      DEFAULT_HISTORY_WINDOW,
+      isHistoryWindowKey,
+    ),
+  );
+  createEffect(
+    on(historyWindow, (v) => writePref(prefKey("window", props.host), v), {
+      defer: true,
+    }),
+  );
   const windowMs = createMemo(() => windowMsFor(historyWindow()));
 
   // Reuses `ctl` — the metricHistory and processesSnapshot streams share

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -17,7 +17,7 @@ import { createMemo, createSignal, For, Show } from "solid-js";
 import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
 import type { View } from "./view";
 import { STATE } from "./connectionColors";
-import type { Theme } from "./theme";
+import { otherTheme, type Theme } from "./theme";
 import { surfaceForHost } from "./wire";
 
 // Shared chip chrome — the fleet tab and the host chips are the same
@@ -69,13 +69,12 @@ export function TabStrip(props: {
 // it will switch *to*, the common affordance: a moon while light, a sun
 // while dark.
 function ThemeToggle(props: { theme: Theme; onToggle: () => void }) {
-  const next = createMemo(() => (props.theme === "dark" ? "light" : "dark"));
   return (
     <button
       type="button"
       class="ml-auto flex items-center px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800/60"
-      title={`Switch to ${next()} theme`}
-      aria-label={`Switch to ${next()} theme`}
+      title={`Switch to ${otherTheme(props.theme)} theme`}
+      aria-label={`Switch to ${otherTheme(props.theme)} theme`}
       onClick={props.onToggle}
     >
       <span aria-hidden="true">{props.theme === "dark" ? "☀" : "☾"}</span>

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -17,6 +17,7 @@ import { createMemo, createSignal, For, Show } from "solid-js";
 import { type ConnectionState, DEFAULT_CONNECTION } from "../common/surface";
 import type { View } from "./view";
 import { STATE } from "./connectionColors";
+import type { Theme } from "./theme";
 import { surfaceForHost } from "./wire";
 
 // Shared chip chrome — the fleet tab and the host chips are the same
@@ -36,6 +37,8 @@ export function TabStrip(props: {
   onSelect: (h: string) => void;
   onAdd: (h: string) => Promise<string | null>;
   onRemove: (h: string) => Promise<void>;
+  theme: Theme;
+  onToggleTheme: () => void;
 }) {
   return (
     <div class="flex flex-wrap items-stretch border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/60">
@@ -57,7 +60,26 @@ export function TabStrip(props: {
         )}
       </For>
       <AddHostForm onAdd={props.onAdd} />
+      <ThemeToggle theme={props.theme} onToggle={props.onToggleTheme} />
     </div>
+  );
+}
+
+// Right-aligned (`ml-auto`) light/dark switch. Shows the icon of the theme
+// it will switch *to*, the common affordance: a moon while light, a sun
+// while dark.
+function ThemeToggle(props: { theme: Theme; onToggle: () => void }) {
+  const next = createMemo(() => (props.theme === "dark" ? "light" : "dark"));
+  return (
+    <button
+      type="button"
+      class="ml-auto flex items-center px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800/60"
+      title={`Switch to ${next()} theme`}
+      aria-label={`Switch to ${next()} theme`}
+      onClick={props.onToggle}
+    >
+      <span aria-hidden="true">{props.theme === "dark" ? "☀" : "☾"}</span>
+    </button>
   );
 }
 

--- a/packages/app/src/client/index.html
+++ b/packages/app/src/client/index.html
@@ -5,6 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>drishti — remote process monitor</title>
     <link rel="stylesheet" href="./styles.css" />
+    <!-- Apply the saved (or OS-default) theme before first paint to avoid a
+         flash of the wrong colours. Runs before any module loads, so it
+         can't import theme.ts — the "drishti:theme" key must match THEME_KEY
+         there. -->
+    <script>
+      try {
+        var t = localStorage.getItem("drishti:theme");
+        if (t !== "light" && t !== "dark")
+          t = matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        document.documentElement.dataset.theme = t;
+      } catch (_) {
+        /* storage blocked — fall through to CSS/OS default */
+      }
+    </script>
   </head>
   <body class="m-0 antialiased">
     <div id="root"></div>

--- a/packages/app/src/client/localStorageState.test.ts
+++ b/packages/app/src/client/localStorageState.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { prefKey } from "./localStorageState";
+
+describe("prefKey", () => {
+  it("namespaces a preference under the host", () => {
+    expect(prefKey("sort", "localhost")).toBe("drishti:sort:localhost");
+  });
+
+  it("keeps ssh targets verbatim so each host gets its own slot", () => {
+    expect(prefKey("window", "user@a.lan")).toBe("drishti:window:user@a.lan");
+    expect(prefKey("window", "[::1]")).toBe("drishti:window:[::1]");
+  });
+
+  it("distinguishes prefs and hosts so keys never collide", () => {
+    const keys = [
+      prefKey("sort", "a"),
+      prefKey("sort", "b"),
+      prefKey("filter", "a"),
+    ];
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/packages/app/src/client/localStorageState.ts
+++ b/packages/app/src/client/localStorageState.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-host UI preferences persisted to browser `localStorage`.
+ *
+ * The same shape as {@link ./urlState}: the signal in the component is the
+ * source of truth, the store is its projection. The pure pieces — the
+ * namespaced key and the validated read — live here; the `createSignal`
+ * seed and the `createEffect` that writes on change stay in `HostView`,
+ * exactly as `urlState`'s (de)serializers stay separate from the
+ * `history.replaceState` effect in `App`.
+ *
+ * Why `localStorage` and not the URL (which already carries the selected
+ * host): the URL is *shareable* state — a link you hand someone resolves
+ * to the same host. Window/sort/filter are *private* reading conveniences;
+ * putting them in the URL would be noise in a shared link. Different
+ * concept, different store — so this is its own module, not an extension
+ * of `urlState`.
+ *
+ * Scope is per host because these signals live in `HostView`, which Solid
+ * remounts (keyed) on every host switch — the `host`-keyed name falls out
+ * of where the state already lives rather than being a flag threaded
+ * through a generic helper.
+ */
+
+const NAMESPACE = "drishti";
+
+/** Storage key for a named preference scoped to one host. */
+export function prefKey(pref: string, host: string): string {
+  return `${NAMESPACE}:${pref}:${host}`;
+}
+
+/**
+ * Read a stored preference, validated through `accept`. Falls back when the
+ * key is absent, the stored value no longer validates (e.g. a sort column
+ * that was removed), or storage is unavailable (Safari private mode throws
+ * on access). `accept` defaults to accepting any non-null string — the
+ * right default for free-text prefs like the process filter.
+ */
+export function readPref<T extends string>(
+  key: string,
+  fallback: T,
+  accept: (raw: string) => boolean = () => true,
+): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw !== null && accept(raw) ? (raw as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Persist a preference. Storage failures (private mode, quota) are
+ * swallowed: a preference that can't be saved simply doesn't survive the
+ * reload — it never breaks the live view.
+ */
+export function writePref(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* storage unavailable — preference won't persist, which is fine */
+  }
+}

--- a/packages/app/src/client/styles.css
+++ b/packages/app/src/client/styles.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/* Drive the `dark:` variant from an explicit `data-theme="dark"` attribute
+ * on <html> (set by the theme toggle / the pre-paint bootstrap in
+ * index.html) instead of the OS `prefers-color-scheme` media query, so a
+ * click can override the system theme. The attribute is seeded from the OS
+ * preference on first visit, so default behaviour is unchanged. */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
 :root {
   font-family:
     ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu,

--- a/packages/app/src/client/theme.test.ts
+++ b/packages/app/src/client/theme.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { otherTheme, parseTheme } from "./theme";
+
+describe("parseTheme", () => {
+  it("accepts the two known themes", () => {
+    expect(parseTheme("light")).toBe("light");
+    expect(parseTheme("dark")).toBe("dark");
+  });
+
+  it("rejects absent, empty, or unknown values", () => {
+    expect(parseTheme(null)).toBeNull();
+    expect(parseTheme("")).toBeNull();
+    expect(parseTheme("Dark")).toBeNull();
+    expect(parseTheme("system")).toBeNull();
+  });
+});
+
+describe("otherTheme", () => {
+  it("flips between the two themes", () => {
+    expect(otherTheme("dark")).toBe("light");
+    expect(otherTheme("light")).toBe("dark");
+  });
+});

--- a/packages/app/src/client/theme.test.ts
+++ b/packages/app/src/client/theme.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { otherTheme, parseTheme } from "./theme";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { otherTheme, parseTheme, THEME_KEY } from "./theme";
 
 describe("parseTheme", () => {
   it("accepts the two known themes", () => {
@@ -19,5 +21,16 @@ describe("otherTheme", () => {
   it("flips between the two themes", () => {
     expect(otherTheme("dark")).toBe("light");
     expect(otherTheme("light")).toBe("dark");
+  });
+});
+
+describe("THEME_KEY", () => {
+  it("matches the literal hardcoded in index.html's pre-paint bootstrap", () => {
+    // The inline script runs before any module loads, so it can't import
+    // THEME_KEY — this canary fails if the constant is renamed without
+    // updating index.html in lockstep (the one duplication that can't be
+    // collapsed away).
+    const html = readFileSync(join(import.meta.dir, "index.html"), "utf8");
+    expect(html).toContain(`"${THEME_KEY}"`);
   });
 });

--- a/packages/app/src/client/theme.ts
+++ b/packages/app/src/client/theme.ts
@@ -18,8 +18,6 @@
  * not per host.
  */
 
-import { writePref } from "./localStorageState";
-
 export type Theme = "light" | "dark";
 
 /**
@@ -58,8 +56,12 @@ export function otherTheme(theme: Theme): Theme {
   return theme === "dark" ? "light" : "dark";
 }
 
-/** Apply a theme to the document and persist the choice for next visit. */
+/**
+ * Apply a theme to the document. This module owns the *how* — which element
+ * and attribute carry the theme — so that detail stays in one place. The
+ * *when* (and persistence) is the caller's reactive effect, keeping the
+ * theme signal the single source of truth.
+ */
 export function applyTheme(theme: Theme): void {
   document.documentElement.dataset.theme = theme;
-  writePref(THEME_KEY, theme);
 }

--- a/packages/app/src/client/theme.ts
+++ b/packages/app/src/client/theme.ts
@@ -1,0 +1,65 @@
+/**
+ * Light/dark theme: a persisted override on top of the OS preference.
+ *
+ * Tailwind's `dark:` variant is rebound (in `styles.css`) to the
+ * `data-theme="dark"` attribute on `<html>` rather than the
+ * `prefers-color-scheme` media query, so a click can flip the theme
+ * without touching OS settings. The chosen theme is saved to
+ * `localStorage` and re-applied on the next visit.
+ *
+ * To avoid a flash of the wrong theme, the attribute is set *before first
+ * paint* by a tiny inline script in `index.html` (it can't import this
+ * module — modules load after paint). That script is the single reader of
+ * storage at startup; here, {@link initialTheme} seeds the signal from the
+ * attribute the script already applied, keeping JS state and the DOM in
+ * lockstep.
+ *
+ * Theme is global app chrome, so the signal lives in `App` (like `view`),
+ * not per host.
+ */
+
+import { writePref } from "./localStorageState";
+
+export type Theme = "light" | "dark";
+
+/**
+ * Storage key for the theme override. Must stay in sync with the literal
+ * in `index.html`'s pre-paint bootstrap, which runs before any module can
+ * import this constant.
+ */
+export const THEME_KEY = "drishti:theme";
+
+/** Narrow an arbitrary string to a {@link Theme}, or null if it is neither. */
+export function parseTheme(raw: string | null): Theme | null {
+  return raw === "light" || raw === "dark" ? raw : null;
+}
+
+/** The OS-level preference — the default before the user picks a theme. */
+export function systemTheme(): Theme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+/**
+ * Theme to seed the signal with: the attribute the pre-paint bootstrap
+ * already applied, falling back to the OS preference if that script didn't
+ * run (e.g. storage threw). Reading the live attribute keeps the signal
+ * agreeing with what's already on screen.
+ */
+export function initialTheme(): Theme {
+  return (
+    parseTheme(document.documentElement.dataset.theme ?? null) ?? systemTheme()
+  );
+}
+
+/** The other theme — what a toggle switches to. */
+export function otherTheme(theme: Theme): Theme {
+  return theme === "dark" ? "light" : "dark";
+}
+
+/** Apply a theme to the document and persist the choice for next visit. */
+export function applyTheme(theme: Theme): void {
+  document.documentElement.dataset.theme = theme;
+  writePref(THEME_KEY, theme);
+}

--- a/packages/app/src/common/history.test.ts
+++ b/packages/app/src/common/history.test.ts
@@ -4,6 +4,7 @@ import {
   captureSample,
   HISTORY_RETENTION_MS,
   HISTORY_WINDOWS,
+  isHistoryWindowKey,
   polylinePoints,
   pushSample,
   windowMsFor,
@@ -44,6 +45,17 @@ describe("windowMsFor", () => {
   it("resolves a known key to its span", () => {
     expect(windowMsFor("1m")).toBe(60_000);
     expect(windowMsFor("15m")).toBe(15 * 60_000);
+  });
+});
+
+describe("isHistoryWindowKey", () => {
+  it("accepts every selectable window key", () => {
+    for (const w of HISTORY_WINDOWS) expect(isHistoryWindowKey(w.key)).toBe(true);
+  });
+
+  it("rejects unknown or stale keys", () => {
+    expect(isHistoryWindowKey("2h")).toBe(false);
+    expect(isHistoryWindowKey("")).toBe(false);
   });
 });
 

--- a/packages/app/src/common/history.ts
+++ b/packages/app/src/common/history.ts
@@ -52,6 +52,13 @@ export function windowMsFor(key: HistoryWindowKey): number {
   return HISTORY_WINDOWS.find((w) => w.key === key)?.ms ?? HISTORY_WINDOWS[0].ms;
 }
 
+/** Whether a raw string is a selectable window key — the guard for
+ *  restoring a persisted choice, so a key dropped from a future build
+ *  falls back to the default instead of selecting nothing. */
+export function isHistoryWindowKey(raw: string): boolean {
+  return HISTORY_WINDOWS.some((w) => w.key === raw);
+}
+
 /** Assemble a `MetricSample` from a live system snapshot and the per-core
  *  usages captured at one instant — the single home for "what a captured
  *  sample is." Adding a series (say, load) becomes one edit here plus the


### PR DESCRIPTION
**Your in-browser reading preferences now survive a reload.** Until now only the selected host persisted (in the URL) — the chart window, process sort column, and filter all snapped back to defaults on every refresh or tab switch, and the theme was whatever the OS dictated with no way to override it. This wires those preferences through `localStorage` and adds a light/dark toggle.

### What persists now

| Preference | Store | Scope |
| --- | --- | --- |
| Chart window (1m/5m/15m/30m), process sort column, process filter | `localStorage` | **per host** |
| Light/dark theme | `localStorage` | global |
| Selected host (unchanged) | URL `?host=` | — |

The split is deliberate. The URL stays the home for *shareable* state — a link you hand someone resolves to the same host. Window/sort/filter are *private* reading conveniences; putting them in a URL would be noise in a shared link. So they get their own store, in a new `localStorageState.ts` that mirrors `urlState.ts`'s shape: **the signal is the source of truth, the store is its projection** — pure namespaced read/write here, the `createSignal` seed + write-back effect in the component. Per-host scope falls out of where the signals already live: `HostView` is keyed-remounted per host, so each tab restores its own settings.

### Theme

The `dark:` Tailwind variant is rebound from the OS `prefers-color-scheme` media query to an explicit `data-theme` attribute, so a click can override the system theme. To avoid a flash of the wrong colours, the attribute is applied *before first paint* by a tiny inline bootstrap in `index.html` — it can't import the module (it runs before the module graph loads), so the storage key is the one duplication that can't be collapsed, guarded instead by a canary test.

> The history ring itself is still server-owned and in-memory (unchanged) — this PR only persists the *client's view* of it.

### Structural review

hickey + lowy ran on the diff (full analysis in a PR comment). Three findings landed as follow-up commits: the theme write-back was reshaped to match the signal-is-truth pattern, the three repeated per-host pref pairs collapsed into a `createPersistedSignal` helper, and the unavoidable key duplication got a canary test. Two were No-ops.

### Try it locally

```sh
nix run github:srid/drishti/localpersist-prefs
```

Then open <http://localhost:7720>, change the window/sort/filter on a host, toggle the theme top-right, and reload.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._