### PR TITLE
Fix MEM column wrapping and USER column over-widening in process table

### DIFF
--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -1115,14 +1115,25 @@ function ProcessRow(props: {
           : "hover:bg-gray-50 dark:hover:bg-gray-800/40"
       }`}
     >
-      <td class="px-3 py-0.5 text-right tabular-nums">{props.pid}</td>
-      <td class="px-3 py-0.5 text-left">{proc()?.user ?? ""}</td>
+      {/* The four leading columns shrink to their content via `w-px` +
+          `whitespace-nowrap`: `w-px` makes each column's preferred width
+          tiny so the auto-layout table collapses it to its (nowrap) content
+          width, leaving COMMAND's `w-full` as the sole absorber of the row's
+          slack. Without this, COMMAND's `max-w-0` caps its growth and the
+          leftover width inflates USER instead; and an un-nowrapped MEM cell
+          wraps "817.5 MB" onto two lines in the narrowed column. */}
+      <td class="w-px whitespace-nowrap px-3 py-0.5 text-right tabular-nums">
+        {props.pid}
+      </td>
+      <td class="w-px whitespace-nowrap px-3 py-0.5 text-left">
+        {proc()?.user ?? ""}
+      </td>
       <td
-        class={`px-3 py-0.5 text-right tabular-nums ${processPctColor(cpu())}`}
+        class={`w-px whitespace-nowrap px-3 py-0.5 text-right tabular-nums ${processPctColor(cpu())}`}
       >
         {cpu().toFixed(1)}
       </td>
-      <td class="px-3 py-0.5 text-right tabular-nums text-gray-700 dark:text-gray-300">
+      <td class="w-px whitespace-nowrap px-3 py-0.5 text-right tabular-nums text-gray-700 dark:text-gray-300">
         {formatBytes(rssBytes())}
       </td>
       {/* COMMAND absorbs the row's residual width and ellipsizes at the cell


### PR DESCRIPTION
**The process table's MEM value no longer wraps onto two lines, and the USER column no longer hogs horizontal space.** Both were symptoms of how the auto-layout table distributed its slack width: COMMAND uses `w-full max-w-0` to absorb leftover width and ellipsize, but `max-w-0` caps how far COMMAND can grow — so the table's residual width spilled into the other auto-sized columns and inflated USER, while the un-`nowrap`'d MEM cell let `"817.5 MB"` break across two rows.

The fix gives the four leading cells (PID / USER / CPU% / MEM) `w-px whitespace-nowrap`, collapsing each to its content width and leaving **COMMAND as the sole absorber of the row's slack**.

| Symptom | Cause | Fix |
| --- | --- | --- |
| MEM reads `817.5` / `MB` on two lines | cell had no `whitespace-nowrap`, wrapped at the space | `whitespace-nowrap` keeps it on one line |
| USER column stretched far past its content | COMMAND's `max-w-0` capped its growth, so slack inflated other auto columns | `w-px` collapses the fixed columns to content width |

_Pure CSS/className change — no behavioral logic touched; `tsc` and the client test suite (51 tests) pass._

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._