### PR TITLE
Inherit the stale-tab handshake gate from @kolu/surface-app

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "fix/stale-client-processid-gate",
+      "branch": "master",
       "submodules": false,
-      "revision": "13c378d9c809f8db03e66e2defdf94aaea0c0ee2",
-      "url": "https://github.com/juspay/kolu/archive/13c378d9c809f8db03e66e2defdf94aaea0c0ee2.tar.gz",
+      "revision": "7126b5fa2a13b21bb1133a33e5d296f65ac2d75d",
+      "url": "https://github.com/juspay/kolu/archive/7126b5fa2a13b21bb1133a33e5d296f65ac2d75d.tar.gz",
       "hash": "sha256-Iuz5DVWvxpZf3WTdtBzGYsUpM3BJ3GA2euccJmS6GQw="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "fix/stale-client-processid-gate",
       "submodules": false,
-      "revision": "ef9887978f0ee19e8ed1ba28b812d90cf3a3e11d",
-      "url": "https://github.com/juspay/kolu/archive/ef9887978f0ee19e8ed1ba28b812d90cf3a3e11d.tar.gz",
-      "hash": "sha256-OJ8nLB9cz9wcoA+ZRQste0WH5IOpRmttNV6FlJuViWY="
+      "revision": "13c378d9c809f8db03e66e2defdf94aaea0c0ee2",
+      "url": "https://github.com/juspay/kolu/archive/13c378d9c809f8db03e66e2defdf94aaea0c0ee2.tar.gz",
+      "hash": "sha256-Iuz5DVWvxpZf3WTdtBzGYsUpM3BJ3GA2euccJmS6GQw="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "fix/stale-client-processid-gate",
       "submodules": false,
-      "revision": "1f21153ecd50ecdb7d514214b37d291610bae1b1",
-      "url": "https://github.com/juspay/kolu/archive/1f21153ecd50ecdb7d514214b37d291610bae1b1.tar.gz",
-      "hash": "sha256-kVp8G4zY//LG4rQaxucZAkOolPoLNgV3NGqUUj/JyJs="
+      "revision": "ef9887978f0ee19e8ed1ba28b812d90cf3a3e11d",
+      "url": "https://github.com/juspay/kolu/archive/ef9887978f0ee19e8ed1ba28b812d90cf3a3e11d.tar.gz",
+      "hash": "sha256-OJ8nLB9cz9wcoA+ZRQste0WH5IOpRmttNV6FlJuViWY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -15,6 +15,7 @@
  */
 
 import { streamCall } from "@kolu/surface/client";
