### PR TITLE
docs(agency): point /do's CI command at the /ci skill; provision the Linux box with `pu create`

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -10,10 +10,11 @@ just fmt
 bun test
 
 ## CI command
-nix run github:juspay/justci -- run
+Use the `/ci` skill.
 
 <!-- Host routing comes from `~/.config/justci/hosts.json`
-(x86_64-linux → vanjaram, aarch64-darwin → rasam); no `--host` override. -->
+(aarch64-darwin → rasam). For the x86_64-linux lane, provision a fresh Linux
+box with `pu create <NAME>` and route the platform to it. -->
 
 
 ## Documentation


### PR DESCRIPTION
The `/do` workflow reads `.agency/do.md`'s `## CI command` section to learn how to run CI. It had the raw `nix run github:juspay/justci -- run` invocation hard-coded, duplicating knowledge that now lives in the `/ci` skill (full-pipeline, single-recipe, platform-pinned-lane, inspection subcommands, decision flow). This points the section at `/ci` instead, so there's one source of truth for the runner.

It also refreshes the host-routing note. `aarch64-darwin` still routes through `~/.config/justci/hosts.json` (→ `rasam`), but the `x86_64-linux` lane no longer pins a fixed host — provision a fresh Linux box on demand with `pu create <NAME>` and route the platform to it.

## Changes

| Before | After |
| --- | --- |
| `## CI command` = `nix run github:juspay/justci -- run` | `## CI command` = use the `/ci` skill |
| `x86_64-linux → vanjaram` (fixed host) | provision via `pu create <NAME>` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)