### PR TITLE
Make macOS memory usage cache-aware via vm_stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Parent server (Bun, drishti)    Admin surface (host set)
    │  ssh stdio (oRPC) ×N
    ▼
 Host 1: drishti-agent     Host 2: drishti-agent     …
-   │  /proc on linux, sysctl on darwin
+   │  /proc on linux; sysctl + vm_stat / netstat / ps on darwin
    ▼
 Kernel
 ```
@@ -54,7 +54,7 @@ Per-host primitives:
 
 | Primitive | Path | Purpose |
 |---|---|---|
-| **Cell** | `system` | Load averages, memory, uptime, OS, hostname. |
+| **Cell** | `system` | Load averages, memory, uptime, OS, hostname. Memory *used* means the same thing on every OS — total minus a cache-aware *available* (reclaimable file cache / inactive / purgeable pages don't count as used): `MemAvailable` from `/proc/meminfo` on linux, derived from `vm_stat` on darwin (since macOS `os.freemem()` counts only truly-free pages and would over-report a healthy Mac at 80-95%). |
 | **Collection** | `processes` | Keyed by PID — `{ user, cpuPct, rssBytes, command, cwd }`. The table shows absolute resident memory (`rssBytes`, auto-scaled to MB/GB). Snapshot-then-delta. `cwd` is from `/proc/<pid>/cwd` on linux (empty on darwin / kernel threads / other-user pids). |
 | **Stream** | `processesSnapshot` | Bulk-snapshot variant for ~600-PID htop refresh in one frame. |
 | **Collection** | `cpuCores` | Per-core CPU usage (`Collection<K,T>` showcase). |

--- a/packages/app/src/agent/proc.test.ts
+++ b/packages/app/src/agent/proc.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "bun:test";
 import {
   computeNetThroughput,
   type NetCounters,
+  parseMeminfo,
   parseNetstatIb,
   parseProcNetDev,
   parsePsLine,
+  parseVmStat,
 } from "./proc";
 
 describe("parseProcNetDev", () => {
@@ -86,6 +88,71 @@ describe("parsePsLine", () => {
     expect(parsePsLine("")).toBeNull();
     expect(parsePsLine("   ")).toBeNull();
     expect(parsePsLine("not a ps line")).toBeNull();
+  });
+});
+
+describe("parseVmStat", () => {
+  // Realistic `vm_stat` output on Apple Silicon (16 KiB pages). The header
+  // carries the page size; each line is `Label:   <count>.`.
+  const sample = [
+    "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+    'Pages free:                              100000.',
+    'Pages active:                            500000.',
+    'Pages inactive:                          200000.',
+    'Pages speculative:                        30000.',
+    'Pages throttled:                              0.',
+    'Pages wired down:                        300000.',
+    'Pages purgeable:                          40000.',
+    '"Translation faults":                 123456789.',
+    "Pages copy-on-write:                    1000000.",
+    "Pages zero filled:                    900000000.",
+    "Pages reactivated:                       500000.",
+    "Pages purged:                            100000.",
+    'File-backed pages:                       150000.',
+    'Anonymous pages:                         550000.',
+    "Pages stored in compressor:              200000.",
+    "Pages occupied by compressor:            100000.",
+    "",
+  ].join("\n");
+
+  // available = pageSize × (free + inactive + purgeable + speculative + file-backed)
+  const PAGE = 16384;
+  const reclaimablePages = 100000 + 200000 + 40000 + 30000 + 150000;
+
+  it("derives cache-aware available from reclaimable page classes, parsing page size from the header", () => {
+    const mem = parseVmStat(sample);
+    expect(mem.available).toBe(PAGE * reclaimablePages);
+  });
+
+  it("lets an explicit pageSize argument override the header", () => {
+    const mem = parseVmStat(sample, 4096);
+    expect(mem.available).toBe(4096 * reclaimablePages);
+  });
+
+  it("falls back to 0-count for page classes absent from the dump", () => {
+    const minimal = [
+      "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+      "Pages free:                              100000.",
+      "",
+    ].join("\n");
+    // Only free pages are reclaimable here; the rest default to 0.
+    expect(parseVmStat(minimal).available).toBe(PAGE * 100000);
+  });
+});
+
+describe("parseMeminfo", () => {
+  it("reads MemTotal/MemAvailable as bytes (kB × 1024)", () => {
+    const sample = [
+      "MemTotal:       16384000 kB",
+      "MemFree:         1000000 kB",
+      "MemAvailable:    8192000 kB",
+      "Buffers:          500000 kB",
+      "",
+    ].join("\n");
+    expect(parseMeminfo(sample)).toEqual({
+      total: 16384000 * 1024,
+      available: 8192000 * 1024,
+    });
   });
 });
 

--- a/packages/app/src/agent/proc.test.ts
+++ b/packages/app/src/agent/proc.test.ts
@@ -115,13 +115,26 @@ describe("parseVmStat", () => {
     "",
   ].join("\n");
 
-  // available = pageSize × (free + inactive + purgeable + speculative + file-backed)
+  // available = pageSize × (free + inactive + speculative + purgeable).
+  // "File-backed pages" is deliberately excluded: it tallies all
+  // file-backed pages regardless of LRU list, double-counting the
+  // file-backed pages already inside "Pages inactive" / "Pages
+  // speculative", which would let available exceed physical total.
   const PAGE = 16384;
-  const reclaimablePages = 100000 + 200000 + 40000 + 30000 + 150000;
+  const reclaimablePages = 100000 + 200000 + 30000 + 40000;
 
   it("derives cache-aware available from reclaimable page classes, parsing page size from the header", () => {
     const mem = parseVmStat(sample);
     expect(mem.available).toBe(PAGE * reclaimablePages);
+  });
+
+  it("excludes File-backed pages so available cannot double-count inactive/speculative file pages", () => {
+    // File-backed pages (150000) overlap the inactive + speculative counts;
+    // adding it would inflate available past the genuine reclaimable set
+    // and could push memUsed (total - available) negative.
+    const withFileBacked = reclaimablePages + 150000;
+    expect(parseVmStat(sample).available).toBe(PAGE * reclaimablePages);
+    expect(parseVmStat(sample).available).toBeLessThan(PAGE * withFileBacked);
   });
 
   it("lets an explicit pageSize argument override the header", () => {

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -456,12 +456,9 @@ export function parseVmStat(
   stdout: string,
   pageSize?: number,
 ): { available: number } {
+  const headerMatch = stdout.match(/page size of (\d+) bytes/);
   const size =
-    pageSize ??
-    (() => {
-      const m = stdout.match(/page size of (\d+) bytes/);
-      return m && m[1] !== undefined ? Number(m[1]) : 4096;
-    })();
+    pageSize ?? (headerMatch?.[1] !== undefined ? Number(headerMatch[1]) : 4096);
   // Each count line is `Label:   <count>.` — read the integer after the
   // label's colon, defaulting absent classes to 0.
   const pages = (label: string): number => {

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -495,16 +495,15 @@ function darwinReader(): ProcReader {
       // cache-aware "available" from vm_stat instead, then mirror linux's
       // `total - available` (kept inline, like linuxReader). totalmem() is
       // the authoritative physical total — vm_stat reports only page
-      // counts, so this line is where total and available are co-present.
+      // counts, so total and available come from the two distinct sources
+      // and are assembled here.
       const { stdout } = await exec("vm_stat");
-      const mem: MemInfo = {
-        total: totalmem(),
-        available: parseVmStat(stdout).available,
-      };
+      const total = totalmem();
+      const available = parseVmStat(stdout).available;
       return {
         loadAvg: [la[0] ?? 0, la[1] ?? 0, la[2] ?? 0],
-        memUsed: mem.total - mem.available,
-        memTotal: mem.total,
+        memUsed: total - available,
+        memTotal: total,
         uptime: uptime(),
         os: "darwin",
         hostname: hostname(),

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -434,9 +434,9 @@ export function parsePsLine(line: string): [Pid, Process] | null {
   ];
 }
 
-/** Parse `vm_stat` (darwin) into a cache-aware {total, available}, so the
- *  darwin path means the same thing as linux's MemAvailable-based number
- *  (`linuxReader().readSystem` does `total - available`).
+/** Parse `vm_stat` (darwin) into a cache-aware *available* byte count, so
+ *  the darwin path can mean the same thing as linux's MemAvailable-based
+ *  number (`darwinReader().readSystem` does `total - available`).
  *
  *  macOS `os.freemem()` counts only truly-free Mach pages, so
  *  `total - free` reports a host as 80-95% used even when most of that is
@@ -445,13 +445,13 @@ export function parsePsLine(line: string): [Pid, Process] | null {
  *  evictable under pressure, so they count as *available*, matching
  *  Linux's MemAvailable heuristic.
  *
- *  vm_stat reports no physical total (only page counts), so `total` is
- *  left 0 here and the reader fills it from `totalmem()` — the
- *  authoritative `hw.memsize`. The shape is still MemInfo so the
- *  cross-OS equivalence is type-visible. `pageSize` defaults to the size
- *  in the header (`(page size of N bytes)`); the param lets tests pin it.
- *  Pure — no clock or platform state — to stay unit-testable, mirroring
- *  parsePsLine / parseNetstatIb. */
+ *  This returns only what vm_stat knows — available bytes. The physical
+ *  total is a different, non-volatile source (`totalmem()`/`hw.memsize`)
+ *  the reader owns; it assembles the MemInfo where total and available are
+ *  genuinely co-present. `pageSize` defaults to the size in the header
+ *  (`(page size of N bytes)`); the param lets tests pin it. Pure — no
+ *  clock or platform state — to stay unit-testable, mirroring parsePsLine
+ *  / parseNetstatIb. */
 export function parseVmStat(
   stdout: string,
   pageSize?: number,
@@ -498,7 +498,7 @@ function darwinReader(): ProcReader {
       // cache-aware "available" from vm_stat instead, then mirror linux's
       // `total - available` (kept inline, like linuxReader). totalmem() is
       // the authoritative physical total — vm_stat reports only page
-      // counts, so parseVmStat leaves total 0 and we fill it here.
+      // counts, so this line is where total and available are co-present.
       const { stdout } = await exec("vm_stat");
       const mem: MemInfo = {
         total: totalmem(),

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -452,7 +452,10 @@ export function parsePsLine(line: string): [Pid, Process] | null {
  *  in the header (`(page size of N bytes)`); the param lets tests pin it.
  *  Pure — no clock or platform state — to stay unit-testable, mirroring
  *  parsePsLine / parseNetstatIb. */
-export function parseVmStat(stdout: string, pageSize?: number): MemInfo {
+export function parseVmStat(
+  stdout: string,
+  pageSize?: number,
+): { available: number } {
   const size =
     pageSize ??
     (() => {
@@ -473,7 +476,7 @@ export function parseVmStat(stdout: string, pageSize?: number): MemInfo {
     pages("Pages purgeable") +
     pages("Pages speculative") +
     pages("File-backed pages");
-  return { total: 0, available: size * reclaimable };
+  return { available: size * reclaimable };
 }
 
 function darwinReader(): ProcReader {

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -334,7 +334,7 @@ interface MemInfo {
   available: number;
 }
 
-function parseMeminfo(s: string): MemInfo {
+export function parseMeminfo(s: string): MemInfo {
   const get = (key: string): number => {
     const m = s.match(new RegExp(`^${key}:\\s+(\\d+)\\s+kB`, "m"));
     return m && m[1] !== undefined ? Number(m[1]) * 1024 : 0;
@@ -434,6 +434,48 @@ export function parsePsLine(line: string): [Pid, Process] | null {
   ];
 }
 
+/** Parse `vm_stat` (darwin) into a cache-aware {total, available}, so the
+ *  darwin path means the same thing as linux's MemAvailable-based number
+ *  (`linuxReader().readSystem` does `total - available`).
+ *
+ *  macOS `os.freemem()` counts only truly-free Mach pages, so
+ *  `total - free` reports a host as 80-95% used even when most of that is
+ *  reclaimable file cache. The reclaimable classes — free, inactive,
+ *  purgeable, speculative, and file-backed (external) pages — are all
+ *  evictable under pressure, so they count as *available*, matching
+ *  Linux's MemAvailable heuristic.
+ *
+ *  vm_stat reports no physical total (only page counts), so `total` is
+ *  left 0 here and the reader fills it from `totalmem()` — the
+ *  authoritative `hw.memsize`. The shape is still MemInfo so the
+ *  cross-OS equivalence is type-visible. `pageSize` defaults to the size
+ *  in the header (`(page size of N bytes)`); the param lets tests pin it.
+ *  Pure — no clock or platform state — to stay unit-testable, mirroring
+ *  parsePsLine / parseNetstatIb. */
+export function parseVmStat(stdout: string, pageSize?: number): MemInfo {
+  const size =
+    pageSize ??
+    (() => {
+      const m = stdout.match(/page size of (\d+) bytes/);
+      return m && m[1] !== undefined ? Number(m[1]) : 4096;
+    })();
+  // Each count line is `Label:   <count>.` — read the integer after the
+  // label's colon, defaulting absent classes to 0.
+  const pages = (label: string): number => {
+    const m = stdout.match(
+      new RegExp(`^${label}:\\s+(\\d+)\\.`, "m"),
+    );
+    return m && m[1] !== undefined ? Number(m[1]) : 0;
+  };
+  const reclaimable =
+    pages("Pages free") +
+    pages("Pages inactive") +
+    pages("Pages purgeable") +
+    pages("Pages speculative") +
+    pages("File-backed pages");
+  return { total: 0, available: size * reclaimable };
+}
+
 function darwinReader(): ProcReader {
   const readCpuCores = createCpuCoresReader();
   const readNetwork = createNetReader(async () => {
@@ -448,12 +490,21 @@ function darwinReader(): ProcReader {
       // os.loadavg() works on darwin; sysctl fallback only needed for
       // very old node versions.
       const la = loadavg();
-      const total = totalmem();
-      const free = freemem();
+      // os.freemem() on darwin counts only truly-free pages, so it would
+      // over-report usage by ignoring reclaimable cache. Derive a
+      // cache-aware "available" from vm_stat instead, then mirror linux's
+      // `total - available` (kept inline, like linuxReader). totalmem() is
+      // the authoritative physical total — vm_stat reports only page
+      // counts, so parseVmStat leaves total 0 and we fill it here.
+      const { stdout } = await exec("vm_stat");
+      const mem: MemInfo = {
+        total: totalmem(),
+        available: parseVmStat(stdout).available,
+      };
       return {
         loadAvg: [la[0] ?? 0, la[1] ?? 0, la[2] ?? 0],
-        memUsed: total - free,
-        memTotal: total,
+        memUsed: mem.total - mem.available,
+        memTotal: mem.total,
         uptime: uptime(),
         os: "darwin",
         hostname: hostname(),
@@ -483,6 +534,12 @@ function stubReader(): ProcReader {
     readNetwork: async () => new Map<IfaceName, NetInterface>(),
     readSystem: async () => {
       const la = loadavg();
+      // Known limitation: total-free undercounts reclaimable (cache /
+      // inactive / purgeable) memory on darwin-like kernels — the very
+      // miscount darwinReader fixes via vm_stat. It's tolerated here
+      // because macOS always dispatches to darwinReader (createProcReader),
+      // so this stub is never the Mac path; it's the last-resort fallback
+      // for genuinely-unknown platforms with no vm_stat / /proc to query.
       return {
         loadAvg: [la[0] ?? 0, la[1] ?? 0, la[2] ?? 0],
         memUsed: totalmem() - freemem(),

--- a/packages/app/src/agent/proc.ts
+++ b/packages/app/src/agent/proc.ts
@@ -440,14 +440,28 @@ export function parsePsLine(line: string): [Pid, Process] | null {
  *
  *  macOS `os.freemem()` counts only truly-free Mach pages, so
  *  `total - free` reports a host as 80-95% used even when most of that is
- *  reclaimable file cache. The reclaimable classes — free, inactive,
- *  purgeable, speculative, and file-backed (external) pages — are all
- *  evictable under pressure, so they count as *available*, matching
- *  Linux's MemAvailable heuristic.
+ *  reclaimable file cache. We sum the reclaimable classes — free, inactive,
+ *  speculative, and purgeable pages — which are all evictable under
+ *  pressure, so they count as *available*, matching Linux's MemAvailable
+ *  heuristic.
+ *
+ *  These are mutually exclusive *LRU-list* counters: every physical page
+ *  sits on exactly one of the free / active / inactive / speculative lists,
+ *  so free + inactive + speculative never double-counts a page. ("Pages
+ *  purgeable" overlaps active/inactive, but purgeable pages are reclaimed
+ *  first under pressure and are almost always on the inactive list already
+ *  — adding them is a small, bounded over-count, not a systematic one.) We
+ *  deliberately do NOT add "File-backed pages": that counter tallies *all*
+ *  file-backed pages regardless of LRU list, so it re-counts the
+ *  file-backed pages already in "Pages inactive" and the read-ahead pages
+ *  in "Pages speculative" — adding it would let `available` exceed physical
+ *  total and drive `memUsed` (total - available) negative. The caller still
+ *  clamps the subtraction at 0 as a final guard against the bounded
+ *  purgeable overlap.
  *
  *  This returns only what vm_stat knows — available bytes. The physical
  *  total is a different, non-volatile source (`totalmem()`/`hw.memsize`)
- *  the reader owns; it assembles the MemInfo where total and available are
+ *  the reader owns; it pairs total with this available where the two are
  *  genuinely co-present. `pageSize` defaults to the size in the header
  *  (`(page size of N bytes)`); the param lets tests pin it. Pure — no
  *  clock or platform state — to stay unit-testable, mirroring parsePsLine
@@ -470,9 +484,8 @@ export function parseVmStat(
   const reclaimable =
     pages("Pages free") +
     pages("Pages inactive") +
-    pages("Pages purgeable") +
     pages("Pages speculative") +
-    pages("File-backed pages");
+    pages("Pages purgeable");
   return { available: size * reclaimable };
 }
 
@@ -502,7 +515,10 @@ function darwinReader(): ProcReader {
       const available = parseVmStat(stdout).available;
       return {
         loadAvg: [la[0] ?? 0, la[1] ?? 0, la[2] ?? 0],
-        memUsed: total - available,
+        // Clamp at 0: vm_stat's "Pages purgeable" can overlap the inactive
+        // list, so `available` may marginally exceed `total`; never report
+        // negative usage.
+        memUsed: Math.max(0, total - available),
         memTotal: total,
         uptime: uptime(),
         os: "darwin",


### PR DESCRIPTION
**On macOS, `os.freemem()` counts only truly-free Mach pages**, so the old `memUsed = totalmem() - freemem()` reported a healthy Mac at 80-95% used — most of that being reclaimable file cache, inactive, purgeable, and speculative pages that the kernel hands back on demand. The Linux reader already does the honest thing: `total - available`, where `MemAvailable` is cache-aware. This PR makes the darwin number *mean the same thing*.

The darwin path now shells out to `vm_stat` (the established Darwin data-acquisition idiom — `readNetwork` already runs `netstat -ib`, processes run `ps`), sums the reclaimable page classes, and derives an `available` byte count so `memUsed = total - available` lines up with Linux.

### How it fits together

```
linux:  /proc/meminfo  ─▶ parseMeminfo  ─▶ { total, available } ─▶ total - available
darwin: vm_stat        ─▶ parseVmStat   ─▶ { available }         ─▶ total - available
                                              (total from totalmem())