+import { STALE_PROCESS_CLOSE_CODE } from "@kolu/surface-app";
 import { SurfaceAppProvider, surfaceAppProbe } from "@kolu/surface-app/solid";
 import { Meta, Title } from "@solidjs/meta";
 import {
@@ -93,6 +94,7 @@ import {
   adminRpc,
   adminSocket,
   disposeHostSurface,
+  rememberServerProcessId,
   surfaceAppClient,
   surfaceForHost,
 } from "./wire";
@@ -318,7 +320,16 @@ export default function App() {
       controlPlane={surfaceAppClient()}
       clientCommit={__SURFACE_APP_COMMIT__}
       ws={adminSocket()}
-      probe={() => surfaceAppProbe(surfaceAppClient())}
+      probe={async () => {
+        const probed = await surfaceAppProbe(surfaceAppClient());
+        // Echo the live id back as the next reconnect's `pid` handshake param
+        // (kolu#1231). The turnkey provider doesn't expose `onProcessId`, so we
+        // stash it from our OWN probe — the one identity hook a provider consumer
+        // owns. (kolu wires the same via `createServerLifecycle`'s `onProcessId`.)
+        rememberServerProcessId(probed.processId);
+        return probed;
+      }}
+      restartCloseCode={STALE_PROCESS_CLOSE_CODE}
     >
       <MultiHostApp />
     </SurfaceAppProvider>

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -79,6 +79,7 @@ import {
   windowSlice,
 } from "../common/history";
 import { TabStrip } from "./TabStrip";
+import { TransportOverlay } from "./TransportOverlay";
 import { prefKey, readPref, writePref } from "./localStorageState";
 import { brandColorForTheme } from "./brand";
 import { APP_TITLE } from "./title";
@@ -314,23 +315,24 @@ function projectHistory(
 //  - ws + probe = the admin socket's open/close paired with the shared
 //    `surfaceAppProbe` helper (the scoped `surface.identity.info` probe), so a
 //    reconnect to a *restarted* parent reads as a restart, not a transient drop.
+//  - onProcessId = the turnkey `{ ws, probe }` source now publishes each observed
+//    server `processId` (kolu#1231); we stash it in the `wire.ts` mutable the
+//    admin/per-host URL thunks echo as the `pid` handshake param. The provider
+//    also retires the admin socket itself on a stale-restart, so drishti no
+//    longer hand-rolls either the probe-wrapper echo or the admin retirement —
+//    the per-host sockets, which have no provider lifecycle, keep their own
+//    close-listener retirement in `wire.ts`.
 export default function App() {
   return (
     <SurfaceAppProvider
       controlPlane={surfaceAppClient()}
       clientCommit={__SURFACE_APP_COMMIT__}
       ws={adminSocket()}
-      probe={async () => {
-        const probed = await surfaceAppProbe(surfaceAppClient());
-        // Echo the live id back as the next reconnect's `pid` handshake param
-        // (kolu#1231). The turnkey provider doesn't expose `onProcessId`, so we
-        // stash it from our OWN probe — the one identity hook a provider consumer
-        // owns. (kolu wires the same via `createServerLifecycle`'s `onProcessId`.)
-        rememberServerProcessId(probed.processId);
-        return probed;
-      }}
+      probe={() => surfaceAppProbe(surfaceAppClient())}
+      onProcessId={rememberServerProcessId}
       restartCloseCode={STALE_PROCESS_CLOSE_CODE}
     >
+      <TransportOverlay />
       <MultiHostApp />
     </SurfaceAppProvider>
   );

--- a/packages/app/src/client/TransportOverlay.tsx
+++ b/packages/app/src/client/TransportOverlay.tsx
@@ -1,0 +1,64 @@
+/**
+ * Full-viewport dim overlay for transport- and update-state — drishti's port of
+ * kolu's `packages/client/src/rpc/TransportOverlay.tsx`, rendered in drishti's
+ * own tailwind palette. surface-app provides the headless MODEL (`useSurfaceApp`);
+ * the app renders the chrome.
+ *
+ * Two independent signals drive it, both off `useSurfaceApp()`:
+ * - `status() === "down"` — the control-plane WebSocket dropped; show
+ *   "Reconnecting…".
+ * - `updateReady()` — a fresh client build is live (build skew OR a parent
+ *   restart). The skew-OR-restart predicate lives in surface-app's model beside
+ *   the `reload()` it gates, so this consumer just reads it.
+ *
+ * The card passes pointer events through (`pointer-events-none` on the dim,
+ * `pointer-events-auto` on the card) so the process table stays scrollable
+ * underneath — only the Reload button is interactive. drishti has no service
+ * worker on the control plane, so `reload()` is a plain `location.reload()`
+ * landing on the `no-store` shell → the current bundle.
+ */
+
+import { useSurfaceApp } from "@kolu/surface-app/solid";
+import { Show } from "solid-js";
+
+export function TransportOverlay() {
+  const app = useSurfaceApp();
+  const disconnected = () => app.status() === "down";
+
+  return (
+    <Show when={disconnected() || app.updateReady()}>
+      <div class="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+        <div
+          class="pointer-events-auto max-w-sm rounded border border-gray-300 bg-white p-6 text-sm shadow-lg dark:border-gray-700 dark:bg-gray-900"
+          data-testid="transport-overlay"
+        >
+          <Show
+            when={disconnected()}
+            fallback={
+              <>
+                <div class="mb-1 font-semibold text-gray-900 dark:text-gray-100">
+                  App updated
+                </div>
+                <div class="mb-4 text-gray-600 dark:text-gray-400">
+                  Reload to apply the latest version.
+                </div>
+                <button
+                  type="button"
+                  class="rounded bg-emerald-600 px-3 py-1.5 font-semibold text-white hover:bg-emerald-500"
+                  onClick={() => app.reload()}
+                >
+                  Reload
+                </button>
+              </>
+            }
+          >
+            <div class="mb-1 font-semibold text-gray-900 dark:text-gray-100">
+              Disconnected from server
+            </div>
+            <div class="text-gray-600 dark:text-gray-400">Reconnecting…</div>
+          </Show>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -15,14 +15,34 @@ import { websocketLink } from "@kolu/surface/links/websocket";
 import { surfaceClient, surfaceClients } from "@kolu/surface/solid";
 import { WebSocket as PartySocket } from "partysocket";
 import {
+  SERVER_PROCESS_ID_PARAM,
+  STALE_PROCESS_CLOSE_CODE,
+} from "@kolu/surface-app";
+import { retireSocket } from "@kolu/surface-app/lifecycle";
+import {
   ADMIN_HOST_SENTINEL,
   adminContract,
   adminSurfaces,
 } from "../common/admin-surface";
 import { surface } from "drishti-common";
 
+// The parent mints a fresh `processId` per boot. We echo the last-known one as a
+// `pid` query param on every (re)connect so the parent recognizes a stale tab
+// after a restart and rejects it at the handshake (kolu#1231). `App.tsx`'s probe
+// wrapper feeds this via `rememberServerProcessId` as each identity probe
+// resolves; it's null until the first probe, so the first connect omits the
+// param. Read by the URL THUNK in `makeSocket`, re-evaluated by partysocket on
+// every reconnect.
+let lastServerProcessId: string | null = null;
+export function rememberServerProcessId(id: string): void {
+  lastServerProcessId = id;
+}
+
 function wsUrlFor(host: string): string {
   const params = new URLSearchParams({ host });
+  if (lastServerProcessId) {
+    params.set(SERVER_PROCESS_ID_PARAM, lastServerProcessId);
+  }
   return `${location.protocol === "https:" ? "wss:" : "ws:"}//${location.host}/rpc/ws?${params.toString()}`;
 }
 
@@ -30,13 +50,26 @@ function wsUrlFor(host: string): string {
 // start can take 30+ seconds while the parent provisions the agent via
 // `nix copy`, so the connect deadline is bumped well past partysocket's
 // 4s default — without this, the socket flaps repeatedly during the
-// first connect.
+// first connect. The URL is a THUNK so partysocket re-reads `lastServerProcessId`
+// (the `pid` echo) on every reconnect.
 function makeSocket(host: string): PartySocket {
-  return new PartySocket(wsUrlFor(host), undefined, {
+  const ws = new PartySocket(() => wsUrlFor(host), undefined, {
     connectionTimeout: 60_000,
     minReconnectionDelay: 2_000,
     maxReconnectionDelay: 15_000,
   });
+  // When the parent rejects this socket as stale (a previous-process binding) it
+  // closes with STALE_PROCESS_CLOSE_CODE. RETIRE the socket: stop reconnect +
+  // fail further sends loudly, so neither partysocket's offline buffer nor oRPC's
+  // pending peers grow unbounded. A fresh page reconnects cleanly. `retireSocket`
+  // is shared @kolu/surface-app electricity (kolu#1231). Applied to every socket
+  // (admin + per-host) since any of them can outlive a parent restart.
+  ws.addEventListener("close", (event) => {
+    if ((event as CloseEvent).code === STALE_PROCESS_CLOSE_CODE) {
+      retireSocket(ws);
+    }
+  });
+  return ws;
 }
 
 type HostClient = ReturnType<typeof buildHostSurface>;

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -28,11 +28,11 @@ import { surface } from "drishti-common";
 
 // The parent mints a fresh `processId` per boot. We echo the last-known one as a
 // `pid` query param on every (re)connect so the parent recognizes a stale tab
-// after a restart and rejects it at the handshake (kolu#1231). `App.tsx`'s probe
-// wrapper feeds this via `rememberServerProcessId` as each identity probe
-// resolves; it's null until the first probe, so the first connect omits the
-// param. Read by the URL THUNK in `makeSocket`, re-evaluated by partysocket on
-// every reconnect.
+// after a restart and rejects it at the handshake (kolu#1231). `App.tsx` feeds
+// this via the provider's `onProcessId` callback (the turnkey `{ ws, probe }`
+// source publishes each observed id — kolu#1231); it's null until the first
+// probe, so the first connect omits the param. Read by the URL THUNK in
+// `makeSocket`, re-evaluated by partysocket on every reconnect.
 let lastServerProcessId: string | null = null;
 export function rememberServerProcessId(id: string): void {
   lastServerProcessId = id;
@@ -52,7 +52,14 @@ function wsUrlFor(host: string): string {
 // 4s default — without this, the socket flaps repeatedly during the
 // first connect. The URL is a THUNK so partysocket re-reads `lastServerProcessId`
 // (the `pid` echo) on every reconnect.
-function makeSocket(host: string): PartySocket {
+//
+// `retire` controls who tears the socket down on a stale-close: the per-host
+// sockets have no provider lifecycle, so they attach the close-listener
+// retirement themselves (`retire: true`). The admin socket is owned by
+// `<SurfaceAppProvider>`'s turnkey `{ ws, probe }` source, which retires it
+// itself (`onStaleRestart: () => retireSocket(ws)` internally, kolu#1231) — so
+// it opts out here (`retire: false`) to avoid a double-retire.
+function makeSocket(host: string, retire: boolean): PartySocket {
   const ws = new PartySocket(() => wsUrlFor(host), undefined, {
     connectionTimeout: 60_000,
     minReconnectionDelay: 2_000,
@@ -62,13 +69,14 @@ function makeSocket(host: string): PartySocket {
   // closes with STALE_PROCESS_CLOSE_CODE. RETIRE the socket: stop reconnect +
   // fail further sends loudly, so neither partysocket's offline buffer nor oRPC's
   // pending peers grow unbounded. A fresh page reconnects cleanly. `retireSocket`
-  // is shared @kolu/surface-app electricity (kolu#1231). Applied to every socket
-  // (admin + per-host) since any of them can outlive a parent restart.
-  ws.addEventListener("close", (event) => {
-    if ((event as CloseEvent).code === STALE_PROCESS_CLOSE_CODE) {
-      retireSocket(ws);
-    }
-  });
+  // is shared @kolu/surface-app electricity (kolu#1231).
+  if (retire) {
+    ws.addEventListener("close", (event) => {
+      if ((event as CloseEvent).code === STALE_PROCESS_CLOSE_CODE) {
+        retireSocket(ws);
+      }
+    });
+  }
   return ws;
 }
 
@@ -76,7 +84,8 @@ type HostClient = ReturnType<typeof buildHostSurface>;
 type AdminClient = ReturnType<typeof buildAdminSurface>;
 
 function buildHostSurface(host: string) {
-  const ws = makeSocket(host);
+  // Per-host sockets own their stale-close retirement — no provider watches them.
+  const ws = makeSocket(host, true);
   const client = surfaceClient(
     surface,
     websocketLink<typeof surface.contract>(ws as unknown as WebSocket),
@@ -85,7 +94,9 @@ function buildHostSurface(host: string) {
 }
 
 function buildAdminSurface() {
-  const ws = makeSocket(ADMIN_HOST_SENTINEL);
+  // The admin socket is owned by `<SurfaceAppProvider>`'s turnkey source, which
+  // retires it on a stale-restart itself (kolu#1231) — so it opts out here.
+  const ws = makeSocket(ADMIN_HOST_SENTINEL, false);
   // The admin transport multiplexes TWO sibling surfaces (kolu#1197/#1201):
   // drishti's own `admin` surface (the host set + procedures) and surface-app's
   // complete surface (`buildInfo` + the `identity.info` probe). `surfaceClients`

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -58,13 +58,18 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // here we add only the server-only per-surface deps, keyed the same way.
   // Per-key deps are typed against each surface's own spec now (kolu#1201), so
   // the concretely-typed admin / surface-app deps bind directly — no cast.
+  // `surfaceAppServer()` mints this process's `processId` (no override passed),
+  // and now EXPOSES it — so the stale-tab handshake gate in `main.ts` compares a
+  // reconnecting tab's `pid` against the SAME id `identity.info` reports, rather
+  // than minting a second one that would never match.
+  const surfaceApp = surfaceAppServer();
   const { router: surfacesRouter, ctx } = implementSurfaces(
     adminSurfaces,
     { channel: inMemoryChannelByName() },
     {
       // ── surface-app served as a sibling ──────────────────────────────
       // `surfaceAppServer()` is the surface-app deps bundle; pass it directly.
-      surfaceApp: surfaceAppServer(),
+      surfaceApp,
 
       // ── drishti's own admin surface served as a sibling ──────────────
       admin: {
@@ -144,5 +149,8 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   const router = implement(adminContract).router({
     ...surfacesRouter,
   });
-  return { router };
+  // `processId` is this parent process's live id — `main.ts`'s WS-upgrade gate
+  // feeds it to `rejectStaleProcess` so a tab that reconnects after a parent
+  // restart is rejected at the handshake.
+  return { router, processId: surfaceApp.processId };
 }

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -28,6 +28,11 @@ import { Hono } from "hono";
 import { WebSocketServer } from "ws";
 import { z } from "zod";
 import { destroyAllSessions } from "@kolu/surface-nix-host";
+import {
+  rejectStaleProcess,
+  SERVER_PROCESS_ID_PARAM,
+  STALE_PROCESS_CLOSE_CODE,
+} from "@kolu/surface-app";
 import { installSurfaceApp } from "@kolu/surface-app/server";
 import { ADMIN_HOST_SENTINEL } from "../common/admin-surface";
 import { BRAND_DARK } from "../client/brand";
@@ -239,6 +244,24 @@ async function main(): Promise<void> {
       socket as Parameters<typeof wss.handleUpgrade>[1],
       head as Parameters<typeof wss.handleUpgrade>[2],
       (ws) => {
+        // Stale-tab handshake gate (kolu#1231 / @kolu/surface-app): a tab that
+        // reconnects after a PARENT restart still carries the previous process's
+        // `pid`. Reject it here — before the oRPC handler upgrades the socket —
+        // so its live subscriptions never replay against a process that never had
+        // them. The client reads STALE_PROCESS_CLOSE_CODE as a definitive restart
+        // and surfaces its reload affordance. An absent `pid` (the first-ever
+        // connect) always passes. `admin.processId` is the live id the
+        // `identity.info` probe reports, so the gate and the probe single-source.
+        if (
+          rejectStaleProcess(
+            url.searchParams.get(SERVER_PROCESS_ID_PARAM),
+            admin.processId,
+          )
+        ) {
+          log(`rejecting stale browser ws (host=${host}) — parent restarted`);
+          ws.close(STALE_PROCESS_CLOSE_CODE, "stale server process");
+          return;
+        }
         if (host === ADMIN_HOST_SENTINEL) {
           log("browser ws connect (admin)");
           ws.on("close", (code, reason) =>


### PR DESCRIPTION
Inherits the stale-tab handshake gate from `@kolu/surface-app`, now that [juspay/kolu#1231](https://github.com/juspay/kolu/pull/1231) has graduated it out of kolu — and made the turnkey `<SurfaceAppProvider { ws, probe }>` source handle the **whole** handshake. The kolu pin tracks that branch (`fix/stale-client-processid-gate`) at commit `13c378d9`; **re-pin to `master` once #1231 merges** (the squashed sha will differ).

### Why
drishti runs the *identical* transport stack as kolu — partysocket `1.1.16` + oRPC `1.13.13` + `@kolu/surface`'s `websocketLink` — and has the same failure: a tab open across a **parent restart** reconnects to the fresh process and replays its live subscriptions against state that process never had. #1231's lens review (lowy ⇄ hickey, twice, the second grounded in *this* repo's real source) established that the gate is therefore **shared `@kolu/surface-app` electricity**, not kolu-specific — so drishti inherits it rather than re-deriving it. This PR is the ③ graduation proof: a second consumer plugging into the upstreamed receptacle.

### What it wires

| Layer | Change |
|---|---|
| `server/admin-router.ts` | Capture `surfaceAppServer()` and expose its minted `processId` — so the gate compares against the **same** id `identity.info` reports (single-sourced, no second mint). |
| `server/main.ts` | Every `/rpc/ws` upgrade extracts the client's `pid` and calls `rejectStaleProcess(claimedPid, admin.processId)`; a mismatch `ws.close(STALE_PROCESS_CLOSE_CODE)` **before** the oRPC handler upgrades, so no dead subscription replays. |
| `client/wire.ts` | `makeSocket`'s URL is a **thunk** that echoes the last-known `processId` as `?pid=` (re-read on every reconnect). Per-host sockets **retire** (`retireSocket`: stop reconnect + throwing `send`) on a `STALE_PROCESS_CLOSE_CODE` close — they have no provider lifecycle, so they own that themselves. |
| `client/App.tsx` | The admin `<SurfaceAppProvider>` uses the turnkey `{ ws, probe }` source: `onProcessId` stashes the echoed id, `restartCloseCode` arms the stale-restart fast path, and the provider **retires the admin socket itself** on a stale-restart. |
| `client/TransportOverlay.tsx` | New dim overlay (drishti's tailwind palette, ported from kolu's `TransportOverlay`): a **Reload** prompt when `useSurfaceApp().updateReady()` (build skew OR parent restart), and a **"Reconnecting…"** state when `status() === "down"`. surface-app provides the model; the app renders the chrome. |

### Removed in this revision (workarounds the turnkey source obsoletes)
Earlier drafts pre-dated #1231 finishing the turnkey source, so they carried two hand-rolled bridges that are now gone:
- **the probe-WRAPPER** in `App.tsx` that stashed the observed `processId` from drishti's own `probe` callback — replaced by the provider's new `onProcessId` prop.
- **the admin-socket close-listener retirement** in `wire.ts` — the provider now retires the admin socket itself (`onStaleRestart: () => retireSocket(ws)` internally). `makeSocket(host, retire)` scopes the close-listener to per-host sockets only.

### Boundary notes (per #1231's lens review)
- `retireSocket` is **shared** — both consumers reverse-engineer the same partysocket `_shouldReconnect` + oRPC `ClientPeer` internals; it takes a structural `{ close; send }`, never the concrete `PartySocket`.
- The pid-echo mutable (`lastServerProcessId`) **stays drishti's**, by design: the echo must keep re-presenting the *dead* id to be re-rejected after a stale close.

### Verification
`just typecheck` passes against the re-pinned kolu tree (`rejectStaleProcess`, `SERVER_PROCESS_ID_PARAM`, `STALE_PROCESS_CLOSE_CODE`, `retireSocket`, `surfaceAppServer().processId`, and the provider's `onProcessId`/`updateReady()`/`reload()` all resolve from `@kolu/surface-app`). `just fmt-check` passes; client unit tests pass (55/55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)