### PR TITLE
Timestamp + per-host-tag connection logs to diagnose connect-flapping

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -10,13 +10,10 @@ just fmt
 bun test
 
 ## CI command
-nix run github:juspay/justci -- run --host x86_64-linux=localhost
+nix run github:juspay/justci -- run
 
-<!-- `--host x86_64-linux=localhost`: the configured `srid-justci` SSH alias
-routes through a Tailscale proxy that returns "not owner of srid-justci",
-so the linux lane runs against this machine until the proxy is restored.
-Drop the override once `~/.config/justci/hosts.json` points linux somewhere
-reachable. -->
+<!-- Host routing comes from `~/.config/justci/hosts.json`
+(x86_64-linux → vanjaram, aarch64-darwin → rasam); no `--host` override. -->
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The monitor binds `0.0.0.0` on `port`. `hosts` are passed as positional argument
 
 See [`nix/home/example/`](nix/home/example/) for a full configuration — a NixOS VM test exercises the systemd path on Linux, and a standalone home-manager activation build exercises the launchd path on Darwin.
 
-On macOS, the LaunchAgent writes stdout to `~/Library/Logs/drishti.out.log` and stderr to `~/Library/Logs/drishti.err.log`, so crashes and startup failures leave logs alongside other user logs.
+On macOS, the LaunchAgent writes stdout to `~/Library/Logs/drishti.out.log` and stderr to `~/Library/Logs/drishti.err.log`, so crashes and startup failures leave logs alongside other user logs. Every stderr line is timestamped (ISO-8601) and tagged by subsystem — `[server]`, `[hosts]`, `[admin]`, and one `[bridge:<host>]` per monitored host — so a connection problem can be traced to a specific host on a timeline (on Linux/systemd, `journalctl --user -u drishti` adds its own timestamps).
 
 ## Project layout
 