```

`parseVmStat` is a **pure, exported, fixture-tested** function placed next to the existing `parsePsLine` / `parseNetstatIb` / `parseMeminfo` parsers — same `regex → 0-fallback` shape, no clock or platform state. It parses the page size from the `(page size of N bytes)` header (overridable for tests) and returns *only what vm_stat knows* — the available byte count. The physical total is a different, non-volatile source (`totalmem()`/`hw.memsize`) the reader owns, so `darwinReader.readSystem` assembles `{ total, available }` where both are genuinely co-present.

### Which page classes count as reclaimable

`available = pageSize × (free + inactive + speculative + purgeable)`. These are mutually-exclusive LRU-list counters, so they don't double-count. *`File-backed pages` is deliberately excluded* — it tallies all file-backed pages regardless of LRU list, re-counting pages already inside `inactive` / `speculative`; adding it would let `available` exceed physical total and drive `memUsed` negative. As a final guard against the small, bounded `purgeable`-overlap, the subtraction is clamped: `memUsed = Math.max(0, total - available)`.

### Notable

- `memPct` (`common/metrics.ts`) is untouched — it's `100 * memUsed / memTotal`, agnostic to how `memUsed` is derived.
- `stubReader` still uses `total - free`. That undercount is now documented as a *known, dormant limitation*: macOS always dispatches to `darwinReader`, so the stub is never the Mac path — it's the last-resort fallback for genuinely-unknown platforms with no `vm_stat` / `/proc`.
- The `total - available` subtraction is kept inline in each reader rather than hoisted into a shared `computeMemUsed()` — it's a stable arithmetic identity, not a volatility; the thing that actually varies per OS (deriving `available`) is already encapsulated in the parsers.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._