### PR TITLE
Adopt @kolu/surface-app connection primitives (drop the hand-rolled echo/socket/gate)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "feat/surface-connection-plan",
+      "branch": "master",
       "submodules": false,
-      "revision": "dbe1900e800a1aab84cae704760a994328f73635",
-      "url": "https://github.com/juspay/kolu/archive/dbe1900e800a1aab84cae704760a994328f73635.tar.gz",
+      "revision": "1aeefdbd6b8b5dd78082b16fe47a518544adbe86",
+      "url": "https://github.com/juspay/kolu/archive/1aeefdbd6b8b5dd78082b16fe47a518544adbe86.tar.gz",
       "hash": "sha256-oWGvwk1tUA1SAaRoav0AeHGew4pGy1UCZLswCvGQcxw="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "feat/surface-connection-plan",
       "submodules": false,
-      "revision": "7126b5fa2a13b21bb1133a33e5d296f65ac2d75d",
-      "url": "https://github.com/juspay/kolu/archive/7126b5fa2a13b21bb1133a33e5d296f65ac2d75d.tar.gz",
-      "hash": "sha256-Iuz5DVWvxpZf3WTdtBzGYsUpM3BJ3GA2euccJmS6GQw="
+      "revision": "dbe1900e800a1aab84cae704760a994328f73635",
+      "url": "https://github.com/juspay/kolu/archive/dbe1900e800a1aab84cae704760a994328f73635.tar.gz",
+      "hash": "sha256-oWGvwk1tUA1SAaRoav0AeHGew4pGy1UCZLswCvGQcxw="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -13,12 +13,10 @@
 
 import { websocketLink } from "@kolu/surface/links/websocket";
 import { surfaceClient, surfaceClients } from "@kolu/surface/solid";
