### PR TITLE
Go full-bleed so the process table uses the whole screen width

### DIFF
--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -345,7 +345,7 @@ export default function App() {
 
   return (
     <div class="min-h-screen bg-gray-50 p-4 font-mono text-sm dark:bg-gray-950">
-      <div class="mx-auto max-w-6xl overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <div class="overflow-hidden rounded border border-gray-300 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
         <TabStrip
           hosts={hostList()}
           activeTab={resolvedView()}
@@ -974,7 +974,7 @@ function ProcessRow(props: {
       <td class="px-3 py-0.5 text-right tabular-nums text-gray-700 dark:text-gray-300">
         {formatBytes(rssBytes())}
       </td>
-      <td class="max-w-md truncate px-3 py-0.5 text-left text-gray-700 dark:text-gray-300">
+      <td class="w-full max-w-0 truncate px-3 py-0.5 text-left text-gray-700 dark:text-gray-300">
         <span>{proc()?.command ?? ""}</span>
         <Show when={proc()?.cwd}>
           {(cwd) => (

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -974,6 +974,12 @@ function ProcessRow(props: {
       <td class="px-3 py-0.5 text-right tabular-nums text-gray-700 dark:text-gray-300">
         {formatBytes(rssBytes())}
       </td>
+      {/* COMMAND absorbs the row's residual width and ellipsizes at the cell
+          edge. Both classes are load-bearing in `table-layout: auto`: `w-full`
+          claims the leftover width after the fixed numeric columns, and
+          `max-w-0` stops the `truncate` nowrap content from ballooning the cell
+          past the card (the card clips horizontally, so an un-capped cell would
+          run off-screen with no ellipsis). Dropping either one breaks it. */}
       <td class="w-full max-w-0 truncate px-3 py-0.5 text-left text-gray-700 dark:text-gray-300">
         <span>{proc()?.command ?? ""}</span>
         <Show when={proc()?.cwd}>


### PR DESCRIPTION
**The dashboard now fills the full viewport width instead of sitting in a centered 1152px column.** On a wide monitor the old `max-w-6xl` cap stranded huge margins on the left and right — a process monitor is a density tool, so it should use the glass it's given (the htop instinct).

The wasted space was really *two* caps wearing one coat, and fixing only the obvious one would have made the screen emptier, not denser:

| Cap | Where | Effect |
| --- | --- | --- |
| App shell `mx-auto max-w-6xl` | `App.tsx:348` | centered the whole card, leaving dead margin on wide screens |
| COMMAND cell `max-w-md` | `App.tsx:977` | truncated commands at ~448px — so widening the shell alone would just grow inter-column gaps, not show more |

Both are lifted. The shell goes full-bleed, and the COMMAND column switches to a `w-full max-w-0 truncate` recipe so it *absorbs* the freed width — long `/nix/store/…` paths that used to cut off mid-hash now read in full, with the ellipsis only kicking in on the genuinely longest lines.

> _`w-full` and `max-w-0` are **both** load-bearing in `table-layout: auto`: `w-full` claims the leftover width after the fixed numeric columns, `max-w-0` stops the nowrap content from ballooning the cell past the card's clipped edge (where it would overflow with no ellipsis). Verified by live measurement — dropping `max-w-0` balloons the cell to 2288px and overflows. There's an inline comment so nobody "simplifies" it back into a bug._

### Try it locally

```sh
nix run github:srid/drishti/full-bleed-layout
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._