### PR TITLE
Bump kolu to fix the reconnect-handoff wedge

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "fix-reconnect-busy-spin",
+      "branch": "master",
       "submodules": false,
-      "revision": "0c762b8c99f3e7c656bc7bd8eaa7092eb26ff442",
-      "url": "https://github.com/juspay/kolu/archive/0c762b8c99f3e7c656bc7bd8eaa7092eb26ff442.tar.gz",
-      "hash": "sha256-O83tCnpJrZRIq3oXI+Xbef6bYH451UA2YaV6yn5a8xQ="
+      "revision": "65724c76b23bba632da5e30674984fac4c0b5cfe",
+      "url": "https://github.com/juspay/kolu/archive/65724c76b23bba632da5e30674984fac4c0b5cfe.tar.gz",
+      "hash": "sha256-73Vh0Ju3N+o3C6TLAgmQ2VX5fUG+kBV0fBezLrE3u1M="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "9b0128d2fc6bd485b9ab8af1e7851003b0f3e9dd",
-      "url": "https://github.com/juspay/kolu/archive/9b0128d2fc6bd485b9ab8af1e7851003b0f3e9dd.tar.gz",
-      "hash": "sha256-W9pXbI4xi/eGrFMHMm2Uzt/VV53FC2NvcXNMyuvG4co="
+      "revision": "82d3a0f9c35d5ac27231d4d174fe0a234c4d53f2",
+      "url": "https://github.com/juspay/kolu/archive/82d3a0f9c35d5ac27231d4d174fe0a234c4d53f2.tar.gz",
+      "hash": "sha256-o9rTR7wLXvDJIGD/9DhAxmSVIn7dDU3I5zk2bWHyK1A="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "fix-reconnect-busy-spin",
       "submodules": false,
-      "revision": "82d3a0f9c35d5ac27231d4d174fe0a234c4d53f2",
-      "url": "https://github.com/juspay/kolu/archive/82d3a0f9c35d5ac27231d4d174fe0a234c4d53f2.tar.gz",
-      "hash": "sha256-o9rTR7wLXvDJIGD/9DhAxmSVIn7dDU3I5zk2bWHyK1A="
+      "revision": "5516571b686f25ea3a110546829729149071cd74",
+      "url": "https://github.com/juspay/kolu/archive/5516571b686f25ea3a110546829729149071cd74.tar.gz",
+      "hash": "sha256-Vtwkp/v6VScR0YnRZSueEca4ORQXO9utNNAQWvRQ0pE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "fix-reconnect-busy-spin",
       "submodules": false,
-      "revision": "5516571b686f25ea3a110546829729149071cd74",
-      "url": "https://github.com/juspay/kolu/archive/5516571b686f25ea3a110546829729149071cd74.tar.gz",
-      "hash": "sha256-Vtwkp/v6VScR0YnRZSueEca4ORQXO9utNNAQWvRQ0pE="
+      "revision": "0c762b8c99f3e7c656bc7bd8eaa7092eb26ff442",
+      "url": "https://github.com/juspay/kolu/archive/0c762b8c99f3e7c656bc7bd8eaa7092eb26ff442.tar.gz",
+      "hash": "sha256-O83tCnpJrZRIq3oXI+Xbef6bYH451UA2YaV6yn5a8xQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -11,8 +11,7 @@
  * from the admin collection so the cache doesn't leak.
  */
 
-import type { ClientRetryPluginContext } from "@orpc/client/plugins";
-import type { ContractRouterClient } from "@orpc/contract";
+import { websocketLink } from "@kolu/surface/links/websocket";
 import { surfaceClient } from "@kolu/surface/solid";
 import { WebSocket as PartySocket } from "partysocket";
 import { ADMIN_HOST_SENTINEL, adminSurface } from "../common/admin-surface";
