### PR TITLE
Open hosts on the 30m window by default

### DIFF
--- a/packages/app/src/common/history.ts
+++ b/packages/app/src/common/history.ts
@@ -42,9 +42,9 @@ export type HistoryWindowKey = (typeof HISTORY_WINDOWS)[number]["key"];
 export const WIDEST_HISTORY_WINDOW: HistoryWindowKey =
   HISTORY_WINDOWS.at(-1)!.key;
 
-/** Default window on first open — the middle ground popular monitors land
- *  on: long enough to show a trend, short enough to stay responsive. */
-export const DEFAULT_HISTORY_WINDOW: HistoryWindowKey = "5m";
+/** Default window on first open — the widest span, so the chart shows the
+ *  fullest trend the ring retains the moment a host opens. */
+export const DEFAULT_HISTORY_WINDOW: HistoryWindowKey = "30m";
 
 /** Retention bound for the ring: the widest selectable window. Samples
  *  older than this are evicted on push, so a host left open for hours


### PR DESCRIPTION
**Opening a host now lands on the 30m window instead of 5m**, so the chart shows the fullest trend the in-memory ring retains the instant a host opens — the same span the fleet-card sparklines already pin to. No more switching from 5m to 30m by hand to see the whole picture.

A single constant flip in `packages/app/src/common/history.ts`: `DEFAULT_HISTORY_WINDOW` goes from `"5m"` to `"30m"` (the widest selectable window), with the doc comment updated to match. The picker still offers 1m / 5m / 15m / 30m and retention is unchanged — this only moves the first-open default.

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._