### PR TITLE
Run the monitor as a service via home-manager (Linux + macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ just regenerate-bun-nix           # after any bun.lock change
 
 The first connect to a fresh remote ships the agent closure over `ssh` (`nix copy --derivation` then `nix-store --realise`); subsequent connects reuse it. The progress is streamed to the browser via the `connection` cell.
 
+## Deployment (home-manager)
+
+A home-manager module runs the monitor as a systemd user service on Linux and as a launchd LaunchAgent on macOS:
+
+```nix
+{
+  imports = [ drishti.homeManagerModules.default ];
+  services.drishti = {
+    enable = true;
+    package = drishti.packages.${system}.default;
+    port = 7720;                  # default
+    hosts = [ "user@host-a" ];    # optional; empty = manage hosts at runtime
+  };
+}
+```
+
+The monitor binds `0.0.0.0` on `port`. `hosts` are passed as positional arguments; leave it empty to let drishti seed from its persisted hosts file (`$XDG_STATE_HOME/drishti/hosts.json`, overridable via `services.drishti.hostsFile`) and manage the set from the admin surface. The packaged wrapper already bakes `DRISHTI_DIST_DIR` / `DRISHTI_AGENT_DRVS_JSON` and puts `openssh` + `nix` on `PATH`, so the service self-contains its runtime needs.
+
+See [`nix/home/example/`](nix/home/example/) for a full configuration — a NixOS VM test exercises the systemd path on Linux, and a standalone home-manager activation build exercises the launchd path on Darwin.
+
+On macOS, the LaunchAgent writes stdout to `~/Library/Logs/drishti.out.log` and stderr to `~/Library/Logs/drishti.err.log`, so crashes and startup failures leave logs alongside other user logs.
+
 ## Project layout
 
 ```
@@ -110,9 +132,12 @@ drishti/
 │  ├─ nixpkgs.nix
 │  ├─ overlay.nix             # kolu-surface, kolu-surface-nix-host
 │  ├─ env.nix                 # DRISHTI_KOLU_SURFACE{,_NIX_HOST}
-│  └─ packages/
-│     ├─ kolu-package.nix     # mkKoluPackage factory
-│     └─ drishti/default.nix  # bun2nix build derivation
+│  ├─ packages/
+│  │  ├─ kolu-package.nix     # mkKoluPackage factory
+│  │  └─ drishti/default.nix  # bun2nix build derivation
+│  └─ home/
+│     ├─ module.nix           # home-manager module (systemd / launchd)
+│     └─ example/             # example config — CI-built (VM + launchd checks)
 ├─ scripts/
 │  └─ hydrate-kolu-packages.sh
 └─ packages/app/

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -15,7 +15,7 @@ nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accep
 [macos]
 [parallel]
 [metadata("ci")]
-default: nix typecheck fmt-check bun-nix-fresh
+default: nix typecheck fmt-check bun-nix-fresh home-manager
 
 # Single per-platform `bun install`. Funnel every bun consumer through this
 # node so concurrent `bun install` runs against the same workspace don't race.
@@ -38,6 +38,13 @@ _prefetch-crates:
 # Build all flake outputs via devour-flake.
 nix: _prefetch-crates
     nix build github:srid/devour-flake -L --no-link --print-out-paths --override-input flake .
+
+# Build the home-manager example flake (nix/home/example) against THIS repo:
+# the Linux nixosTest boots a VM and curls the systemd user service, and the
+# Darwin check eval-builds the launchd plist. `flake/drishti` is overridden to
+# the repo root so the example consumes the local module, not the published one.
+home-manager: nix
+    nix build github:srid/devour-flake -L --no-link --print-out-paths --override-input flake ./nix/home/example --override-input flake/drishti .
 
 # TypeScript type checking
 typecheck: install

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,11 @@
       # system attr structure.
       agentDrvsJson = builtins.toJSON agentDrvBySystem;
 
+      # home-manager module — runs the monitor as a systemd user service on
+      # Linux and a launchd LaunchAgent on macOS. System-independent; the
+      # consumer supplies `services.drishti.package` per their system.
+      homeManagerModules.default = import ./nix/home/module.nix;
+
       # `nix fmt` — format *.nix files only.
       formatter = eachSystem ({ pkgs, ... }: pkgs.nixpkgs-fmt);
 

--- a/nix/home/example/flake.lock
+++ b/nix/home/example/flake.lock
@@ -1,0 +1,164 @@
+{
+  "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1779931262,
+        "narHash": "sha256-8ypPqVPCxiLD6GAvGjA+cJ3REJzgMJDGkGJLZYuCfGo=",
+        "owner": "juspay",
+        "repo": "bun2nix",
+        "rev": "ce67cc1885e5e28fcc3ff865479be1a19ff396cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "ref": "rawflake",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "drishti": {
+      "inputs": {
+        "bun2nix": "bun2nix"
+      },
+      "locked": {
+        "lastModified": 1780084001,
+        "narHash": "sha256-X4P4AYHm7hDdd8jw3/uZyCB5Y9tCzYlAUtn6b6AC1wA=",
+        "owner": "srid",
+        "repo": "drishti",
+        "rev": "6c06b5ff45a3a3bd4098fbc87c94ebcbef0c2f87",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "drishti",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "drishti",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779969295,
+        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "drishti": "drishti",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "drishti",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -4,6 +4,14 @@
 # service actually starts and binds its port. Darwin: standalone
 # home-manager eval-build that verifies the launchd path produces a valid
 # plist (no runtime test — CI builders don't have a launchd session).
+#
+# Standalone evaluation note: the committed flake.lock pins `drishti` to the
+# master tip, which only exports `homeManagerModules` once this PR lands
+# upstream. Until then, evaluate/build this example against a local checkout
+# that has the module, e.g.
+#   nix flake check ./nix/home/example --override-input drishti .
+# (CI does exactly this — see the inputs comment below.) After the PR merges,
+# `nix flake update` in this directory makes standalone evaluation work.
 {
   inputs = {
     # In CI, justci builds this with --override-input drishti pointing to the repo root.

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -1,0 +1,136 @@
+# Example configuration using drishti's home-manager module.
+# Built in CI to ensure the module evaluates correctly.
+# Linux: NixOS VM test that boots the config and verifies the systemd
+# service actually starts and binds its port. Darwin: standalone
+# home-manager eval-build that verifies the launchd path produces a valid
+# plist (no runtime test — CI builders don't have a launchd session).
+{
+  inputs = {
+    # In CI, justci builds this with --override-input drishti pointing to the repo root.
+    drishti.url = "github:srid/drishti";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, home-manager, drishti, ... }:
+    let
+      linuxSystem = "x86_64-linux";
+      darwinSystem = "aarch64-darwin";
+      linuxPkgs = nixpkgs.legacyPackages.${linuxSystem};
+      darwinPkgs = nixpkgs.legacyPackages.${darwinSystem};
+
+      # Pure home-manager module — used both inside the NixOS VM (Linux
+      # systemd path) and standalone on Darwin (launchd path).
+      drishtiHmModule = { pkgs, ... }: {
+        imports = [ drishti.homeManagerModules.default ];
+        services.drishti = {
+          enable = true;
+          package = drishti.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+        home.stateVersion = "24.11";
+        # The example pins its own nixpkgs-unstable + home-manager (drishti
+        # exposes no nixpkgs flake input to follow), so their release tags can
+        # drift apart. Silence the cosmetic mismatch warning.
+        home.enableNixpkgsReleaseCheck = false;
+      };
+
+      darwinHome = home-manager.lib.homeManagerConfiguration {
+        pkgs = darwinPkgs;
+        modules = [
+          drishtiHmModule
+          {
+            home.username = "alice";
+            home.homeDirectory = "/Users/alice";
+          }
+        ];
+      };
+
+      # NixOS module: minimal system + home-manager with drishti enabled.
+      nixosModule = {
+        boot.loader.grub.devices = [ "nodev" ];
+        fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
+        system.stateVersion = "24.11";
+
+        users.users.alice = {
+          isNormalUser = true;
+          # Auto-login so the user session (and its systemd units) starts in the VM
+          initialPassword = "pass";
+        };
+
+        home-manager.users.alice = drishtiHmModule;
+      };
+    in
+    {
+      nixosConfigurations.example = nixpkgs.lib.nixosSystem {
+        system = linuxSystem;
+        modules = [
+          home-manager.nixosModules.home-manager
+          nixosModule
+        ];
+      };
+
+      # Linux: VM test boots the config and verifies drishti listens on its port.
+      checks.${linuxSystem}.vm-test = linuxPkgs.testers.nixosTest {
+        name = "drishti-service";
+
+        nodes.machine = { ... }: {
+          imports = [
+            home-manager.nixosModules.home-manager
+            nixosModule
+          ];
+
+          # Auto-login alice so her user session starts
+          services.getty.autologinUser = "alice";
+        };
+
+        testScript = ''
+          machine.wait_for_unit("multi-user.target")
+          # Poll for alice's user session. wait_for_unit fails fast if the
+          # unit is still inactive with no pending job — a race with
+          # auto-login queueing user@1000. wait_until_succeeds retries.
+          machine.wait_until_succeeds(
+              "systemctl is-active user@1000.service",
+              timeout=60,
+          )
+
+          # Use machinectl shell to get a proper user session with
+          # DBUS_SESSION_BUS_ADDRESS and XDG_RUNTIME_DIR set.
+          # Plain `su` doesn't set these, so systemctl --user fails.
+          machine.succeed(
+              "machinectl -q shell alice@.host /run/current-system/sw/bin/systemctl --user is-active drishti.service"
+          )
+
+          # Poll until drishti's HTTP listener binds — systemd reports
+          # "active" before the port is open. 120s headroom for hosts
+          # without KVM acceleration (qemu TCG fallback inflates the
+          # bun/node startup substantially).
+          machine.wait_until_succeeds(
+              "curl --fail --silent http://127.0.0.1:7720/ > /dev/null",
+              timeout=120,
+          )
+        '';
+      };
+
+      # Darwin: standalone home-manager activation package. Building this
+      # exercises the launchd.agents.drishti path end-to-end (plist
+      # generation, wait4path wrapping, etc.) without a live launchd session.
+      checks.${darwinSystem} = {
+        home-activation = darwinHome.activationPackage;
+
+        launchd-config =
+          let
+            agentConfig = darwinHome.config.launchd.agents.drishti.config;
+          in
+          assert agentConfig.StandardOutPath == "/Users/alice/Library/Logs/drishti.out.log";
+          assert agentConfig.StandardErrorPath == "/Users/alice/Library/Logs/drishti.err.log";
+          # Restart on non-zero exit AND on crash signals — matches systemd's
+          # `Restart = "on-failure"`. `SuccessfulExit` alone misses SIGSEGV etc.
+          assert agentConfig.KeepAlive.SuccessfulExit == false;
+          assert agentConfig.KeepAlive.Crashed == true;
+          darwinPkgs.runCommand "drishti-launchd-config" { } ''
+            touch $out
+          '';
+      };
+    };
+}

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -70,14 +70,6 @@
       };
     in
     {
-      nixosConfigurations.example = nixpkgs.lib.nixosSystem {
-        system = linuxSystem;
-        modules = [
-          home-manager.nixosModules.home-manager
-          nixosModule
-        ];
-      };
-
       # Linux: VM test boots the config and verifies drishti listens on its port.
       checks.${linuxSystem}.vm-test = linuxPkgs.testers.nixosTest {
         name = "drishti-service";

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -117,8 +117,10 @@
       };
 
       # Darwin: standalone home-manager activation package. Building this
-      # exercises the launchd.agents.drishti path end-to-end (plist
-      # generation, wait4path wrapping, etc.) without a live launchd session.
+      # exercises the launchd.agents.drishti path end-to-end (plist generation
+      # plus the RunAtLoad / KeepAlive / StandardOutPath / StandardErrorPath /
+      # EnvironmentVariables config the module sets) without a live launchd
+      # session.
       checks.${darwinSystem} = {
         home-activation = darwinHome.activationPackage;
 

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -88,9 +88,13 @@
           machine.wait_for_unit("multi-user.target")
           # Poll for alice's user session. wait_for_unit fails fast if the
           # unit is still inactive with no pending job — a race with
-          # auto-login queueing user@1000. wait_until_succeeds retries.
+          # auto-login queueing the per-user manager. wait_until_succeeds
+          # retries. Resolve alice's UID at runtime rather than assuming 1000:
+          # NixOS does not guarantee a normal user lands on UID 1000, so a
+          # hardcoded user@1000.service could poll a nonexistent unit until
+          # the timeout.
           machine.wait_until_succeeds(
-              "systemctl is-active user@1000.service",
+              "systemctl is-active user@$(id -u alice).service",
               timeout=60,
           )
 

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -54,6 +54,12 @@
         ];
       };
 
+      # Single source of truth for the port the test polls: read it back from
+      # the evaluated home-manager config rather than re-hardcoding the module
+      # default. If the module's `services.drishti.port` default changes (or the
+      # example overrides it), the curl below follows automatically.
+      testPort = darwinHome.config.services.drishti.port;
+
       # NixOS module: minimal system + home-manager with drishti enabled.
       nixosModule = {
         boot.loader.grub.devices = [ "nodev" ];
@@ -110,7 +116,7 @@
           # without KVM acceleration (qemu TCG fallback inflates the
           # bun/node startup substantially).
           machine.wait_until_succeeds(
-              "curl --fail --silent http://127.0.0.1:7720/ > /dev/null",
+              "curl --fail --silent http://127.0.0.1:${toString testPort}/ > /dev/null",
               timeout=120,
           )
         '';

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -1,0 +1,106 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.drishti;
+
+  # drishti's CLI surface (packages/app/src/server/main.ts): a single
+  # `--port` flag plus positional `[host...]` args. There is no `--host`
+  # (the server binds 0.0.0.0 hardcoded), no `--tls`, no `--verbose`.
+  args = [
+    (lib.getExe cfg.package)
+    "--port"
+    (toString cfg.port)
+  ]
+  ++ cfg.hosts;
+
+  # Shared by both supervisors. systemd wants `[ "KEY=val" ]`; launchd wants
+  # the attrset as a plist dict — converted at each call site. drishti's
+  # monitor wrapper already bakes DRISHTI_DIST_DIR / DRISHTI_AGENT_DRVS_JSON
+  # and prefixes openssh+nix onto PATH, so the only env we ever set here is
+  # the optional hosts-file override.
+  envAttrs = lib.optionalAttrs (cfg.hostsFile != null) {
+    DRISHTI_HOSTS_FILE = cfg.hostsFile;
+  };
+in
+{
+  options.services.drishti = {
+    enable = lib.mkEnableOption "drishti remote host monitor";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The drishti package to use.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 7720;
+      description = "Port the HTTP+WebSocket server listens on (binds 0.0.0.0).";
+    };
+
+    hosts = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = lib.literalExpression ''[ "user@host-a" "host-b" ]'';
+      description = ''
+        Hosts to monitor, passed as positional arguments to the monitor.
+        When empty, drishti seeds from its persisted hosts file (or
+        `["localhost"]` on first run) and lets the admin surface manage the
+        set at runtime.
+      '';
+    };
+
+    hostsFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = lib.literalExpression ''"''${config.home.homeDirectory}/.local/state/drishti/hosts.json"'';
+      description = ''
+        Override the file drishti reads/writes its host set to (the
+        `DRISHTI_HOSTS_FILE` env var). `null` uses the default
+        `$XDG_STATE_HOME/drishti/hosts.json`. Must be an absolute path —
+        systemd `%h` specifiers are not expanded here and would not work on
+        launchd anyway.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+      drishti = {
+        Unit = {
+          Description = "drishti remote host monitor";
+          After = [ "network.target" ];
+        };
+        Service = {
+          ExecStart = toString args;
+          Restart = "on-failure";
+        } // lib.optionalAttrs (envAttrs != { }) {
+          Environment = lib.mapAttrsToList (k: v: "${k}=${v}") envAttrs;
+        };
+        Install = {
+          WantedBy = [ "default.target" ];
+        };
+      };
+    };
+
+    launchd.agents = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+      drishti = {
+        enable = true;
+        config = {
+          ProgramArguments = args;
+          RunAtLoad = true;
+          # Match systemd's `Restart = "on-failure"`: restart on non-zero exit
+          # AND on crash signals (SIGSEGV, SIGILL, …). `SuccessfulExit` alone
+          # only covers clean exits with non-zero status.
+          KeepAlive = {
+            SuccessfulExit = false;
+            Crashed = true;
+          };
+          # launchd drops stdout/stderr by default; keep service crashes visible.
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/drishti.out.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/drishti.err.log";
+        } // lib.optionalAttrs (envAttrs != { }) {
+          EnvironmentVariables = envAttrs;
+        };
+      };
+    };
+  };
+}

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -49,15 +49,15 @@ in
     };
 
     hostsFile = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = lib.types.nullOr lib.types.path;
       default = null;
-      example = lib.literalExpression ''"''${config.home.homeDirectory}/.local/state/drishti/hosts.json"'';
+      example = lib.literalExpression ''/home/alice/.local/state/drishti/hosts.json'';
       description = ''
         Override the file drishti reads/writes its host set to (the
         `DRISHTI_HOSTS_FILE` env var). `null` uses the default
-        `$XDG_STATE_HOME/drishti/hosts.json`. Must be an absolute path —
-        systemd `%h` specifiers are not expanded here and would not work on
-        launchd anyway.
+        `$XDG_STATE_HOME/drishti/hosts.json`. The `path` type enforces an
+        absolute path; systemd `%h` specifiers are not expanded here and
+        would not work on launchd anyway.
       '';
     };
   };


### PR DESCRIPTION
**drishti now ships a home-manager module** that runs the monitor as a long-lived service — a systemd user service on Linux, a launchd LaunchAgent on macOS — selected automatically from the host platform. Consumers import one module, set `enable` + `package`, and never touch the supervisor distinction.

```nix
{
  imports = [ drishti.homeManagerModules.default ];
  services.drishti = {
    enable = true;
    package = drishti.packages.${system}.default;
    port = 7720;                  # default
    hosts = [ "user@host-a" ];    # optional; empty = manage hosts at runtime
  };
}
```

### One interface, two supervisors

The single axis of volatility — *which init system manages the process* — is encapsulated behind the stable `services.drishti` contract. The shared `args` / env facts are assembled once, then each platform branch converts them into its own transport shape:

```
services.drishti (enable, package, port, hosts, hostsFile)
        │
   ┌────┴─────────────────┐
 isLinux               isDarwin
 systemd.user.services  launchd.agents
 (Restart=on-failure)   (KeepAlive: Crashed + !SuccessfulExit)
```

The launchd `KeepAlive` is set to restart on both non-zero exit *and* crash signals, matching systemd's `Restart = "on-failure"` (plain `SuccessfulExit` would miss SIGSEGV and friends). On macOS the agent also writes `~/Library/Logs/drishti.{out,err}.log`, since launchd drops stdout/stderr by default.

### Subtracted from the kolu template, not copied

The module follows juspay/kolu's three-file pattern (drishti already builds on `@kolu/surface`), but the option surface is pared down to drishti's *actual* CLI (`packages/app/src/server/main.ts`): positional `[host...]` plus a single `--port`. kolu's `tls.*`, `verbose`, `diagnostics.*`, and `--host` are dropped — the server binds `0.0.0.0` hardcoded, and adding receptacles for non-existent flags would be speculative. The only env knob is `hostsFile` → `DRISHTI_HOSTS_FILE`; the packaged wrapper already self-contains `DRISHTI_DIST_DIR` / `DRISHTI_AGENT_DRVS_JSON` and the `openssh` + `nix` PATH wiring, so the module duplicates none of it.

### Tested in CI on both platforms

A new `home-manager` recipe in `ci/mod.just` builds `nix/home/example/` against this repo (`--override-input flake/drishti .`):

- **Linux** — a `nixosTest` boots a VM, waits for alice's user session, and curls the systemd service's port (UID resolved at runtime, port read back from the evaluated config).
- **Darwin** — a standalone home-manager activation build plus `assert`s on the generated launchd plist (no live launchd session needed on CI builders).

> The example's committed `flake.lock` pins `drishti` to the current master tip, which only exports `homeManagerModules` once this PR merges. The example header documents the `--override-input drishti .` workaround for standalone evaluation until then; `nix flake update` self-heals it post-merge.

### Try it locally

```sh
nix flake check github:srid/drishti/hm?dir=nix/home/example --override-input drishti github:srid/drishti/hm
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._