### PR TITLE
Bump kolu to fix the realise/copy ssh hang

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "4a22dff485977e7a77095fed29a1d2e137612128",
-      "url": "https://github.com/juspay/kolu/archive/4a22dff485977e7a77095fed29a1d2e137612128.tar.gz",
-      "hash": "sha256-GxC7WuFb75+TW4mdYiM99LTtDmVryTpuX9D76bhNUGs="
+      "revision": "66be612e482fada5f240c283f67a8a532fd6cf1d",
+      "url": "https://github.com/juspay/kolu/archive/66be612e482fada5f240c283f67a8a532fd6cf1d.tar.gz",
+      "hash": "sha256-ask5FsVwInCdPOER8p+Syaso8O6Kk0w1rFIbCXRaLsg="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Follows #37. Picks up [juspay/kolu#1071](https://github.com/juspay/kolu/pull/1071), the fix for the wedge diagnosed this round.

## What it fixes

A host (`vanjaram`) sat stuck on **"Copying agent to remote…" for hours**. The copy had finished — what hung was the *next* step, the remote realise. The host **pinged fine** (0% loss via tailscale) but **refused new TCP/22**, and the in-flight `ssh … nix-store --realise` — spawned before the degradation — sat parked on a half-open socket using 0.03s CPU in 11+ minutes:

```
15:59:51  realising '…-drishti-agent.drv' on remote…   ← last line, then nothing
```

With no result ever returned, the spawn cycle never left `copying`/`connecting`, and nothing reaped it (the existing watchdog guards the *post-spawn* handshake, not provisioning).

## Root cause (fixed upstream)

`surface-nix-host` wrapped the realise/probe ssh in bare `ssh -o BatchMode=yes`, deliberately omitting the keepalive the long-lived agent session gets — on the theory a "one-shot" command doesn't need it. But `nix-store --realise` over ssh is a **remote build**, idle for minutes while the far end compiles; a one-shot command blocks on a dead peer just as hard.

kolu#1071 folds the ssh options into one source of truth and adds dead-peer detection — `ServerAliveInterval=10 ServerAliveCountMax=3 ConnectTimeout=10` — applied to **both** the commands surface-nix-host spawns directly *and* (via `NIX_SSHOPTS`) the ssh that `nix copy --to ssh-ng://` forks internally, so the copy step is covered too. A dead peer now trips in ~30s → non-zero exit → the reconnect loop retries instead of hanging. A healthy-but-slow build is never capped: keepalives ride the protocol layer independently of channel data.

## The bump

`kolu: 4a22dff → 66be612`. `nix build .#drishti` green against the new pin.

## Follow-up

The slow-provision *cost* (every drishti rebuild changes the agent `.drv` → first reconnect to each remote is a full rebuild + closure copy) is tracked separately in #38 — kolu#1071 stops the hang, not the slow window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)