### PR TITLE
Make drishti strictly read-only by removing process kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Open <http://localhost:7720>. The UI opens on the **fleet** tab — a single ove
 - **Runtime host management** — the `+ add host` button adds hosts, the `×` on each tab removes one. Added/removed hosts persist to `$XDG_STATE_HOME/drishti/hosts.json` (override with `DRISHTI_HOSTS_FILE`), so `nix run github:srid/drishti` with no args restores the last session.
 - **Per-host view memory** — the chart window, process sort column, and process filter stick across reloads via `localStorage`, remembered per host. A **light/dark toggle** (top-right of the tab strip) overrides the OS theme and is remembered globally; until you touch it, the theme follows your system preference.
 - **Idle NICs collapse** behind a `+N idle` toggle by default, so the few interfaces moving traffic aren't buried under the dozens of always-zero virtual ones (utunN, anpiN, …).
-- **Process kill** — sends `TERM` / `KILL` / `HUP` / `INT`; the only mutation.
+- **Strictly read-only** — drishti only ever *observes* a host. The per-host surface exposes no procedures, so there is no way to signal, kill, or otherwise mutate a monitored process through the UI or the wire.
 
 Requirements:
 
@@ -68,7 +68,8 @@ Per-host primitives:
 | **Stream** | `processesSnapshot` | Bulk-snapshot variant for ~600-PID htop refresh in one frame. |
 | **Collection** | `cpuCores` | Per-core CPU usage (`Collection<K,T>` showcase). |
 | **Collection** | `networkInterfaces` | Per-NIC network I/O, keyed by interface name — `{ rxBytes, txBytes, rxRate, txRate }` (cumulative bytes since boot + bytes/sec throughput). `/proc/net/dev` on linux, `netstat -ib` on darwin; loopback filtered out. The UI strip collapses idle interfaces (both rates 0) behind a `+N idle` toggle by default, so the few NICs moving traffic aren't buried under the dozens of always-zero virtual ones (utunN, anpiN, …). |
-| **Procedure** | `process.kill` | The only mutation — sends `TERM` / `KILL` / `HUP` / `INT`. |
+
+The per-host surface is **read-only** — cells, collections, and streams only, no procedures. The only procedures anywhere live on the separate admin surface below (host-set management), never on a monitored host.
 
 Admin surface primitives:
 

--- a/packages/app/src/agent/main.ts
+++ b/packages/app/src/agent/main.ts
@@ -174,21 +174,6 @@ async function main(): Promise<void> {
         },
       },
     },
-    procedures: {
-      process: {
-        kill: async ({ input }) => {
-          try {
-            process.kill(input.pid, input.signal);
-            return { ok: true };
-          } catch (err) {
-            log(
-              `kill ${input.pid} ${input.signal} failed: ${(err as Error).message}`,
-            );
-            return { ok: false };
-          }
-        },
-      },
-    },
   });
 
   // Poll loop: refresh system + processes, diff against current

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -554,14 +554,6 @@ function HostView(props: { host: string }) {
     polylinePoints(windowedSamples(), "mem", chartNow(), windowMs()),
   );
 