-import { WebSocket as PartySocket } from "partysocket";
 import {
-  SERVER_PROCESS_ID_PARAM,
-  STALE_PROCESS_CLOSE_CODE,
-} from "@kolu/surface-app";
-import { retireSocket } from "@kolu/surface-app/lifecycle";
+  createProcessIdEcho,
+  createSurfaceSocket,
+} from "@kolu/surface-app/connect";
 import {
   ADMIN_HOST_SENTINEL,
   adminContract,
@@ -26,58 +24,43 @@ import {
 } from "../common/admin-surface";
 import { surface } from "drishti-common";
 
-// The parent mints a fresh `processId` per boot. We echo the last-known one as a
+// ONE shared `pid` echo across every socket (per-host + admin). The parent mints
+// a fresh `processId` per boot; the echo threads the last-known one back as the
 // `pid` query param on every (re)connect so the parent recognizes a stale tab
-// after a restart and rejects it at the handshake (kolu#1231). `App.tsx` feeds
-// this via the provider's `onProcessId` callback (the turnkey `{ ws, probe }`
-// source publishes each observed id — kolu#1231); it's null until the first
-// probe, so the first connect omits the param. Read by the URL THUNK in
-// `makeSocket`, re-evaluated by partysocket on every reconnect.
-let lastServerProcessId: string | null = null;
-export function rememberServerProcessId(id: string): void {
-  lastServerProcessId = id;
+// after a restart and rejects it at the handshake. `App.tsx` feeds this via the
+// provider's `onProcessId` callback (the turnkey `{ ws, probe }` source publishes
+// each observed id); it's null until the first probe, so the first connect omits
+// the param. `createSurfaceSocket` reads it on every reconnect.
+const echo = createProcessIdEcho();
+export const rememberServerProcessId = echo.remember;
+
+// The base WS URL — WITHOUT the `pid` (the echo appends it). A per-host string is
+// built fresh on each reconnect by `createSurfaceSocket`'s URL thunk.
+function wsBaseFor(host: string): string {
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${location.host}/rpc/ws?host=${encodeURIComponent(host)}`;
 }
 
-function wsUrlFor(host: string): string {
-  const params = new URLSearchParams({ host });
-  if (lastServerProcessId) {
-    params.set(SERVER_PROCESS_ID_PARAM, lastServerProcessId);
-  }
-  return `${location.protocol === "https:" ? "wss:" : "ws:"}//${location.host}/rpc/ws?${params.toString()}`;
-}
-
-// `partysocket`'s `WebSocket` export is `ReconnectingWebSocket`. Cold
-// start can take 30+ seconds while the parent provisions the agent via
-// `nix copy`, so the connect deadline is bumped well past partysocket's
-// 4s default — without this, the socket flaps repeatedly during the
-// first connect. The URL is a THUNK so partysocket re-reads `lastServerProcessId`
-// (the `pid` echo) on every reconnect.
+// Cold start can take 30+ seconds while the parent provisions the agent via
+// `nix copy`, so the connect deadline is bumped well past partysocket's 4s
+// default — without this, the socket flaps repeatedly during the first connect.
 //
 // `retire` controls who tears the socket down on a stale-close: the per-host
-// sockets have no provider lifecycle, so they attach the close-listener
-// retirement themselves (`retire: true`). The admin socket is owned by
-// `<SurfaceAppProvider>`'s turnkey `{ ws, probe }` source, which retires it
-// itself (`onStaleRestart: () => retireSocket(ws)` internally, kolu#1231) — so
-// it opts out here (`retire: false`) to avoid a double-retire.
-function makeSocket(host: string, retire: boolean): PartySocket {
-  const ws = new PartySocket(() => wsUrlFor(host), undefined, {
-    connectionTimeout: 60_000,
-    minReconnectionDelay: 2_000,
-    maxReconnectionDelay: 15_000,
-  });
-  // When the parent rejects this socket as stale (a previous-process binding) it
-  // closes with STALE_PROCESS_CLOSE_CODE. RETIRE the socket: stop reconnect +
-  // fail further sends loudly, so neither partysocket's offline buffer nor oRPC's
-  // pending peers grow unbounded. A fresh page reconnects cleanly. `retireSocket`
-  // is shared @kolu/surface-app electricity (kolu#1231).
-  if (retire) {
-    ws.addEventListener("close", (event) => {
-      if ((event as CloseEvent).code === STALE_PROCESS_CLOSE_CODE) {
-        retireSocket(ws);
-      }
-    });
-  }
-  return ws;
+// sockets have no provider lifecycle, so they self-retire on a stale-close
+// (`retire: true`). The admin socket is owned by `<SurfaceAppProvider>`'s turnkey
+// `{ ws, probe }` source, which retires it itself — so it opts out (`retire:
+// false`) to avoid a double-retire.
+function makeSocket(host: string, retire: boolean) {
+  return createSurfaceSocket({
+    url: () => wsBaseFor(host),
+    echo,
+    socketOptions: {
+      connectionTimeout: 60_000,
+      minReconnectionDelay: 2_000,
+      maxReconnectionDelay: 15_000,
+    },
+    retireOnStaleClose: retire,
+  }).ws;
 }
 
 type HostClient = ReturnType<typeof buildHostSurface>;

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -28,12 +28,7 @@ import { Hono } from "hono";
 import { WebSocketServer } from "ws";
 import { z } from "zod";
 import { destroyAllSessions } from "@kolu/surface-nix-host";
-import {
-  rejectStaleProcess,
-  SERVER_PROCESS_ID_PARAM,
-  STALE_PROCESS_CLOSE_CODE,
-} from "@kolu/surface-app";
-import { installSurfaceApp } from "@kolu/surface-app/server";
+import { gateStaleSocket, installSurfaceApp } from "@kolu/surface-app/server";
 import { ADMIN_HOST_SENTINEL } from "../common/admin-surface";
 import { BRAND_DARK } from "../client/brand";
 import { appNameForHost } from "../client/title";
@@ -244,33 +239,34 @@ async function main(): Promise<void> {
       socket as Parameters<typeof wss.handleUpgrade>[1],
       head as Parameters<typeof wss.handleUpgrade>[2],
       (ws) => {
-        // Stale-tab handshake gate (kolu#1231 / @kolu/surface-app): a tab that
-        // reconnects after a PARENT restart still carries the previous process's
-        // `pid`. Reject it here — before the oRPC handler upgrades the socket —
+        // Stale-tab handshake gate (@kolu/surface-app): a tab that reconnects
+        // after a PARENT restart still carries the previous process's `pid`.
+        // `gateStaleSocket` installs the `error` listener FIRST (the one crash-free
+        // order), reads the claimed `pid` off the request URL, and on a stale tab
+        // closes with STALE_PROCESS_CLOSE_CODE before the oRPC handler upgrades —
         // so its live subscriptions never replay against a process that never had
-        // them. The client reads STALE_PROCESS_CLOSE_CODE as a definitive restart
-        // and surfaces its reload affordance. An absent `pid` (the first-ever
-        // connect) always passes. `admin.processId` is the live id the
-        // `identity.info` probe reports, so the gate and the probe single-source.
+        // them. An absent `pid` (the first-ever connect) always passes.
+        // `admin.processId` is the live id the `identity.info` probe reports, so
+        // the gate and the probe single-source. The installed `error` listener
+        // persists for the connection lifetime — so the per-branch handlers below
+        // no longer re-install one.
         if (
-          rejectStaleProcess(
-            url.searchParams.get(SERVER_PROCESS_ID_PARAM),
-            admin.processId,
-          )
-        ) {
-          log(`rejecting stale browser ws (host=${host}) — parent restarted`);
-          ws.close(STALE_PROCESS_CLOSE_CODE, "stale server process");
+          gateStaleSocket(ws, url, admin.processId, {
+            onError: (err) =>
+              log(`browser ws error (host=${host}): ${err.message}`),
+            onReject: () =>
+              log(
+                `rejecting stale browser ws (host=${host}) — parent restarted`,
+              ),
+          })
+        )
           return;
-        }
         if (host === ADMIN_HOST_SENTINEL) {
           log("browser ws connect (admin)");
           ws.on("close", (code, reason) =>
             log(
               `browser ws disconnect (admin) (code=${code} reason=${reason.toString() || "<none>"})`,
             ),
-          );
-          ws.on("error", (err) =>
-            log(`browser ws error (admin): ${err.message}`),
           );
           void adminHandler.upgrade(
             ws as unknown as Parameters<typeof adminHandler.upgrade>[0],
@@ -290,9 +286,6 @@ async function main(): Promise<void> {
             `browser ws disconnect (host=${host}) (code=${code} reason=${reason.toString() || "<none>"})`,
           );
         });
-        ws.on("error", (err) =>
-          log(`browser ws error (host=${host}): ${err.message}`),
-        );
         void handler.upgrade(
           ws as unknown as Parameters<typeof handler.upgrade>[0],
         );


### PR DESCRIPTION
kolu [#1234](https://github.com/juspay/kolu/pull/1234) lifted the WebSocket connection plumbing — the `pid`-echo, the `new PartySocket(...)` construction, and the server-side stale-tab gate — into three composable `@kolu/surface-app` primitives, because kolu and drishti had each hand-rolled the *same* code. This PR makes drishti consume them and deletes its copies.

## What changed

**Re-pin** kolu to `feat/surface-connection-plan` (`dbe1900e`), which exposes `@kolu/surface-app/connect` (`createProcessIdEcho` + `createSurfaceSocket`) and `@kolu/surface-app/server`'s `gateStaleSocket`.

**Client — `wire.ts`.** Build ONE shared echo (`createProcessIdEcho()`, re-exported as `rememberServerProcessId = echo.remember` so `App.tsx`'s `<SurfaceAppProvider onProcessId=…>` keeps feeding it), and rewrite `makeSocket(host, retire)` over `createSurfaceSocket({ url: () => wsBaseFor(host), echo, socketOptions, retireOnStaleClose: retire })`. The base URL no longer carries `pid` — the echo appends it. This **deletes** drishti's `lastServerProcessId` mutable, its hand-written `rememberServerProcessId`, the `wsUrlFor` pid-threading, and the manual `close → retireSocket` listener. The link + clients assembly (per-host + admin, the host cache, the accessors) stays consumer-owned by design.

**Server — `main.ts`.** Replace the inline upgrade gate with a single `gateStaleSocket(ws, url, admin.processId, { onError, onReject })` call as the first line of the `handleUpgrade` callback. Because `gateStaleSocket` installs the socket's `error` listener FIRST — the one crash-free order, which a hand-rolled gate gets wrong and drishti's only avoided by luck of timing — **drishti gains that error-handler-before-gate fix it never had**, and the now-redundant per-branch `ws.on("error", …)` handlers are dropped. The `ws.on("close", …)` handlers stay (they call `registry.unregisterConnection` — domain logic).

This is the paired ③-proof for kolu #1234: a second real consumer adopting the extracted primitives unchanged.

## Verification

`just typecheck` and `just fmt` pass against the new pin; `bun test` is green (124/124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)