### PR TITLE
Add demo screencast link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A live process monitor that runs against any host you can `ssh` into. Browser SolidJS UI ↔ local parent server (Bun) ↔ remote agent over `ssh` stdio. Built on [`@kolu/surface`](https://kolu.dev/blog/surface-framework/) (with https://github.com/juspay/kolu/pull/984) for the typed reactive transport.
 
+## Demo
+
+▶ **[Watch drishti in action](https://x.com/sridca/status/2060333167463088637)** — a short screencast demoing the multi-host fleet view and live htop drill-down.
+
 ## Quick start
 
 ```sh


### PR DESCRIPTION
Adds a **Demo** section near the top of the README linking to the screencast on X that demos the app (multi-host fleet view + live htop drill-down).

**Note on embedding:** GitHub-flavored markdown can't embed/iframe an X video inline — `<iframe>`/`<script>` are stripped from rendered READMEs, and native `<video>` only works for files uploaded to GitHub's own `user-attachments`. X also blocks automated download of the underlying mp4. So this uses the standard pattern: a prominent clickable link to the post. If you'd prefer a true inline player, we can re-upload the mp4 as a GitHub asset and switch to a `<video>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)