-  const killProcess = async (pid: number, signal: "TERM" | "KILL") => {
-    try {
-      await app.rpc.surface.process.kill({ pid, signal });
-    } catch (err) {
-      console.error(`kill ${pid} ${signal} failed`, err);
-    }
-  };
-
   return (
     <>
       <Header
@@ -596,7 +588,6 @@ function HostView(props: { host: string }) {
           processes={processes}
           sortKey={sortKey()}
           onSort={setSortKey}
-          onKill={killProcess}
         />
       </Show>
     </>
@@ -739,7 +730,6 @@ function ProcessTable(props: {
   processes: Record<Pid, Process>;
   sortKey: SortKey;
   onSort: (k: SortKey) => void;
-  onKill: (pid: number, signal: "TERM" | "KILL") => void;
 }) {
   return (
     <div class="max-h-[70vh] overflow-y-auto">
@@ -771,17 +761,12 @@ function ProcessTable(props: {
               onClick={() => props.onSort("mem")}
             />
             <th class="px-3 py-1.5 text-left">COMMAND</th>
-            <th class="px-3 py-1.5 text-right" />
           </tr>
         </thead>
         <tbody>
           <For each={props.pids}>
             {(pid) => (
-              <ProcessRow
-                pid={pid}
-                processes={props.processes}
-                onKill={props.onKill}
-              />
+              <ProcessRow pid={pid} processes={props.processes} />
             )}
           </For>
         </tbody>
@@ -800,7 +785,6 @@ function ProcessTable(props: {
 function ProcessRow(props: {
   pid: Pid;
   processes: Record<Pid, Process>;
-  onKill: (pid: number, signal: "TERM" | "KILL") => void;
 }) {
   const proc = () => props.processes[props.pid];
   const cpu = () => proc()?.cpuPct ?? 0;
@@ -826,16 +810,6 @@ function ProcessRow(props: {
             </span>
           )}
         </Show>
-      </td>
-      <td class="px-3 py-0.5 text-right">
-        <button
-          type="button"
-          class="rounded border border-gray-300 px-1.5 text-xs text-red-600 hover:bg-red-50 dark:border-gray-700 dark:text-red-400 dark:hover:bg-red-950/40"
-          onClick={() => props.onKill(props.pid, "TERM")}
-          title="Send SIGTERM"
-        >
-          kill
-        </button>
       </td>
     </tr>
   );

--- a/packages/app/src/common/surface.test.ts
+++ b/packages/app/src/common/surface.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { surface } from "./surface";
+
+// drishti is a read-only monitor: the per-host surface must expose
+// cells, collections, and streams but **no procedures**. A procedure is
+// the only way to push a mutation (e.g. a signal/kill) down to the
+// monitored host, so the absence of any procedure is the structural
+// guarantee that the app can't act on a host — only observe it. If a
+// future change re-introduces a procedure here, this test fails on
+// purpose: removing the kill capability was a deliberate decision, not
+// an oversight to be quietly undone.
+describe("surface is read-only", () => {
+  it("declares no procedures", () => {
+    // The spec type literally has no `procedures` key (read-only by
+    // construction). Widen to read the optional slot at runtime: this
+    // still fails the moment a procedure is re-added, even though the
+    // type would also light up at the call sites that consume it.
+    const spec = surface.spec as Record<string, unknown>;
+    expect(spec.procedures).toBeUndefined();
+  });
+
+  it("still exposes the read-only primitives", () => {
+    expect(Object.keys(surface.spec.cells ?? {})).toContain("system");
+    expect(Object.keys(surface.spec.collections ?? {})).toContain("processes");
+    expect(Object.keys(surface.spec.streams ?? {})).toContain(
+      "processesSnapshot",
+    );
+  });
+});

--- a/packages/app/src/common/surface.ts
+++ b/packages/app/src/common/surface.ts
@@ -2,11 +2,14 @@
  * drishti surface — the shape served by the agent over stdio and
  * re-served by the parent over WebSocket.
  *
- * Three primitives carry the entire feature:
+ * Two primitives carry the entire feature:
  *
  *   - `system`     — singleton cell with load averages, memory, uptime.
  *   - `processes`  — keyed collection (PID → per-process snapshot).
- *   - `kill`       — imperative procedure (the only mutation).
+ *
+ * The surface is **strictly read-only**: it exposes cells, collections,
+ * and streams, but no procedures — there is no way to mutate the
+ * monitored host through it.
  *
  * Plus a `connection` cell so the parent can stream "copying agent to
  * remote…" lifecycle to the browser while `nix copy` is in flight.
@@ -202,17 +205,6 @@ export const surface = defineSurface({
     metricHistory: {
       inputSchema: z.object({}),
       outputSchema: MetricHistoryMessage,
-    },
-  },
-  procedures: {
-    process: {
-      kill: {
-        input: z.object({
-          pid: PidSchema,
-          signal: z.enum(["TERM", "KILL", "HUP", "INT"]).default("TERM"),
-        }),
-        output: z.object({ ok: z.boolean() }),
-      },
     },
   },
 });

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -13,8 +13,9 @@
  *   3. Per-key process upserts/removes from the agent flow through to
  *      the framework's channels and on to the browser.
  *
- * `kill` forwards directly to the agent — the parent has no business
- * keeping its own state for an imperative mutation.
+ * The surface is strictly read-only — it carries no procedures, so the
+ * parent only ever mirrors agent data inward; it never forwards a
+ * mutation back to the host.
  */
 
 import { implement } from "@orpc/server";
@@ -164,18 +165,6 @@ export function buildRouter(opts: BuildRouterOptions) {
           } satisfies MetricHistoryMsg;
           for await (const msg of historyBus.subscribe(signal)) {
             yield msg;
-          }
-        },
-      },
-    },
-    procedures: {
-      process: {
-        kill: async ({ input }) => {
-          const client = await session.acquire();
-          try {
-            return await client.surface.process.kill(input);
-          } finally {
-            session.release();
           }
         },
       },


### PR DESCRIPTION
**drishti is a monitor, and now it can only ever observe — never act.** The single mutating capability was `process.kill` (send `TERM`/`KILL`/`HUP`/`INT` to a PID); this PR excises it end-to-end so there is no path from the UI or the wire to mutate a monitored host.

The kill capability threaded cleanly through one RPC procedure across every tier, so removal is a clean cut rather than a refactor:

```
surface schema  ─▶  agent handler  ─▶  parent router  ─▶  client UI
(process.kill)      process.kill()     forwards to agent   "kill" button
   removed             removed             removed            removed
```

The per-host surface now declares **cells, collections, and streams but no procedures at all** — `procedures` is optional in the surface spec, so dropping it leaves a well-formed read-only contract. The only procedures left anywhere live on the separate *admin* surface (host-set add/remove), which never touches a monitored host.

A guard test (`common/surface.test.ts`) asserts the surface exposes no procedures, so the read-only invariant can't be silently undone by a future change.

### Try it locally

```sh
nix run github:srid/drishti/nokill
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._