--- a/docs/plans/talk-drishti-connect-failures.html
+++ b/docs/plans/talk-drishti-connect-failures.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>drishti — why 3 hosts fail to connect</title>
+<style>
+  :root{
+    --bg:#0f1419; --panel:#161b22; --panel2:#1c232c; --ink:#d7dee6; --dim:#8b97a5;
+    --line:#272f3a; --amber:#e0a23b; --red:#e0564b; --green:#3fb950; --blue:#58a6ff;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    padding:32px 22px 80px;max-width:1180px;margin-inline:auto}
+  h1{font-size:23px;margin:0 0 4px}
+  h2{font-size:17px;margin:34px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+  h3{font-size:14px;margin:20px 0 6px;color:var(--blue)}
+  p{margin:9px 0}
+  code{font-family:var(--mono);font-size:.86em;background:var(--panel2);padding:1px 5px;border-radius:4px;color:#c8d3df}
+  .sub{color:var(--dim)}
+  .verdict{background:linear-gradient(180deg,#1a2330,#161b22);border:1px solid #2b3645;
+    border-left:3px solid var(--red);border-radius:9px;padding:16px 18px;margin:14px 0}
+  .verdict strong{color:#fff}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:14px 16px;margin:12px 0}
+  table{border-collapse:collapse;width:100%;margin:10px 0;font-size:13.5px}
+  th,td{border:1px solid var(--line);padding:7px 10px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:var(--dim);font-weight:600}
+  td.n{font-family:var(--mono);text-align:right;white-space:nowrap}
+  .ok{color:var(--green)} .bad{color:var(--red)} .warn{color:var(--amber)}
+  .mono{font-family:var(--mono)}
+  pre{background:#0b0f14;border:1px solid var(--line);border-radius:8px;padding:12px 14px;
+    overflow-x:auto;font-family:var(--mono);font-size:12.5px;line-height:1.5;color:#b7c3d0;margin:8px 0}
+  pre .t{color:#5b6775}.pre .h{color:var(--blue)}
+  .cite{font-family:var(--mono);font-size:11.5px;color:var(--dim)}
+  ol,ul{margin:8px 0 8px 4px;padding-left:20px}
+  li{margin:5px 0}
+  .seq td:first-child{font-family:var(--mono);white-space:nowrap;color:var(--dim)}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11px;padding:1px 6px;border-radius:4px;border:1px solid var(--line)}
+  .tagdrishti{color:var(--green);border-color:#234} .tagkolu{color:var(--amber);border-color:#432}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  @media(max-width:760px){.two{grid-template-columns:1fr}}
+  .kbd{font-family:var(--mono);background:#222b35;border:1px solid #313c48;border-bottom-width:2px;border-radius:5px;padding:1px 6px;font-size:12px}
+</style>
+</head>
+<body>
+
+<h1>Why the 3 hosts fail to connect</h1>
+<p class="sub">Production drishti (launchd, home-manager) on this machine · log <code>~/Library/Logs/drishti.err.log</code> · server pid 75024, up 3h, <span class="mono">LastExitStatus=0</span> (not crash-looping).</p>
+
+<div class="verdict">
+<strong>It is not ssh, not <code>trusted-users</code>, not the agent copy.</strong> ssh works, the closure copies, the agent re-realises and runs perfectly on <em>every</em> attempt. The failure is entirely in the <strong>parent server's per-host reconnect bridge</strong>: after the first ssh link drops, the parent <strong>stops issuing the <code>system.get</code> subscription</strong> to the freshly-respawned agent. The agent boots, prints <code>serving surface over stdio</code>, and waits for a first RPC that never arrives — so kolu's 30 s connect-watchdog kills it, 5&nbsp;strikes &rarr; <span class="bad mono">failed</span>. The "Copying agent to remote…" you saw is just one frame of that retry spin.
+</div>
+
+<h2>The evidence (current 3-hour process only)</h2>
+<p>The log spans many server generations (older ones had 3 hosts; rasam/vanjaram were added later). Sliced to the live process — from the last <code>[server] hosts from CLI (5)</code> banner — the per-host counts are unambiguous:</p>
+
+<table>
+<tr><th>host</th><th class="n">agent booted¹</th><th class="n">first RPC received²</th><th class="n">handshake timeouts</th><th>terminal state</th></tr>
+<tr><td class="mono">localhost</td><td class="n">1</td><td class="n ok">1</td><td class="n">0</td><td class="ok">connected ✓</td></tr>
+<tr><td class="mono">pureintent</td><td class="n">5</td><td class="n bad">1</td><td class="n">8</td><td class="bad">failed</td></tr>
+<tr><td class="mono">sincereintent</td><td class="n">20</td><td class="n bad">1</td><td class="n">38</td><td class="bad">failed</td></tr>
+<tr><td class="mono">vanjaram.…ts.net</td><td class="n">~20</td><td class="n bad">1</td><td class="n">20</td><td class="bad">failed</td></tr>
+<tr><td class="mono">nix-infra@rasam.…</td><td class="n">~7</td><td class="n bad">1</td><td class="n">20</td><td class="bad">failed</td></tr>
+</table>
+<p class="sub">¹ agent printed <code>drishti-agent: os=…</code> + <code>serving surface over stdio</code> (counted on the bare-name hosts where the grep is exact). ² <code>first RPC received — link is live</code>. Bridge-wide: <span class="mono">5</span> <code>marking connected</code> total, <span class="mono">16</span> stream-errors (one death-wave of 4 remotes × 4 pumps), then <strong>silence</strong> for ~3h while agents kept respawning.</p>
+
+<p><strong>Read that table again:</strong> sincereintent booted a fresh agent <strong>20 times</strong> and got the first RPC across exactly <strong>once</strong>. The remote side is healthy on every single attempt. Only the parent's first attempt ever completes the handshake. <code>localhost</code> survives purely because its local-stdio link never drops, so it never needs a reconnect.</p>
+
+<h2>The mechanism</h2>
+<table class="seq">
+<tr><th>step</th><th>what happens</th><th>where</th></tr>
+<tr><td>1</td><td>First connect succeeds — bridge issues <code>system.get</code>, agent answers, <code>markConnected()</code>.</td><td class="cite">router.ts <code>pumpSystemCell</code></td></tr>
+<tr><td>2</td><td>ssh link drops (<code class="bad">agent exited code=255</code> — ssh's connection-lost code; <span class="mono">8</span>× in this process, consistent with <code>ServerAliveInterval=10</code> × default CountMax 3 ≈ 30 s tolerance on a laggy tailscale path).</td><td class="cite">host.ts <code>buildAgentCommand</code></td></tr>
+<tr><td>3</td><td>The <em>session's</em> reconnect loop re-provisions and respawns the agent on backoff — <strong>this part works</strong>, every time (copy→realise→<code>serving surface over stdio</code>).</td><td class="cite">hostSession.ts <code>scheduleReconnect</code>/<code>spawn</code></td></tr>
+<tr><td>4</td><td><span class="bad">BUG:</span> the <em>bridge's</em> pumps never re-subscribe against the respawned agent. No new <code>marking connected</code>, no new stream-error — the bridge goes silent. The new agent sits idle on stdin.</td><td class="cite">router.ts <code>bridgeAgentToParent</code> + kolu <code>waitForNextClient</code></td></tr>
+<tr><td>5</td><td>kolu's 30 s connect-watchdog finds the child alive but no first RPC → <code>SIGTERM</code> → <code>connect handshake timed out … (transport up, no first RPC)</code>.</td><td class="cite">hostSession.ts <code>spawn</code> watchdog</td></tr>
+<tr><td>6</td><td>5 consecutive strikes → terminal <span class="bad mono">failed</span> (with the generic <em>"often: trusted-users…"</em> hint — a <strong>red herring</strong> here).</td><td class="cite">hostSession.ts <code>MAX_CONSECUTIVE_FAILURES</code></td></tr>
+</table>
+
+<p>So "I can ssh fine" is fully consistent with the symptom: ssh, the closure, and the agent are all healthy. What's broken is the parent's in-process handoff from "the agent respawned" to "re-issue the subscription on the new client." <code>CONNECT_TIMEOUT_MS = 30_000</code> (<span class="cite">hostRegistry.ts ~:40</span>) is doing its job — raising it would only delay each kill, not deliver the missing RPC.</p>
+
+<h2>What the logs can't tell us yet — and why we need richer logging</h2>
+<p>Two things blind the diagnosis from here, both fixable:</p>
+<ul>
+<li><strong>The <code>[bridge]</code> prefix carries no host tag.</strong> All five hosts' bridge loops write a flat <code>[bridge] …</code> (<span class="cite">router.ts <code>log()</code> ~:264</span>), so their lines interleave indistinguishably. kolu already tags its own lines <code>[host:X local|remote]</code> — drishti's bridge breaks that symmetry.</li>
+<li><strong>No timestamps anywhere.</strong> Can't measure the 30 s boundary, can't tell a <em>slow first-snapshot</em> apart from a <em>never-sent subscription</em>, can't correlate the ssh drop with the respawn.</li>
+</ul>
+<p>With those two gaps closed, the next production log will say outright which of the two handoff failure modes is biting (bridge latches a stale/dead client vs. <code>system.get</code> on the new client hangs without erroring).</p>
+
+<div class="panel" style="border-left:3px solid var(--green)">
+<p style="margin-top:0"><strong>Merge note (PR #33, kolu <span class="mono">9f2a9e6 → 9b0128d</span>):</strong> the diagnosis is unchanged. <code>waitForNextClient.ts</code> is byte-identical across the bump, and <code>hostSession.ts</code>'s spawn / reconnect / 30 s-watchdog logic is untouched — the only diff defers <code>.drv</code> resolution into the spawn cycle (the pool key dropped from <code>(host, drvPath, binary)</code> to <code>(host, binary)</code>, <code>buildEntry</code> is now sync). The reconnect-handoff gap stands.</p>
+</div>
+
+<h2>"Isn't it time for a real logging library?" — No.</h2>
+<p>I came into this leaning toward <code>pino</code> (child loggers for per-host context, free timestamps/levels/JSON). Both reviewers pushed back, independently and convincingly, and I've reversed. Here's the honest reasoning, because the instinct is reasonable but wrong <em>for this codebase</em>:</p>
+<ul>
+<li><strong>The problem is fragmentation, not feature-poverty.</strong> There aren't "no features" — there are <strong>five</strong> hand-rolled one-line writers, each with its own ad-hoc bracket prefix: <code>[server]</code> (<span class="cite">main.ts:39</span>), <code>[hosts]</code> (<span class="cite">hostsStore.ts:41</span>), <code>[bridge]</code> (<span class="cite">router.ts:265</span>), <code>[admin]</code> (<span class="cite">admin-router.ts:77</span>), and an unprefixed one in the agent (<span class="cite">agent/main.ts:53</span>). That's <em>one</em> concept split five ways. The fix is to stop splitting it — a 3-line factory — not to import a framework.</li>
+<li><strong>pino's structure answers no consumer drishti has.</strong> Logs are read in a journal / tmux pane, not an aggregation pipeline. JSON-in-a-terminal would itself need a prettifier (another dep) to be readable. The project's whole ethos is zero-runtime-dep, npins, "zero config" — a logging dependency is a poor trade when the only structurally-useful pino feature (<code>child({host})</code> context) is reproducible in one closure.</li>
+<li><strong>A library wouldn't even cover the lines that matter.</strong> kolu writes its <code>[host:X local|remote]</code> lines straight to <code>process.stderr</code>; no logger you add to drishti restructures those. Timestamps — the one thing you genuinely lack — have to come from the <em>sink</em>, not the writer (below). A logger in drishti would produce a JSON/plaintext <em>mixed</em> stream, strictly worse to read than uniform plaintext.</li>
+</ul>
+<p><strong>Verdict:</strong> a tiny <code>makeLogger(tag)</code> factory + per-host context + sink-level timestamps gets everything a library would give that drishti can actually use, at zero dependency cost. The plan below is the post-review shape.</p>
+
+<h2>The actual plan to deploy <span class="sub">(reviewed — Lowy + Hickey)</span></h2>
+<p>All drishti-side; <strong>no edits to the pinned kolu library.</strong></p>
+
+<h3>1 · One <code>makeLogger(tag)</code> factory, host-scoped at the bridge</h3>
+<p>New <code>server/log.ts</code>: <code>makeLogger(tag) =&gt; (line) =&gt; process.stderr.write(`[${tag}] ${line}\n`)</code>. Replace all five writers — including the two <em>inline</em> <code>process.stderr.write</code> sites a naive swap would miss: <span class="cite">hostsStore.ts:41/:48</span> and <span class="cite">admin-router.ts:77</span> (both load-bearing error paths — corrupt hosts-file, failed host-removal). Then the load-bearing fix: <code>buildRouter</code> builds <code>makeLogger(`bridge:${host}`)</code> and threads the <em>logger</em> (not the raw host) into <code>bridgeAgentToParent</code> + the four pumps — which already accept a <code>log</code> param (<span class="cite">router.ts ~:322/:339</span>), so internals don't change. <code>host</code> is already at the call site (<span class="cite">hostRegistry.ts buildEntry</span>). This is the same per-host attribution <code>child({host})</code> would give, minus the dependency — and it fixes the real <code>[bridge]</code>-interleaving bug, not just cosmetics.</p>
+
+<h3>2 · Timestamps at the sink — covers kolu too</h3>
+<p>A timestamp is a property of <em>when a line hits the sink</em>, so the factory deliberately does <strong>not</strong> stamp (that would miss kolu's own <code>[host:X]</code> writes and the forwarded agent lines). Time the unified stream once:</p>
+<ul>
+<li><strong>linux:</strong> free — journald already stamps (<code>journalctl --user -u drishti</code>).</li>
+<li><strong>darwin (your prod):</strong> pipe stderr through <code>moreutils ts '%FT%T.'</code> in <span class="cite">nix/home/module.nix:99</span> (<code>StandardErrorPath</code>). No code, no global monkeypatch, covers drishti + kolu + forwarded-agent lines uniformly.</li>
+</ul>
+<p class="sub">Reviewers split on whether to also re-emit kolu's structured <code>onState</code> data (connection/lastError/progressLines, already consumed at <span class="cite">router.ts:183</span>) through drishti's logger. Resolution: <strong>don't</strong> — kolu's stderr already carries that content; re-logging it would double every line and invent a "cell and stderr must agree" invariant. Consume the cell for the UI (as today); leave logging to kolu's own stderr + the sink timestamp. No kolu <code>onLog</code> upstream needed.</p>
+
+<h3>3 · Instrument the reconnect handoff — in drishti's pump (the real point)</h3>
+<p>The blind spot is the gap between "pumps started" and "first snapshot" inside <code>pumpSystemCell</code> (<span class="cite">router.ts</span>): if the subscription never fires, nothing logs. On the now-host-tagged bridge logger, add:</p>
+<ul>
+<li>a per-spawn <strong>client sequence id</strong> at <code>agent client ready; starting pumps</code>;</li>
+<li><code>issuing system.get subscription (client #N)</code> immediately before the <code>for await … client.surface.system.get({})</code>;</li>
+<li>elapsed-ms-to-first-yield in the existing <code>n === 1</code> branch.</li>
+</ul>
+<p>If <code>#N</code> climbs but "issuing" never reaches a yield → the subscription hangs on the new client; if "issuing" never logs for <code>#N&gt;1</code> → the bridge never got the new client. Either way the next log pins which line to fix.</p>
+
+<h3>4 · Agent-side liveness <span class="sub">(optional, confirms the idle-wait)</span></h3>
+<p>In <span class="cite">agent/main.ts</span>: pid in <code>first RPC received</code>, and a <code>waiting for first RPC (Ns)…</code> heartbeat while <code>serveOverStdio</code> blocks on stdin. A respawned agent ticking to ~30 s with no RPC <em>is</em> the proof from the remote end.</p>
+
+<h3>What the enriched log will look like</h3>
+<div class="two">
+<div class="panel"><div class="sub" style="margin-bottom:6px">today <span class="tag tagdrishti">drishti</span> <span class="tag tagkolu">kolu</span></div>
+<pre><span class="t"></span><span class="h">[bridge]</span> agent client ready; starting pumps
+<span class="h">[bridge]</span> pumps ended (link likely died)
+<span class="h">[bridge]</span> agent client ready; starting pumps
+[host:sincereintent remote] serving surface over stdio
+[host:sincereintent local] connect handshake
+  timed out after 30000ms</pre>
+<p class="sub" style="margin:6px 0 0">5 hosts interleaved, untaggable, untimed — can't tell which bridge stalled or for how long.</p>
+</div>
+<div class="panel"><div class="sub" style="margin-bottom:6px">enriched</div>
+<pre><span class="t">19:01:42.118</span> [bridge:sincereintent]
+  agent client ready (client #7); starting pumps
+<span class="t">19:01:42.119</span> [bridge:sincereintent]
+  issuing system.get subscription (client #7)
+<span class="t">19:01:44.301</span> [host:sincereintent remote]
+  serving surface over stdio (pid=12118)
+<span class="t">19:01:54.300</span> [host:sincereintent remote]
+  waiting for first RPC (10s)…
+<span class="t">19:02:12.120</span> [bridge:sincereintent]
+  ⚠ system.get for client #7 never yielded (30000ms)</pre>
+<p class="sub" style="margin:6px 0 0">Now the stalled bridge, its client id, and the agent's idle wait are all visible and correlated.</p>
+</div>
+</div>
+
+<h2>Bottom line</h2>
+<p>The three hosts aren't failing to <em>connect</em> — they connect once, then the parent's reconnect bridge fails to re-subscribe after the first ssh blip, and the watchdog reaps the idle agents. The fix lives in <code>bridgeAgentToParent</code>/<code>pumpSystemCell</code> (and possibly kolu's <code>waitForNextClient</code> handoff), but ship the <strong>logging enrichment first</strong> — items 1–3 are ~an hour, touch only drishti, and the next production log tells us exactly which handoff line to fix instead of guessing.</p>
+<p class="sub">When you want this implemented, run <span class="kbd">/do</span> — this is talk mode, so nothing here has been changed.</p>
+
+</body>
+</html>

--- a/packages/app/src/agent/main.ts
+++ b/packages/app/src/agent/main.ts
@@ -286,11 +286,26 @@ async function main(): Promise<void> {
   const router = implement(surface.contract).router({ ...fragment.router });
 
   log("serving surface over stdio (read=stdin, write=stdout)");
+  // Heartbeat while blocked on the first request. A healthy connect
+  // roundtrips sub-second; if this keeps ticking up to ~30s the parent's
+  // connect watchdog is about to kill us — and these lines (forwarded to
+  // the parent's log) show the agent was alive and waiting the whole time,
+  // pinning the stall on the parent→agent handshake rather than the remote.
+  const servingSince = Date.now();
+  const waitingHeartbeat = setInterval(() => {
+    log(
+      `waiting for first RPC (${Math.round((Date.now() - servingSince) / 1000)}s)…`,
+    );
+  }, 5000);
   await serveOverStdio({
     // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
     router: router as any,
-    onFirstRequest: () => log("first RPC received — link is live"),
+    onFirstRequest: () => {
+      clearInterval(waitingHeartbeat);
+      log(`first RPC received — link is live (pid=${process.pid})`);
+    },
   });
+  clearInterval(waitingHeartbeat);
   clearInterval(interval);
   log("stdin closed — agent exiting");
 }

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -21,6 +21,9 @@ import {
 } from "@kolu/surface/server";
 import { adminSurface } from "../common/admin-surface";
 import type { HostRegistry } from "./hostRegistry";
+import { makeLogger } from "./log";
+
+const log = makeLogger("admin");
 
 export interface AdminRouterOptions {
   registry: HostRegistry;
@@ -74,9 +77,7 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
             // then is the subscriber notified the host has gone.
             await opts.registry.remove(input.host);
           } catch (err) {
-            process.stderr.write(
-              `[admin] remove ${input.host} failed: ${(err as Error).message}\n`,
-            );
+            log(`remove ${input.host} failed: ${(err as Error).message}`);
             return { ok: false };
           }
           fragment.ctx.collections.hosts.remove(input.host);

--- a/packages/app/src/server/build.ts
+++ b/packages/app/src/server/build.ts
@@ -65,7 +65,7 @@ export async function buildClient(distDir: string): Promise<void> {
     plugins: [solidJsxPlugin],
   });
   if (!jsResult.success) {
-    for (const m of jsResult.logs) log(String(m));
+    for (const m of jsResult.logs) log(m.message);
     throw new Error("Bun.build failed for client");
   }
 

--- a/packages/app/src/server/build.ts
+++ b/packages/app/src/server/build.ts
@@ -20,6 +20,9 @@ import babelTypeScript from "@babel/preset-typescript";
 // @ts-expect-error - babel preset types are loose
 import babelSolid from "babel-preset-solid";
 import type { BunPlugin } from "bun";
+import { makeLogger } from "./log";
+
+const log = makeLogger("build");
 
 // Solid JSX transform. babel-preset-solid emits the compiled-template
 // runtime (template/insert/createComponent) so signals drive DOM updates;
@@ -62,7 +65,7 @@ export async function buildClient(distDir: string): Promise<void> {
     plugins: [solidJsxPlugin],
   });
   if (!jsResult.success) {
-    for (const m of jsResult.logs) console.error(m);
+    for (const m of jsResult.logs) log(String(m));
     throw new Error("Bun.build failed for client");
   }
 
@@ -121,7 +124,7 @@ export async function buildClient(distDir: string): Promise<void> {
 if (import.meta.main) {
   const distDir = process.argv[2];
   if (!distDir) {
-    console.error("usage: bun src/server/build.ts <distDir>");
+    log("usage: bun src/server/build.ts <distDir>");
     process.exit(1);
   }
   await buildClient(resolve(distDir));

--- a/packages/app/src/server/hostRegistry.ts
+++ b/packages/app/src/server/hostRegistry.ts
@@ -28,7 +28,13 @@ import type { WebSocket as WsConn } from "ws";
 import type { HostEntry } from "../common/admin-surface";
 import type { surface } from "../common/surface";
 import { saveHosts } from "./hostsStore";
+import { makeLogger } from "./log";
 import { buildRouter } from "./router";
+
+// Registry lifecycle events (host added/removed) get their own tag, like
+// every other subsystem — so they can be filtered out of the combined
+// stderr stream without the caller threading a logger in.
+const log = makeLogger("registry");
 
 // The parent's connect-handshake watchdog budget, passed explicitly to
 // every session. Must stay well under the browser socket's own deadline
@@ -79,7 +85,6 @@ export interface HostRegistryOptions {
    *  the resolved path per host. */
   resolveDrvPath: (host: string) => Promise<string>;
   hostsFile: string;
-  log: (line: string) => void;
 }
 
 export async function buildHostRegistry(
@@ -133,7 +138,7 @@ export async function buildHostRegistry(
       }
       entries.set(host, buildEntry(host));
       await saveHosts(opts.hostsFile, [...entries.keys()]);
-      opts.log(`added host: ${host} (total ${entries.size})`);
+      log(`added host: ${host} (total ${entries.size})`);
     },
 
     async remove(host) {
@@ -153,7 +158,7 @@ export async function buildHostRegistry(
       entry.session.destroy();
       entries.delete(host);
       await saveHosts(opts.hostsFile, [...entries.keys()]);
-      opts.log(`removed host: ${host} (total ${entries.size})`);
+      log(`removed host: ${host} (total ${entries.size})`);
     },
 
     reconnect(host) {

--- a/packages/app/src/server/hostRegistry.ts
+++ b/packages/app/src/server/hostRegistry.ts
@@ -102,7 +102,7 @@ export async function buildHostRegistry(
       binary: "drishti-agent",
       connectTimeoutMs: CONNECT_TIMEOUT_MS,
     });
-    const { router } = buildRouter({ session });
+    const { router } = buildRouter({ host, session });
     // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
     const handler = new RPCHandler(router as any);
     return { session, handler };

--- a/packages/app/src/server/hostsStore.ts
+++ b/packages/app/src/server/hostsStore.ts
@@ -20,6 +20,9 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { makeLogger } from "./log";
+
+const log = makeLogger("hosts");
 
 export function resolveHostsFile(): string {
   const override = process.env.DRISHTI_HOSTS_FILE;
@@ -38,16 +41,14 @@ export async function loadHosts(file: string): Promise<string[]> {
     text = await readFile(file, "utf-8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
-    process.stderr.write(`[hosts] read failed: ${(err as Error).message}\n`);
+    log(`read failed: ${(err as Error).message}`);
     return [];
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch (err) {
-    process.stderr.write(
-      `[hosts] malformed JSON in ${file}: ${(err as Error).message}\n`,
-    );
+    log(`malformed JSON in ${file}: ${(err as Error).message}`);
     return [];
   }
   if (

--- a/packages/app/src/server/log.test.ts
+++ b/packages/app/src/server/log.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { installStderrTimestamps, makeLogger } from "./log";
+
+/** Run `fn` with `process.stderr.write` swapped for a capturing stub,
+ *  always restoring the original — `installStderrTimestamps` mutates the
+ *  global, so a leak would corrupt every later test's stderr. Captures
+ *  raw chunks (string or Buffer) so the Buffer pass-through is checkable. */
+function captureStderr(fn: () => void): unknown[] {
+  const original = process.stderr.write;
+  const out: unknown[] = [];
+  process.stderr.write = ((chunk: unknown): boolean => {
+    out.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return out;
+}
+
+describe("makeLogger", () => {
+  it("prefixes the tag in brackets and terminates with a newline", () => {
+    const out = captureStderr(() => {
+      makeLogger("server")("hello");
+      makeLogger("bridge:user@host")("client #2 ready");
+    });
+    expect(out).toEqual([
+      "[server] hello\n",
+      "[bridge:user@host] client #2 ready\n",
+    ]);
+  });
+});
+
+describe("installStderrTimestamps", () => {
+  const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z /;
+
+  it("stamps a single complete line", () => {
+    const out = captureStderr(() => {
+      installStderrTimestamps();
+      process.stderr.write("[server] one\n");
+    });
+    const line = out[0] as string;
+    expect(line).toMatch(ISO);
+    expect(line).toMatch(/ \[server\] one\n$/);
+  });
+
+  it("stamps every line in a multi-line chunk but not the trailing newline", () => {
+    const out = captureStderr(() => {
+      installStderrTimestamps();
+      process.stderr.write("a\nb\n");
+    });
+    const lines = (out[0] as string).split("\n");
+    expect(lines[0]).toMatch(ISO);
+    expect(lines[0]).toContain("a");
+    expect(lines[1]).toMatch(ISO);
+    expect(lines[1]).toContain("b");
+    // The empty segment after the final "\n" must NOT get a stray stamp —
+    // otherwise a bare line ending would sprout a timestamp with no text.
+    expect(lines[2]).toBe("");
+  });
+
+  it("passes non-string (Buffer) chunks through untouched", () => {
+    const buf = Buffer.from("raw\n");
+    const out = captureStderr(() => {
+      installStderrTimestamps();
+      process.stderr.write(buf);
+    });
+    expect(out[0]).toBe(buf);
+  });
+});

--- a/packages/app/src/server/log.test.ts
+++ b/packages/app/src/server/log.test.ts
@@ -61,6 +61,18 @@ describe("installStderrTimestamps", () => {
     expect(lines[2]).toBe("");
   });
 
+  it("is idempotent — a second install does not double-stamp", () => {
+    const out = captureStderr(() => {
+      installStderrTimestamps();
+      installStderrTimestamps();
+      process.stderr.write("[server] once\n");
+    });
+    const line = out[0] as string;
+    // Exactly one ISO timestamp at the start, not two nested ones.
+    expect(line).toMatch(ISO);
+    expect(line.replace(ISO, "")).toBe("[server] once\n");
+  });
+
   it("passes non-string (Buffer) chunks through untouched", () => {
     const buf = Buffer.from("raw\n");
     const out = captureStderr(() => {

--- a/packages/app/src/server/log.ts
+++ b/packages/app/src/server/log.ts
@@ -1,0 +1,55 @@
+/**
+ * Parent-server logging primitives.
+ *
+ * One concept — "write a tagged diagnostic line to stderr" — that the
+ * server used to hand-roll five separate ways (`[server]`, `[hosts]`,
+ * `[bridge]`, `[admin]`, …). `makeLogger(tag)` is the single factory;
+ * every caller closes over its own tag. The bridge builds a *per-host*
+ * tag (`bridge:${host}`) so the five concurrent per-host bridge loops
+ * stop interleaving into one indistinguishable `[bridge]` stream.
+ *
+ * Timestamps are deliberately NOT added here. They are a property of
+ * *when a line reaches the sink*, not of each writer — and prefixing
+ * per-writer would miss the lines drishti does not own: `@kolu/surface-
+ * nix-host` writes its `[host:X local|remote]` progress straight to
+ * `process.stderr`, and the remote agent's stderr arrives the same way
+ * (kolu forwards it). `installStderrTimestamps` stamps the unified
+ * stream once, at the single fd every writer shares, so kolu's lines and
+ * the forwarded agent lines get the same treatment as drishti's own.
+ */
+
+export type Logger = (line: string) => void;
+
+/** Build a logger that prefixes every line with `[tag] ` and writes it
+ *  to stderr. The tag carries the subsystem identity (`server`,
+ *  `hosts`, `admin`) or, for the bridge, the per-host discriminator
+ *  (`bridge:user@host`) that lets multi-host logs be told apart. */
+export function makeLogger(tag: string): Logger {
+  return (line: string): void => {
+    process.stderr.write(`[${tag}] ${line}\n`);
+  };
+}
+
+/** Wrap `process.stderr.write` once so every line — drishti's own,
+ *  kolu's direct writes, and the remote agent's forwarded stderr —
+ *  carries an ISO-8601 millisecond timestamp. Installed once at parent
+ *  boot.
+ *
+ *  Every writer in this process emits one complete `\n`-terminated line
+ *  per call, so stamping at each line start within the chunk is exact;
+ *  the `(?=.)` guard skips the empty segment after a trailing newline so
+ *  a lone `\n` isn't given a stray timestamp. Idempotent in effect only
+ *  if called once — call it before any other logging. */
+export function installStderrTimestamps(): void {
+  const original = process.stderr.write.bind(process.stderr);
+  // biome-ignore lint/suspicious/noExplicitAny: matching Node's overloaded write() signature, which we forward verbatim.
+  process.stderr.write = ((chunk: any, ...rest: any[]): boolean => {
+    if (typeof chunk === "string") {
+      const stamped = chunk.replace(/^(?=.)/gm, `${new Date().toISOString()} `);
+      // biome-ignore lint/suspicious/noExplicitAny: forwarding the original variadic (encoding?, cb?) tail unchanged.
+      return original(stamped, ...(rest as [any]));
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: non-string (Buffer) chunks pass through unstamped — no writer uses them.
+    return original(chunk, ...(rest as [any]));
+  }) as typeof process.stderr.write;
+}

--- a/packages/app/src/server/log.ts
+++ b/packages/app/src/server/log.ts
@@ -38,12 +38,22 @@ export function makeLogger(tag: string): Logger {
  *  Every writer in this process emits one complete `\n`-terminated line
  *  per call, so stamping at each line start within the chunk is exact;
  *  the `(?=.)` guard skips the empty segment after a trailing newline so
- *  a lone `\n` isn't given a stray timestamp. Idempotent in effect only
- *  if called once — call it before any other logging. */
+ *  a lone `\n` isn't given a stray timestamp.
+ *
+ *  Idempotent by construction: the marker below is stamped onto the
+ *  installed wrapper, so a second call (or a re-imported module) returns
+ *  early instead of wrapping the already-wrapped `write` — which would
+ *  nest a second stamping pass and double-prefix every line. */
+const STDERR_TIMESTAMPED = Symbol("drishti.stderr.timestamped");
+type MarkedWrite = typeof process.stderr.write & {
+  [STDERR_TIMESTAMPED]?: true;
+};
+
 export function installStderrTimestamps(): void {
+  if ((process.stderr.write as MarkedWrite)[STDERR_TIMESTAMPED]) return;
   const original = process.stderr.write.bind(process.stderr);
   // biome-ignore lint/suspicious/noExplicitAny: matching Node's overloaded write() signature, which we forward verbatim.
-  process.stderr.write = ((chunk: any, ...rest: any[]): boolean => {
+  const wrapper = ((chunk: any, ...rest: any[]): boolean => {
     if (typeof chunk === "string") {
       const stamped = chunk.replace(/^(?=.)/gm, `${new Date().toISOString()} `);
       // biome-ignore lint/suspicious/noExplicitAny: forwarding the original variadic (encoding?, cb?) tail unchanged.
@@ -51,5 +61,7 @@ export function installStderrTimestamps(): void {
     }
     // biome-ignore lint/suspicious/noExplicitAny: non-string (Buffer) chunks pass through unstamped — no writer uses them.
     return original(chunk, ...(rest as [any]));
-  }) as typeof process.stderr.write;
+  }) as MarkedWrite;
+  wrapper[STDERR_TIMESTAMPED] = true;
+  process.stderr.write = wrapper;
 }

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -100,7 +100,6 @@ async function main(): Promise<void> {
     initialHosts,
     resolveDrvPath,
     hostsFile,
-    log,
   });
 
   const admin = buildAdminRouter({ registry });

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -34,10 +34,14 @@ import { resolveDrvForHost } from "./archMap";
 import { buildClient } from "./build";
 import { buildHostRegistry } from "./hostRegistry";
 import { loadHosts, resolveHostsFile, saveHosts } from "./hostsStore";
+import { installStderrTimestamps, makeLogger } from "./log";
 
-function log(line: string): void {
-  process.stderr.write(`[server] ${line}\n`);
-}
+// Stamp every stderr line (drishti's, kolu's, and the forwarded remote
+// agent's) with a timestamp before anything logs — the connection
+// diagnostics are unreadable without a timeline.
+installStderrTimestamps();
+
+const log = makeLogger("server");
 
 const argv = cli({
   name: "drishti",
@@ -246,6 +250,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  process.stderr.write(`[server] fatal: ${(err as Error).message}\n`);
+  log(`fatal: ${(err as Error).message}`);
   process.exit(1);
 });

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -54,10 +54,15 @@ import {
   HISTORY_RETENTION_MS,
   pushSample,
 } from "../common/history";
+import { type Logger, makeLogger } from "./log";
 
 type DrishtiAgent = AgentClient<typeof surface.contract>;
 
 export interface BuildRouterOptions {
+  /** The host this router bridges — used only to tag the bridge's log
+   *  lines (`bridge:${host}`). `HostSession` keeps its `host` private,
+   *  so the registry (which has it) passes it in explicitly. */
+  host: string;
   session: HostSession<typeof surface.contract>;
 }
 
@@ -66,6 +71,11 @@ export interface BuildRouterOptions {
  *  flows through once the link is live. */
 export function buildRouter(opts: BuildRouterOptions) {
   const session = opts.session;
+  // Per-host bridge logger. One `buildRouter` runs per host, so a tag
+  // built from `host` here gives every bridge line a host discriminator —
+  // without it, the N concurrent per-host bridge loops all wrote a flat
+  // `[bridge]` and interleaved into one unattributable stream.
+  const log = makeLogger(`bridge:${opts.host}`);
   const systemStore: CellStore<SystemInfo> = inMemoryStore({
     ...DEFAULT_SYSTEM,
   });
@@ -214,6 +224,7 @@ export function buildRouter(opts: BuildRouterOptions) {
   // *new* client. The outer loop is what implements "reconnect → state
   // reconciles, no ghosts".
   void bridgeAgentToParent(
+    log,
     session,
     fragment,
     processCache,
@@ -261,15 +272,19 @@ type FragmentCtx = {
   };
 };
 
-function log(line: string): void {
-  process.stderr.write(`[bridge] ${line}\n`);
-}
-
 /** Pin the session, then loop: fetch the current AgentClient, run all
  *  pumps against it concurrently, wait for them to end (which happens
  *  when the link errors — stdio process death), then wait for the
- *  session to provide a fresh client (post-reconnect) and repeat. */
+ *  session to provide a fresh client (post-reconnect) and repeat.
+ *
+ *  Each loop iteration owns one client — a fresh ssh subprocess. The
+ *  `clientSeq` counter labels them (`#1`, `#2`, …) so the otherwise
+ *  identical per-reconnect log lines can be traced to a specific spawn:
+ *  if `system.get` against `#2` never yields while the agent on the far
+ *  end logged `serving surface over stdio`, the handoff — not the remote
+ *  — is where a stuck reconnect lives. */
 async function bridgeAgentToParent(
+  log: Logger,
   session: HostSession<typeof surface.contract>,
   fragment: FragmentCtx,
   processCache: Map<Pid, Process>,
@@ -285,6 +300,7 @@ async function bridgeAgentToParent(
   });
 
   let lastClient: DrishtiAgent | null = null;
+  let clientSeq = 0;
   while (!session.isDestroyed()) {
     let client: DrishtiAgent;
     try {
@@ -294,14 +310,23 @@ async function bridgeAgentToParent(
       break;
     }
     lastClient = client;
-    log("agent client ready; starting pumps");
+    clientSeq += 1;
+    log(`agent client ready (client #${clientSeq}); starting pumps`);
     await Promise.allSettled([
-      pumpSystemCell(client, session, fragment, recordSample),
-      pumpProcessesSnapshot(client, fragment, processCache, browserSnapshotBus),
-      pumpCpuCores(client, fragment),
-      pumpNetworkInterfaces(client, fragment),
+      pumpSystemCell(log, clientSeq, client, session, fragment, recordSample),
+      pumpProcessesSnapshot(
+        log,
+        client,
+        fragment,
+        processCache,
+        browserSnapshotBus,
+      ),
+      pumpCpuCores(log, client, fragment),
+      pumpNetworkInterfaces(log, client, fragment),
     ]);
-    log("bridge: pumps ended (link likely died) — awaiting next client");
+    log(
+      `bridge: pumps ended for client #${clientSeq} (link likely died) — awaiting next client`,
+    );
   }
   log("bridge: session destroyed — exiting reconnect loop");
 }
@@ -309,6 +334,7 @@ async function bridgeAgentToParent(
 /** Mirror the agent's `cpuCores` collection — small-N showcase of
  *  `mirrorRemoteCollection`. */
 function pumpCpuCores(
+  log: Logger,
   client: DrishtiAgent,
   fragment: FragmentCtx,
 ): Promise<void> {
@@ -331,6 +357,7 @@ function pumpCpuCores(
 /** Mirror the agent's `networkInterfaces` collection — same
  *  `mirrorRemoteCollection` shape as cpuCores, keyed by NIC name. */
 function pumpNetworkInterfaces(
+  log: Logger,
   client: DrishtiAgent,
   fragment: FragmentCtx,
 ): Promise<void> {
@@ -350,27 +377,44 @@ function pumpNetworkInterfaces(
   });
 }
 
-/** Mirror the agent's system cell into the parent's local cell. */
+/** Mirror the agent's system cell into the parent's local cell. The
+ *  `system.get` subscription is also the connection handshake: its first
+ *  yield is what flips the session to `connected`. So the two log lines
+ *  bracketing the `for await` — "issuing" before, elapsed-to-first-yield
+ *  on `n === 1` — are the parent-side view of the handshake. A reconnect
+ *  that logs "issuing … (client #N)" but never reaches the first yield is
+ *  a subscription that never roundtripped on the new client, distinct
+ *  from one where the bridge never got a new client to issue against. */
 async function pumpSystemCell(
+  log: Logger,
+  clientSeq: number,
   client: DrishtiAgent,
   session: HostSession<typeof surface.contract>,
   fragment: FragmentCtx,
   recordSample: (system: SystemInfo) => void,
 ): Promise<void> {
   let n = 0;
+  const issuedAt = Date.now();
+  log(`system: issuing system.get subscription (client #${clientSeq})`);
   try {
     for await (const remoteSystem of await client.surface.system.get({})) {
       n += 1;
-      if (n === 1) log("system: first snapshot → marking connected");
+      if (n === 1) {
+        log(
+          `system: first snapshot → marking connected (client #${clientSeq}, ${Date.now() - issuedAt}ms to first RPC)`,
+        );
+      }
       session.markConnected();
       fragment.ctx.cells.system.set(remoteSystem);
       // One history sample per system tick — the parent's authoritative
       // sampling point (it sees every tick, browser or not).
       recordSample(remoteSystem);
     }
-    log(`system: stream closed cleanly after ${n} yields`);
+    log(`system: stream closed cleanly after ${n} yields (client #${clientSeq})`);
   } catch (err) {
-    log(`system: stream error after ${n} yields: ${(err as Error).message}`);
+    log(
+      `system: stream error after ${n} yields (client #${clientSeq}): ${(err as Error).message}`,
+    );
   }
 }
 
@@ -386,6 +430,7 @@ async function pumpSystemCell(
  *  one-row-at-a-time fill). With the bulk stream, cold-start is O(1)
  *  RPCs regardless of process count. */
 async function pumpProcessesSnapshot(
+  log: Logger,
   client: DrishtiAgent,
   fragment: FragmentCtx,
   processCache: Map<Pid, Process>,
@@ -395,7 +440,7 @@ async function pumpProcessesSnapshot(
   try {
     for await (const msg of await client.surface.processesSnapshot.get({})) {
       frames += 1;
-      applySnapshotMessage(msg, processCache, fragment, frames);
+      applySnapshotMessage(log, msg, processCache, fragment, frames);
       // Independent activity: re-publish to browser subscribers via
       // the parent's local bus. Verbatim forward — no inspection of
       // frame contents here; the mirror logic above is the only
@@ -415,6 +460,7 @@ async function pumpProcessesSnapshot(
  *  channels in lockstep, so there's no separate shadow set to
  *  maintain here. */
 function applySnapshotMessage(
+  log: Logger,
   msg: ProcessesSnapshotMsg,
   processCache: Map<Pid, Process>,
   fragment: FragmentCtx,


### PR DESCRIPTION
**The parent server's connection logs couldn't be read on a timeline.** There were no timestamps anywhere, and all N per-host bridge loops wrote a single, flat, interleaved `[bridge]` prefix with no host attribution — so a flapping reconnect (every host connects once, then every later reconnect's handshake times out at 30s → `failed`) was impossible to pin from the logs. This enriches the logging so the *next* production capture is diagnostic, then the underlying bridge bug can be fixed with evidence instead of a guess.

The forensic walk-through that motivated this — agent respawns cleanly every time, but the parent stops re-issuing the `system.get` subscription after the first link drop, so the 30s watchdog reaps each idle agent — is in [`docs/plans/talk-drishti-connect-failures.html`](../blob/enrich-connection-logging/docs/plans/talk-drishti-connect-failures.html).

### What the enrichment adds

- **One `makeLogger(tag)` factory** (`server/log.ts`) replacing five hand-rolled `process.stderr.write` writers (`[server]`, `[hosts]`, `[admin]`, `[bridge]`, plus inline writes). Every subsystem — including the host registry (`[registry]`) and the client bundler (`[build]`) — now carries its own tag.
- **Per-host bridge tags** — each host's bridge loop logs `[bridge:<host>]`, so the concurrent loops stop interleaving into one unattributable stream. `buildRouter` builds the tagged logger (the registry passes `host` in, since `HostSession` keeps it private).
- **Timestamps at the sink** — `installStderrTimestamps()` wraps `process.stderr.write` once at boot to ISO-stamp every line. This is the one seam that also reaches `@kolu/surface-nix-host`'s own `[host:X]` writes and the forwarded remote-agent stderr, which a per-writer prefix can't. On Linux/systemd, journald already stamps.
- **Reconnect-handoff instrumentation** (`pumpSystemCell`) — a per-spawn client sequence id, an `issuing system.get subscription (client #N)` line, and elapsed-to-first-RPC on the first yield. A subscription that never roundtrips on a new client becomes visible and distinct from "the bridge never got a new client".
- **Agent-side liveness** — pid in `first RPC received`, and a `waiting for first RPC (Ns)…` heartbeat while blocked on stdin, so a reaped idle agent proves the stall is the parent→agent handshake, not the remote.

### What a stuck reconnect now looks like

```
19:01:42.118 [bridge:sincereintent] agent client ready (client #7); starting pumps
19:01:42.119 [bridge:sincereintent] system: issuing system.get subscription (client #7)
19:01:44.301 [host:sincereintent remote] serving surface over stdio
19:01:54.301 [host:sincereintent remote] waiting for first RPC (10s)…
19:02:12.119 [host:sincereintent local] connect handshake timed out after 30000ms
```

The stalled bridge, its client id, and the agent's idle wait are all attributable and on a timeline — which the flat untimed log could not show.

> _No behavioral change to the connection lifecycle itself — this is diagnostics only. The bridge bug it surfaces is a follow-up, to be fixed against the richer log._

### Try it locally

```sh
nix run github:srid/drishti/enrich-connection-logging -- localhost
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._