### PR TITLE
Serve the agent surface before enumerating processes

### DIFF
--- a/docs/plans/talk-localhost-handshake-timeout.html
+++ b/docs/plans/talk-localhost-handshake-timeout.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>“localhost” timed out — the host that needs no connection</title>
+<style>
+  :root {
+    --bg: #0b1020; --panel: #121a2e; --panel2: #0e1526; --line: #1f2a44;
+    --ink: #d7deec; --dim: #8a96b0; --faint: #5d6886;
+    --amber: #f59e0b; --emerald: #10b981; --red: #ef4444; --blue: #6366f1;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2.2rem clamp(1rem, 4vw, 3.5rem); background: var(--bg);
+    color: var(--ink); font: 15px/1.6 system-ui, -apple-system, sans-serif;
+  }
+  main { max-width: 920px; margin: 0 auto; }
+  h1 { font-size: 1.5rem; margin: 0 0 .2rem; }
+  h2 { font-size: 1.05rem; margin: 2.2rem 0 .6rem; color: #fff;
+       border-bottom: 1px solid var(--line); padding-bottom: .35rem; }
+  h3 { font-size: .92rem; margin: 1.3rem 0 .4rem; color: var(--ink); }
+  p { margin: .55rem 0; }
+  code { font-family: var(--mono); font-size: .85em; color: #e6c07b;
+         background: #1a2238; padding: .08em .35em; border-radius: 4px; }
+  .sub { color: var(--dim); margin-top: .1rem; }
+  .cite { font-family: var(--mono); font-size: .8em; color: var(--faint); }
+  .pill { display: inline-block; font-size: .72rem; font-family: var(--mono);
+          padding: .1em .5em; border-radius: 999px; border: 1px solid var(--line);
+          color: var(--dim); }
+  .key { background: #161f38; border: 1px solid var(--line); border-radius: 10px;
+         padding: 1rem 1.2rem; margin: 1rem 0; }
+  .key strong { color: #fff; }
+  .log { background: #07060b; border: 1px solid var(--line); border-radius: 8px;
+         padding: .9rem 1rem; font-family: var(--mono); font-size: .76rem;
+         line-height: 1.55; overflow-x: auto; white-space: pre; color: #aeb6c8; }
+  .log .l { color: var(--dim); }
+  .log .r { color: #7f8aa6; }
+  .log .ok { color: var(--emerald); }
+  .log .warn { color: var(--amber); }
+  .log .stuck { color: var(--red); font-weight: 600; }
+  ul { margin: .5rem 0; padding-left: 1.2rem; }
+  li { margin: .3rem 0; }
+  table { width: 100%; border-collapse: collapse; margin: .8rem 0; font-size: .88rem; }
+  th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid var(--line);
+           vertical-align: top; }
+  th { color: var(--dim); font-weight: 600; font-size: .78rem; text-transform: uppercase;
+       letter-spacing: .03em; }
+  td code { white-space: nowrap; }
+  .flow { font-family: var(--mono); font-size: .82rem; line-height: 1.9; margin: .6rem 0;
+          color: var(--dim); }
+  .flow b { color: var(--amber); }
+  .flow .g { color: var(--emerald); }
+  .flow .x { color: var(--red); }
+  .mockwrap { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0; }
+  @media (max-width: 720px) { .mockwrap { grid-template-columns: 1fr; } }
+  .mock { background: #0a0f1e; border: 1px solid var(--line); border-radius: 10px;
+          padding: 0; overflow: hidden; }
+  .mockhead { font-size: .72rem; color: var(--faint); font-family: var(--mono);
+              padding: .45rem .8rem; border-bottom: 1px solid var(--line);
+              background: #0e1526; }
+  .mockbody { padding: 1rem; min-height: 150px; }
+  .verdict { font-size: .8rem; color: var(--faint); margin-top: .55rem; }
+  .verdict.good { color: var(--emerald); }
+  .verdict.bad { color: var(--red); }
+  .rev { font-size: .82rem; color: var(--dim); border-left: 2px solid var(--line);
+         padding: .15rem 0 .15rem .8rem; margin: .5rem 0; }
+  .rev b { color: var(--ink); }
+  .tag { font-family: var(--mono); font-size: .72rem; padding: .06em .45em; border-radius: 4px; }
+  .tag.proven { color: var(--emerald); border: 1px solid rgba(16,185,129,.4); }
+  .tag.inferred { color: var(--amber); border: 1px solid rgba(245,158,11,.4); }
+</style>
+</head>
+<body>
+<main>
+
+<h1>“localhost” timed out — the host that needs no connection</h1>
+<p class="sub">Why the one tab that should <em>always</em> be green is the only one that’s red. <span class="pill">talk · --html</span></p>
+
+<div class="key">
+<strong>The punchline.</strong> You’re right that <code>localhost</code> uses no network — and it doesn’t. But “no connection” isn’t “no handshake.” drishti treats <em>every</em> host uniformly: even localhost gets <code>nix-store&nbsp;--realise</code> → spawn the agent as a local stdio child → wait ≤30&nbsp;s for the first RPC. The agent enumerates <strong>all 956 processes before it starts answering</strong>, and on <code>zest</code> — a load-9.58 macOS box running <code>lsof</code> over its own process table — that enumeration overruns the 30&nbsp;s budget. The host that “should just work” is in fact the <em>worst</em> case in the fleet.
+</div>
+
+<h2>What you’re looking at</h2>
+<p>The card says <code>connect handshake timed out after 30000ms (transport up, no first RPC)</code>, then it backs off and retries to attempt 5/5, then gives up. The log shows the agent <em>realising fine</em> and only then the timeout:</p>
+
+<div class="log"><span class="stuck">[local]</span> connect handshake timed out after 30000ms (transport up, no first RPC)
+<span class="l">[local]</span> reconnecting in 16000ms… (attempt 4/5)
+<span class="l">[local]</span> localhost: realising '/nix/store/…-drishti-agent.drv'…
+<span class="warn">[local]</span> warning: you did not specify '--add-root'; the result might be removed by the GC
+<span class="ok">[local]</span> localhost: agent realised at /nix/store/…-drishti-agent</div>
+
+<p>That ordering is the first clue: the realise <em>succeeds</em> (<code>agent realised at …</code>) — the 30&nbsp;s is spent <em>after</em> it, on the handshake. The slow-nix-build theory is dead on arrival.</p>
+
+<h2>localhost really does skip the network</h2>
+<p>The transport layer special-cases the loopback names — no ssh, no <code>nix copy</code>:</p>
+
+<table>
+<tr><th>Step</th><th>localhost</th><th>a real remote</th></tr>
+<tr><td>arch probe</td><td><code>nix-instantiate --eval</code> run locally</td><td><code>ssh host nix-instantiate …</code></td></tr>
+<tr><td>ship closure</td><td>— skipped —</td><td><code>nix copy --to ssh-ng://host</code></td></tr>
+<tr><td>realise</td><td><code>nix-store --realise</code> run locally</td><td><code>ssh host nix-store --realise</code></td></tr>
+<tr><td>spawn agent</td><td><code>${agentPath}/bin/drishti-agent --stdio</code> (direct child)</td><td><code>ssh host … --stdio</code></td></tr>
+</table>
+<p class="cite">isLocalHost: @kolu/surface-nix-host host.ts:6 · buildAgentCommand host.ts:210 · buildSshProbeCommand host.ts:232 · nix-copy guard nixCopy.ts</p>
+
+<p>So your instinct holds: nothing leaves the box. What <em>doesn’t</em> change for localhost is the session lifecycle — it still spawns a child and waits for a handshake under a watchdog:</p>
+
+<div class="flow">
+copying <span class="g">──realise locally (outside the 30s)──▶</span> <b>connecting</b> <span class="g">──first RPC──▶</span> connected<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>connecting</b> <span class="x">──30s watchdog──▶</span> disconnected <span class="x">──×5 (cause “remote”)──▶</span> failed
+</div>
+
+<div class="key">
+The 30&nbsp;s watchdog is armed <strong>the instant the child is spawned</strong> — <em>after</em> <code>provisionAgent</code> (probe + realise) returns. So realise time is genuinely <em>not</em> in the budget; the whole 30&nbsp;s belongs to the agent’s own post-spawn startup. <span class="cite">watchdog armed at spawn: hostSession.ts:515 · default 30s: hostSession.ts:433 · wired by drishti: hostRegistry.ts:46,117</span>
+</div>
+
+<h2>Why it times out anyway: the agent serves last</h2>
+<p>The “first RPC” the parent waits on is the bridge’s <code>system.get</code> subscription — its first yield calls <code>markConnected()</code> (<code>connecting → connected</code>). But the agent can’t answer until it reaches <code>serveOverStdio()</code>, and that is the <em>last</em> thing <code>main()</code> does:</p>
+
+<div class="log"><span class="l">main.ts:106</span>  await reader.readSystem()      <span class="r">// darwin: vm_stat + statfs        (cheap)</span>
+<span class="l">main.ts:110</span>  await reader.readProcesses()   <span class="stuck">// darwin: ps  +  lsof -nP -d cwd  ← all 956 pids</span>
+<span class="l">main.ts:120</span>  await reader.readNetwork()     <span class="r">// darwin: netstat -ib</span>
+<span class="l">  …</span>
+<span class="l">main.ts:300</span>  await serveOverStdio(…)        <span class="ok">// ← only NOW is stdin read / RPCs answered</span></div>
+
+<p>Those are plain sequential <code>await</code>s, not a background warm-up. The parent’s <code>system.get</code> frame is written to the child’s stdin the moment the link opens — and then sits <strong>buffered, unread</strong>, because <code>serveOverStdio</code> hasn’t attached the stdin reader yet. The dominant cost is <code>lsof -nP -d cwd</code> over the whole table (the per-process cwd lookup added in <code>3d6ff0b</code>). On a load-9.58 box with 956 processes that overruns 30&nbsp;s → watchdog → SIGTERM → the exit handler reports the verbatim string and classifies it <code>"remote"</code> (bounded), so after 5 strikes it lands in terminal <code>failed</code>.</p>
+<p class="cite">handshake = system.get first yield → markConnected: router.ts:404–411 · ps+lsof: proc.ts:681 · timeout string + cause "remote": hostSession.ts:473 · give-up after 5: hostSession.ts (MAX_CONSECUTIVE_FAILURES)</p>
+
+<h2>The irony: localhost is the <em>worst</em> host, not the easiest</h2>
+<p>Three things stack up, and they all land hardest on exactly this host:</p>
+<ul>
+  <li><strong>localhost <em>is</em> zest.</strong> The agent runs <em>on</em> the most-loaded, highest-process-count box in the fleet — and competes for the very CPU it’s trying to measure.</li>
+  <li><strong>It’s darwin.</strong> macOS has no <code>/proc</code>, so the reader forks <code>ps</code> + <code>lsof</code> + <code>netstat</code>. Your green Linux remotes use pure <code>/proc</code> file reads (<span class="cite">proc.ts:328–381</span>) — no <code>lsof</code> fork — so they handshake sub-second even with more PIDs.</li>
+  <li><strong>The agent serves last.</strong> All 956 PIDs of <code>lsof</code> sit squarely on the handshake critical path, instead of filling in a beat after the link is live.</li>
+</ul>
+<p>A remote Linux host with 200 idle processes connects instantly; localhost — “which needs no connection” — is the one whose agent is too busy enumerating its own process table to say hello in time.</p>
+
+<h2>Confirm it in five seconds <span class="tag inferred">mechanism proven, magnitude to verify</span></h2>
+<p>The serve-after-enumerate ordering is proven in source. What the screenshot can’t prove on its own is that the enumeration is what ran out the clock (vs. a slow first-RPC <em>roundtrip</em> after serving). The agent prints a deliberate tell that settles it — scroll up in the connection log and look for these <code>[remote]</code> lines:</p>
+
+<div class="mockwrap">
+  <div class="mock">
+    <div class="mockhead">stuck pre-serve → the diagnosis holds</div>
+    <div class="mockbody">
+      <div class="log"><span class="r">[remote]</span> drishti-agent: os=darwin, pid=…
+<span class="stuck">⟨ 30s of silence — then SIGTERM ⟩</span></div>
+      <div class="verdict bad">no “serving surface over stdio”, no heartbeat → agent stuck in lsof. Serve-first fix applies.</div>
+    </div>
+  </div>
+  <div class="mock">
+    <div class="mockhead">served, but roundtrip slow → different bug</div>
+    <div class="mockbody">
+      <div class="log"><span class="r">[remote]</span> serving surface over stdio …
+<span class="r">[remote]</span> waiting for first RPC (5s)…
+<span class="r">[remote]</span> waiting for first RPC (25s)…</div>
+      <div class="verdict">heartbeat climbs to ~30s → stall is the parent→agent roundtrip; serve-first would <em>not</em> help.</div>
+    </div>
+  </div>
+</div>
+<p class="cite">os= line printed on spawn: main.ts:103 · “serving surface over stdio”: main.ts:288 · heartbeat: main.ts:295 · the agent’s own comment frames this as the discriminator</p>
+<p>Everything points to the left card. (Note: <code>lsof</code> is wrapped in <code>.catch(() =&gt; "")</code> — a <em>failing</em> lsof degrades to blank cwds and doesn’t block, so the stall needs lsof to be <em>slow</em>, not broken; under load 9.58 with a stale/network-backed cwd somewhere in 956 procs, slow is exactly what you get.)</p>
+
+<h2>Fix: serve first, enumerate lazily</h2>
+<p>The handshake only needs the cheap <code>system</code> cell — already seeded by <code>readSystem()</code> at <code>main.ts:106</code>. It does <em>not</em> need the <code>lsof</code>-driven process table or <code>netstat</code>. Reorder so the agent answers RPCs immediately and lets its existing 2-second poll loop fill the rest.</p>
+
+<table>
+<tr><th>Decision</th><th>Shape</th></tr>
+<tr>
+  <td>Move the seam</td>
+  <td>Call <code>serveOverStdio()</code> right after the cheap <code>readSystem()</code> seed; defer the two subprocess-backed reads (<code>readProcesses</code>’ lsof, <code>readNetwork</code>’ netstat) to the first <code>tick()</code> of the existing poll loop. <span class="cite">main.ts:105–121 vs :300</span></td>
+</tr>
+<tr>
+  <td>Keep the cheap seed</td>
+  <td><span class="rev"><b>Don’t defer everything.</b> <code>readCpuCores()</code> (main.ts:115) is synchronous <code>os.cpus()</code> — keep seeding it pre-serve; it costs nothing and gives the CPU-delta its baseline. Only the <em>fork</em>-backed reads belong off the critical path.</span></td>
+</tr>
+<tr>
+  <td>Uniformity preserved</td>
+  <td><span class="rev"><b>No localhost special-case.</b> This is an agent-startup fix, not a transport branch — so it speeds up <em>every</em> host’s cold start, darwin or linux, local or remote. The deliberate “localhost is not special” design (hostRegistry / host.ts) stays intact.</span></td>
+</tr>
+<tr>
+  <td>Accept the first-frame blip</td>
+  <td>CPU% / net throughput are deltas against a prior tick (<span class="cite">proc.ts:64–95, 201–220</span>); a browser that subscribes in the sub-second gap before tick #1 sees one frame of 0% / 0&nbsp;B/s and a momentarily empty process list, corrected on the next delta. Benign under the snapshot-then-delta contract the pumps already tolerate.</td>
+</tr>
+<tr>
+  <td>Not the watchdog</td>
+  <td>Raising / scaling <code>connectTimeoutMs</code> is a band-aid: it hides the latency instead of removing it, and a 956-proc darwin box under heavier load would still blow a bigger budget. Leave the 30&nbsp;s where it is.</td>
+</tr>
+</table>
+
+<div class="mockwrap">
+  <div class="mock">
+    <div class="mockhead">today — serve after enumerate</div>
+    <div class="mockbody">
+      <div class="flow">spawn <span class="x">─lsof×956─▶</span> serve <span class="x">─▶</span> answer<br><span class="verdict bad">handshake waits on the whole table → &gt;30s on zest → failed</span></div>
+    </div>
+  </div>
+  <div class="mock">
+    <div class="mockhead">after — serve, then enumerate on tick #1</div>
+    <div class="mockbody">
+      <div class="flow">spawn <span class="g">─▶</span> serve <span class="g">─▶</span> answer <span class="g">(sub-second)</span><br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ poll tick fills procs/cpu/net<br><span class="verdict good">link live regardless of process count</span></div>
+    </div>
+  </div>
+</div>
+
+<h3>Scope</h3>
+<p>One file: <code>packages/agent/src/main.ts</code> (~lines 105–300) reordered. Add a regression test that the agent answers a <code>system.get</code> before <code>readProcesses()</code> resolves (stub a slow reader). No kolu change, no UI change. README has no user-facing surface to update — startup just gets faster.</p>
+
+<p class="sub" style="margin-top:2rem">Ready to ship? Verify the left-hand log card first (it’s a five-second scroll), then invoke <code>do</code> to implement the reorder + test and run <code>/ci</code>.</p>
+
+</main>
+</body>
+</html>

--- a/packages/agent/src/main.test.ts
+++ b/packages/agent/src/main.test.ts
@@ -38,7 +38,6 @@ describe("serveAgent", () => {
     const reader = gatedReader(processesGate);
 
     let served = false;
-    let firstRequestFired = false;
     // Fake transport passed inline so it's contextually typed by serveAgent's
     // `serve` parameter (no exported type needed). It resolves immediately, as
     // if stdin closed at once. Were `serveAgent` to gate serving on the process
@@ -48,11 +47,9 @@ describe("serveAgent", () => {
     await serveAgent(reader, async ({ onFirstRequest }) => {
       served = true;
       onFirstRequest();
-      firstRequestFired = true;
     });
 
     expect(served).toBe(true);
-    expect(firstRequestFired).toBe(true);
 
     // Release the gate so the fire-and-forget first tick settles cleanly.
     releaseProcesses();

--- a/packages/agent/src/main.test.ts
+++ b/packages/agent/src/main.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { type ServeOverStdio, serveAgent } from "./main";
+import { serveAgent } from "./main";
 import type { ProcReader } from "./proc";
 
 // A reader whose process enumeration is the expensive part — the darwin
@@ -39,19 +39,17 @@ describe("serveAgent", () => {
 
     let served = false;
     let firstRequestFired = false;
-    // Fake transport: resolves immediately (as if stdin closed at once),
-    // standing in for serveOverStdio. Were `serveAgent` to gate serving on
-    // the process scan — the pre-fix behaviour — this would never be called
-    // and the `await` below would hang the test out (timeout). That hang is
-    // exactly the connect-handshake stall this reorder fixes, so a green run
-    // here is the regression guard.
-    const serve: ServeOverStdio = async ({ onFirstRequest }) => {
+    // Fake transport passed inline so it's contextually typed by serveAgent's
+    // `serve` parameter (no exported type needed). It resolves immediately, as
+    // if stdin closed at once. Were `serveAgent` to gate serving on the process
+    // scan — the pre-fix behaviour — this fake would never be called and the
+    // `await` below would hang the test out (timeout). That hang is exactly the
+    // connect-handshake stall this reorder fixes, so a green run is the guard.
+    await serveAgent(reader, async ({ onFirstRequest }) => {
       served = true;
       onFirstRequest();
       firstRequestFired = true;
-    };
-
-    await serveAgent(reader, serve);
+    });
 
     expect(served).toBe(true);
     expect(firstRequestFired).toBe(true);

--- a/packages/agent/src/main.test.ts
+++ b/packages/agent/src/main.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { type ServeOverStdio, serveAgent } from "./main";
+import type { ProcReader } from "./proc";
+
+// A reader whose process enumeration is the expensive part — the darwin
+// `ps` + `lsof` scan, modelled here as a promise the test controls. The
+// system/cpu/network reads are trivial; only `readProcesses` blocks, so we
+// can prove the agent answers the first RPC *without* waiting for that scan.
+function gatedReader(processesGate: Promise<void>): ProcReader {
+  return {
+    os: "linux",
+    readSystem: async () => ({
+      loadAvg: [0, 0, 0],
+      memUsed: 0,
+      memTotal: 1,
+      diskUsed: 0,
+      diskTotal: 1,
+      uptime: 0,
+      os: "linux",
+      hostname: "test",
+    }),
+    // Stand-in for the lsof-over-every-pid scan: blocks until released.
+    readProcesses: async () => {
+      await processesGate;
+      return new Map();
+    },
+    readCpuCores: () => new Map(),
+    readNetwork: async () => new Map(),
+  };
+}
+
+describe("serveAgent", () => {
+  it("answers the first RPC without waiting for the process enumeration", async () => {
+    let releaseProcesses!: () => void;
+    const processesGate = new Promise<void>((resolve) => {
+      releaseProcesses = resolve;
+    });
+    const reader = gatedReader(processesGate);
+
+    let served = false;
+    let firstRequestFired = false;
+    // Fake transport: resolves immediately (as if stdin closed at once),
+    // standing in for serveOverStdio. Were `serveAgent` to gate serving on
+    // the process scan — the pre-fix behaviour — this would never be called
+    // and the `await` below would hang the test out (timeout). That hang is
+    // exactly the connect-handshake stall this reorder fixes, so a green run
+    // here is the regression guard.
+    const serve: ServeOverStdio = async ({ onFirstRequest }) => {
+      served = true;
+      onFirstRequest();
+      firstRequestFired = true;
+    };
+
+    await serveAgent(reader, serve);
+
+    expect(served).toBe(true);
+    expect(firstRequestFired).toBe(true);
+
+    // Release the gate so the fire-and-forget first tick settles cleanly.
+    releaseProcesses();
+  });
+});

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -250,7 +250,7 @@ export async function serveAgent(
           upserts.push([pid, value]);
         }
       }
-      for (const pid of [...processSnapshot.keys()]) {
+      for (const pid of processSnapshot.keys()) {
         if (!nextProcesses.has(pid)) {
           fragment.ctx.collections.processes.remove(pid);
           removes.push(pid);

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -94,11 +94,12 @@ function processChanged(a: Process, b: Process): boolean {
   return MUTABLE_PROCESS_FIELDS.some((f) => a[f] !== b[f]);
 }
 
-/** The slice of `serveOverStdio` that `serveAgent` depends on — narrowed to
- *  the one call shape it uses, so a test can inject a fake transport (no real
- *  stdio) and prove the first RPC is answered without waiting on the process
- *  scan. The real `serveOverStdio` is assignable to this. */
-export type ServeOverStdio = (opts: {
+/** The serve operation `serveAgent` calls — narrowed to the one shape it
+ *  uses, so a test can inject a fake (the default is the real stdio
+ *  transport, which is assignable to this). Module-private and named for the
+ *  *role*, not the `serveOverStdio` implementation: nothing outside this file
+ *  consumes it, and the test passes an inline, contextually-typed fake. */
+type Serve = (opts: {
   // biome-ignore lint/suspicious/noExplicitAny: the kolu handler's router type; the real serveOverStdio is invoked with the same `as any` cast at the call site below.
   router: any;
   onFirstRequest: () => void;
@@ -121,7 +122,7 @@ export type ServeOverStdio = (opts: {
  */
 export async function serveAgent(
   reader: ProcReader,
-  serve: ServeOverStdio = serveOverStdio,
+  serve: Serve = serveOverStdio,
 ): Promise<void> {
   // Seed the `system` cell synchronously — the cheap read (vm_stat + statfs
   // on darwin, a couple of /proc reads on linux) the handshake actually

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -45,7 +45,7 @@ import {
   type ProcessesSnapshotMsg,
   surface,
 } from "drishti-common";
-import { createProcReader } from "./proc";
+import { createProcReader, type ProcReader } from "./proc";
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -94,31 +94,55 @@ function processChanged(a: Process, b: Process): boolean {
   return MUTABLE_PROCESS_FIELDS.some((f) => a[f] !== b[f]);
 }
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  if (!args.includes("--stdio")) usage();
-  const brokenStdoutLog = args.includes("--broken-stdout-log");
+/** The slice of `serveOverStdio` that `serveAgent` depends on — narrowed to
+ *  the one call shape it uses, so a test can inject a fake transport (no real
+ *  stdio) and prove the first RPC is answered without waiting on the process
+ *  scan. The real `serveOverStdio` is assignable to this. */
+export type ServeOverStdio = (opts: {
+  // biome-ignore lint/suspicious/noExplicitAny: the kolu handler's router type; the real serveOverStdio is invoked with the same `as any` cast at the call site below.
+  router: any;
+  onFirstRequest: () => void;
+}) => Promise<void>;
 
-  const reader = createProcReader();
-  log(`drishti-agent: os=${reader.os}, pid=${process.pid}`);
-
+/**
+ * Build the surface fragment + poll loop for `reader`, then serve it.
+ *
+ * **Serve before you enumerate.** The connect handshake — the parent's first
+ * `system.get` — needs only the cheap `system` snapshot, so that is the one
+ * read we seed before serving. The expensive process scan (darwin: `ps` +
+ * `lsof -nP -d cwd` over the *whole* table) and network read (`netstat`) are
+ * NOT on the handshake's critical path: they start empty and the poll loop
+ * fills them. `await`-ing them before `serve` is what let a busy,
+ * high-process-count host (a loaded macOS box as `localhost`, say) blow the
+ * parent's 30s connect watchdog — "transport up, no first RPC" — while the
+ * link itself was fine. See docs/plans/talk-localhost-handshake-timeout.html.
+ *
+ * `serve` is injectable for tests; it defaults to the real stdio transport.
+ */
+export async function serveAgent(
+  reader: ProcReader,
+  serve: ServeOverStdio = serveOverStdio,
+): Promise<void> {
+  // Seed the `system` cell synchronously — the cheap read (vm_stat + statfs
+  // on darwin, a couple of /proc reads on linux) the handshake actually
+  // needs, so the cell is live the instant we serve.
   const systemStore = inMemoryStore({
     ...(await reader.readSystem()),
     pollIntervalMs: POLL_INTERVAL_MS,
   });
-  const processSnapshot = new Map<Pid, Process>();
-  for (const [pid, value] of await reader.readProcesses())
-    processSnapshot.set(pid, value);
-  // Seed CPU-core baseline so the first delta has a previous tick to
-  // compare against — first call returns mostly-zero usages.
+  // Per-core CPU usage is a *rate* against the previous tick; the reader
+  // captured its baseline at construction, so this synchronous seed (just
+  // os.cpus(), no fork) costs nothing and lets a subscriber see cores at once.
   const cpuCoreSnapshot = new Map<CoreId, CpuCore>();
   for (const [core, value] of reader.readCpuCores())
     cpuCoreSnapshot.set(core, value);
-  // Seed the network baseline so the first published delta has a previous
-  // tick to rate against — this first read returns 0 bytes/sec everywhere.
+  // Processes and network start EMPTY and are filled by the poll loop's first
+  // tick (kicked immediately below), NOT awaited here. On darwin
+  // `readProcesses` forks `ps` + `lsof` over every pid and `readNetwork`
+  // forks `netstat`; awaiting them before serving would gate the first RPC
+  // behind a full process scan — the bug this reorder fixes.
+  const processSnapshot = new Map<Pid, Process>();
   const netSnapshot = new Map<IfaceName, NetInterface>();
-  for (const [iface, value] of await reader.readNetwork())
-    netSnapshot.set(iface, value);
 
   // Build the surface implementation. The `processes` collection's
   // `readAll` yields the current snapshot; `upsert`/`remove` are the
@@ -268,15 +292,12 @@ async function main(): Promise<void> {
   const interval = setInterval(() => {
     void tick();
   }, POLL_INTERVAL_MS);
-
-  // Deliberately broken variant — bypass console.log redirection and
-  // write directly to fd 1. This is exactly the wire-corrupting bug
-  // `serveOverStdio` documents.
-  if (brokenStdoutLog) {
-    process.stdout.write(
-      "DEBUG: this line corrupts the protocol channel\n",
-    );
-  }
+  // Kick the first enumeration immediately and fire-and-forget, so processes
+  // and network populate within one scan rather than after a full poll
+  // interval — but off the serving critical path, so the handshake still
+  // roundtrips now. (The broken-stdout smoke test writes to fd 1 in `main`,
+  // before we ever serve.)
+  void tick();
 
   // `implementSurface` returns a fragment with shape `{ surface: ... }`;
   // passing it straight to `serveOverStdio`'s `StandardRPCHandler`
@@ -297,7 +318,7 @@ async function main(): Promise<void> {
       `waiting for first RPC (${Math.round((Date.now() - servingSince) / 1000)}s)…`,
     );
   }, 5000);
-  await serveOverStdio({
+  await serve({
     // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
     router: router as any,
     onFirstRequest: () => {
@@ -310,7 +331,30 @@ async function main(): Promise<void> {
   log("stdin closed — agent exiting");
 }
 
-main().catch((err) => {
-  log(`fatal: ${(err as Error).message}\n${(err as Error).stack ?? ""}`);
-  process.exit(1);
-});
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (!args.includes("--stdio")) usage();
+  const brokenStdoutLog = args.includes("--broken-stdout-log");
+
+  const reader = createProcReader();
+  log(`drishti-agent: os=${reader.os}, pid=${process.pid}`);
+
+  // Deliberately broken variant — bypass console.log redirection and write
+  // directly to fd 1, before any RPC. This is exactly the wire-corrupting bug
+  // `serveOverStdio` documents: the parent's client peer sees garbage and
+  // surfaces a frame-parse failure rather than hanging. Smoke-test only.
+  if (brokenStdoutLog) {
+    process.stdout.write("DEBUG: this line corrupts the protocol channel\n");
+  }
+
+  await serveAgent(reader);
+}
+
+// Guard the entrypoint so importing this module (e.g. from main.test.ts to
+// exercise `serveAgent` directly) doesn't spawn the agent. Mirrors build.ts.
+if (import.meta.main) {
+  main().catch((err) => {
+    log(`fatal: ${(err as Error).message}\n${(err as Error).stack ?? ""}`);
+    process.exit(1);
+  });
+}

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -231,9 +231,10 @@ export async function serveAgent(
   // mutates the snapshot AND publishes to subscribers in one step).
   const tick = async (): Promise<void> => {
     try {
-      const [nextSystem, nextProcesses] = await Promise.all([
+      const [nextSystem, nextProcesses, nextNet] = await Promise.all([
         reader.readSystem(),
         reader.readProcesses(),
+        reader.readNetwork(),
       ]);
       fragment.ctx.cells.system.set({
         ...nextSystem,
@@ -276,8 +277,10 @@ export async function serveAgent(
       // Per-NIC network I/O — same Collection<K,T> publish shape as
       // cpuCores. Throughput shifts almost every tick, so unconditional
       // upserts are simplest; evict interfaces that vanished (NIC down /
-      // hot-unplug) so stale rows don't linger in the browser.
-      const nextNet = await reader.readNetwork();
+      // hot-unplug) so stale rows don't linger in the browser. `nextNet`
+      // is read in the tick-top Promise.all — an independent forked probe
+      // (darwin `netstat`), so it rides alongside system/processes rather
+      // than adding a serial leg to every tick's latency.
       for (const [iface, value] of nextNet) {
         fragment.ctx.collections.networkInterfaces.upsert(iface, value);
       }


### PR DESCRIPTION
**The `localhost` tab could fail to connect — `connect handshake timed out after 30000ms (transport up, no first RPC)` — even though localhost needs no network at all.** drishti treats every host uniformly: even localhost realises the agent `.drv` and spawns it as a local stdio child, then waits ≤30s for the first RPC. But the agent enumerated *every* process before it started serving — on macOS that's `ps` + `lsof -nP -d cwd` over the whole table — so the parent's first `system.get` sat unread in the child's stdin until that scan finished. On a busy, high-process-count box (a 956-process Mac at load 9.58) the scan overran the 30s connect watchdog, and the host went terminal-`failed`. The irony: localhost is the *worst* case in a fleet — the agent runs on the saturated box itself, while idle Linux remotes (pure `/proc` reads, no `lsof` fork) handshake sub-second.

The fix is **serve first, enumerate lazily** — the handshake needs only the cheap `system` cell, not the `lsof`-driven process table:

```
before:  spawn ─▶ readSystem ─▶ ps + lsof×N ─▶ netstat ─▶ serve ─▶ answer   ✗ >30s on a loaded box
after:   spawn ─▶ readSystem ─▶ serve ─▶ answer   ✓ sub-second
                                  └─ poll tick fills processes / cpu / net, off the critical path
```

### What changed

- Seed only the cheap `system` cell (vm_stat + statfs on darwin; a couple of `/proc` reads on linux) plus the synchronous `os.cpus()` core baseline before `serveOverStdio()`.
- Start the process and network maps **empty**; the poll loop's first tick — kicked immediately, fire-and-forget — fills them, so the `ps`/`lsof`/`netstat` forks never sit on the handshake's critical path.
- Extract `serveAgent(reader, serve)` with an injectable transport and guard the entrypoint with `import.meta.main`, so a regression test can prove the first RPC is answered *while* `readProcesses()` is still blocked.

_First-tick cost: a browser that subscribes in the sub-second window before tick #1 sees an empty process list and 0 B/s rates for one poll, corrected on the next delta — benign under the existing snapshot-then-delta contract._

### Review refinements (hickey / lowy / police)

| Lens | Finding | Fix |
| --- | --- | --- |
| Hickey | `readNetwork()` awaited serially after the `Promise.all` in `tick` | folded into the tick-top `Promise.all` — netstat rides alongside system/processes |
| Lowy + Hickey | injectable type exported as `ServeOverStdio` — names the *implementation*, not the role, with no external consumer | module-private `Serve`; the test passes an inline, contextually-typed fake |
| Police | needless `[...keys()]` spread on the process eviction loop; a vacuous test assertion | both removed |

Full root-cause + design write-up: `docs/plans/talk-localhost-handshake-timeout.html`.

### Try it locally

```sh
nix run github:srid/drishti/fix/agent-serve-before-enumerate
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._