@@ -41,19 +40,19 @@ type AdminClient = ReturnType<typeof buildAdminSurface>;
 
 function buildHostSurface(host: string) {
   const ws = makeSocket(host);
-  const client = surfaceClient<
-    typeof surface.spec,
-    ContractRouterClient<typeof surface.contract, ClientRetryPluginContext>
-  >(surface, { websocket: ws as unknown as WebSocket });
+  const client = surfaceClient(
+    surface,
+    websocketLink<typeof surface.contract>(ws as unknown as WebSocket),
+  );
   return { ws, client };
 }
 
 function buildAdminSurface() {
   const ws = makeSocket(ADMIN_HOST_SENTINEL);
-  const client = surfaceClient<
-    typeof adminSurface.spec,
-    ContractRouterClient<typeof adminSurface.contract, ClientRetryPluginContext>
-  >(adminSurface, { websocket: ws as unknown as WebSocket });
+  const client = surfaceClient(
+    adminSurface,
+    websocketLink<typeof adminSurface.contract>(ws as unknown as WebSocket),
+  );
   return { ws, client };
 }
 

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -30,9 +30,8 @@ import {
 import {
   type AgentClient,
   type HostSession,
+  makeClientCursor,
   mirrorRemoteCollection,
-  type NextClient,
-  waitForNextClient,
 } from "@kolu/surface-nix-host";
 import {
   type ConnectionInfo,
@@ -300,21 +299,16 @@ async function bridgeAgentToParent(
     /* logged via state cell; loop handles recovery */
   });
 
-  // Thread the *clientPromise* (not the awaited client) back in — the
-  // client proxy is thenable, so comparing it by identity makes
-  // waitForNextClient resolve every iteration and busy-spin once a link
-  // fails fast. See @kolu/surface-nix-host's waitForNextClient.
-  let lastClientPromise: Promise<DrishtiAgent> | null = null;
+  // A cursor over the session's spawn lifecycle — `next()` blocks until a
+  // genuinely new spawn appears and resolves with its live client (it owns
+  // the stable-clientPromise comparison that keeps the loop from busy-
+  // spinning once a dead link fails fast).
+  const cursor = makeClientCursor(session);
   let clientSeq = 0;
   while (!session.isDestroyed()) {
     let client: DrishtiAgent;
     try {
-      const next: NextClient<typeof surface.contract> = await waitForNextClient(
-        session,
-        lastClientPromise,
-      );
-      client = next.client;
-      lastClientPromise = next.clientPromise;
+      client = await cursor.next();
     } catch (err) {
       log(`bridge: waiting for next client failed: ${(err as Error).message}`);
       break;

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -31,6 +31,7 @@ import {
   type AgentClient,
   type HostSession,
   mirrorRemoteCollection,
+  type NextClient,
   waitForNextClient,
 } from "@kolu/surface-nix-host";
 import {
@@ -299,17 +300,25 @@ async function bridgeAgentToParent(
     /* logged via state cell; loop handles recovery */
   });
 
-  let lastClient: DrishtiAgent | null = null;
+  // Thread the *clientPromise* (not the awaited client) back in — the
+  // client proxy is thenable, so comparing it by identity makes
+  // waitForNextClient resolve every iteration and busy-spin once a link
+  // fails fast. See @kolu/surface-nix-host's waitForNextClient.
+  let lastClientPromise: Promise<DrishtiAgent> | null = null;
   let clientSeq = 0;
   while (!session.isDestroyed()) {
     let client: DrishtiAgent;
     try {
-      client = await waitForNextClient(session, lastClient);
+      const next: NextClient<typeof surface.contract> = await waitForNextClient(
+        session,
+        lastClientPromise,
+      );
+      client = next.client;
+      lastClientPromise = next.clientPromise;
     } catch (err) {
       log(`bridge: waiting for next client failed: ${(err as Error).message}`);
       break;
     }
-    lastClient = client;
     clientSeq += 1;
     log(`agent client ready (client #${clientSeq}); starting pumps`);
     await Promise.allSettled([


### PR DESCRIPTION
**Picks up [juspay/kolu#1060](https://github.com/juspay/kolu/pull/1060) — "Fail stdio RPCs on a closed transport instead of hanging."** That's the fix for the production wedge this repo's enriched connection logging diagnosed and then reproduced live.

### The bug it fixes

After an ssh link drops, the parent's reconnect bridge re-issues `system.get` against the just-exited child's stdio client. The dead link neither answered nor errored, so the pump hung, `Promise.allSettled` never resolved, the reconnect loop never advanced, and **every respawned agent sat idle until the 30s connect watchdog reaped it** — 5 strikes → terminal `failed`. One transient network blip permanently downed a host.

This wasn't theoretical — the `[bridge:<host>]` / `client #N` instrumentation caught it on production:

```
04:23:23 [bridge:pureintent] stream error (client #1) — link died
04:23:23 [bridge:pureintent] agent client ready (client #2); starting pumps
04:23:23 [bridge:pureintent] issuing system.get subscription (client #2)   ◀ never a "first snapshot (client #2)"
04:23:23 [host:pureintent] agent exited (code=255)
...→ 5 attempts → failed
```

A single 04:23Z tailscale blip took **3 of 5 hosts** to terminal `failed` this way. kolu#1060 makes the dead link reject fast, so the pump errors → the loop advances → it binds the live respawned agent.

### What's in this bump

- `npins`: `@kolu/surface*` → kolu master `82d3a0f9`.
- The bump also crosses [kolu#1059](https://github.com/juspay/kolu/pull/1059)'s link-family unification, which renamed the browser client constructor. `client/wire.ts` adopts the new form:

  ```diff
  - surfaceClient(surface, { websocket: ws })
  + surfaceClient(surface, websocketLink<typeof surface.contract>(ws))
  ```

> _Verification: once deployed, the `[bridge:<host>]` logs should show a respawned agent reaching `first snapshot (client #N)` after a drop instead of stalling on `waiting for first RPC` — i.e. a dropped host recovers instead of wedging._

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._