### PR TITLE
fix(fleet): sparkline background ignores dark mode

### DIFF
--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -1136,7 +1136,7 @@ function Sparkline(props: {
 }) {
   return (
     <div
-      class={`relative w-full overflow-hidden rounded bg-gray-100 dark:bg-gray-800/50${props.class ? ` ${props.class}` : ""}`}
+      class={`relative w-full overflow-hidden rounded bg-gray-100 dark:bg-gray-800/50 ${props.class ?? ""}`}
     >
       <svg
         class="h-full w-full"


### PR DESCRIPTION
## What

The 30m CPU/memory sparkline (added in #20) renders with a **light** background in dark mode — on both the fleet card and the open host view. The trace lines are themed, but the box behind them stays `bg-gray-100`.

![before — light sparkline boxes in a dark UI](https://github.com/srid/drishti/assets/placeholder)

## Why

The `Sparkline` background was written inside a template literal with the dark utility jammed directly against `${...}` interpolation:

```tsx
class={`... bg-gray-100 dark:bg-gray-800/50${props.class ? ` ${props.class}` : ""}`}
//                       ^^^^^^^^^^^^^^^^^^^^^ no separator before ${
```

Tailwind v4's static class extractor only sees **complete, statically-present** class names. A utility butted against `${` isn't recognized, so `.dark:bg-gray-800/50` was **never emitted into the compiled CSS** — only the base `bg-gray-100` survived, hence the light box.

The card's own `dark:bg-gray-900/40` lives in a plain `class="..."` string, so it compiled fine — which is why *only* the sparkline was affected, and why it looked like a one-off styling miss rather than a build-time drop.

I confirmed this against the real `@tailwindcss/cli` build:

| utility | context | emitted? |
|---|---|---|
| `dark:bg-gray-900/40` (card) | `class="..."` | ✅ |
| `dark:bg-gray-800/50` (sparkline, before) | `dark:bg-gray-800/50${...}` | ❌ |
| `dark:bg-gray-800/50` (sparkline, after) | `dark:bg-gray-800/50 ${...}` | ✅ |

## Fix

Keep the utility a statically-extractable token by putting a space before the interpolation:

```tsx
class={`... bg-gray-100 dark:bg-gray-800/50 ${props.class ?? ""}`}
```

One-line change. Both callers (`h-10` fleet card, `h-24` host view) pass a static `class`, so the `?? ""` form is equivalent. Verified the class is now present in the compiled CSS, and grepped the client for any other Tailwind utilities adjacent to `${` — none remain.

## Avoiding this in future

The trap: Tailwind can only generate CSS for class names it can find as literal substrings. Any time a class string is *built* (interpolation, concatenation, computed keys), a needed utility can silently vanish from the bundle — no error, just missing styles.

Cheap guardrails, roughly in order of bang-for-buck:

1. **Convention:** never butt a utility against `${`. Write `\`base… ${dynamic ?? ""}\`` (space + nullish), or skip the template entirely when the dynamic part is conditional.
2. **Prefer Solid's `classList`** for conditional classes and keep the base classes in one plain static string — the base set then never passes through interpolation at all.
3. **Tooling:** the official Prettier `prettier-plugin-tailwindcss` / VS Code Tailwind IntelliSense only act on statically-detectable classes, so a utility that "won't sort / won't autocomplete" is an early warning it won't compile either. `eslint-plugin-tailwindcss` can flag this in CI.
4. If a dynamic class genuinely can't be made static, **`@source inline(...)` / a safelist** is the escape hatch — but that's a last resort, not the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)