### PR TITLE
Reap half-open WebSockets, and inherit kolu's client heartbeat

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "suited-salt",
+      "branch": "master",
       "submodules": false,
-      "revision": "b2533c6daa5412dafe8b42a18acbc1e0f34c0280",
-      "url": "https://github.com/juspay/kolu/archive/b2533c6daa5412dafe8b42a18acbc1e0f34c0280.tar.gz",
+      "revision": "485bbb5cbb09e470d9544c39decea02d90f5015c",
+      "url": "https://github.com/juspay/kolu/archive/485bbb5cbb09e470d9544c39decea02d90f5015c.tar.gz",
       "hash": "sha256-umdVGdx8dNMj57vzVSCOUFeiu19jZjP5wxQKCrlj9kA="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "release1",
+      "branch": "suited-salt",
       "submodules": false,
-      "revision": "b91fbf21895e134a5e128a4aadc1506e35f397df",
-      "url": "https://github.com/juspay/kolu/archive/b91fbf21895e134a5e128a4aadc1506e35f397df.tar.gz",
-      "hash": "sha256-KVf5qmRGcLsWX/Ae0NYzOk7BXS9QhReiWbbwWmcppWQ="
+      "revision": "b2533c6daa5412dafe8b42a18acbc1e0f34c0280",
+      "url": "https://github.com/juspay/kolu/archive/b2533c6daa5412dafe8b42a18acbc1e0f34c0280.tar.gz",
+      "hash": "sha256-umdVGdx8dNMj57vzVSCOUFeiu19jZjP5wxQKCrlj9kA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -28,7 +28,11 @@ import { Hono } from "hono";
 import { WebSocketServer } from "ws";
 import { z } from "zod";
 import { destroyAllSessions } from "@kolu/surface-nix-host";
-import { gateStaleSocket, installSurfaceApp } from "@kolu/surface-app/server";
+import {
+  gateStaleSocket,
+  installSurfaceApp,
+  startWsHeartbeat,
+} from "@kolu/surface-app/server";
 import { ADMIN_HOST_SENTINEL } from "../common/admin-surface";
 import { BRAND_DARK } from "../client/brand";
 import { appNameForHost } from "../client/title";
@@ -203,6 +207,15 @@ async function main(): Promise<void> {
     maxPayload: 8 * 1024 * 1024,
   });
 
+  // Liveness heartbeat (@kolu/surface-app): ping accepted sockets and terminate
+  // any that stop ponging, reaping the server-side zombie a half-open browser
+  // (laptop sleep, Wi-Fi roam, a NAT/proxy dropping an idle connection) would
+  // otherwise leak. Covers BOTH the admin control-plane socket and every per-host
+  // socket — each registers below, after the stale-tab gate. The browser's own
+  // recovery is automatic: the admin socket rides `<SurfaceAppProvider>`'s turnkey
+  // source, which now starts a `createHeartbeat` watchdog itself.
+  const heartbeat = startWsHeartbeat(wss);
+
   // ── WebSocket upgrade: parse ?host=<id>, then dispatch directly ──────
   // The `host` variable is closed over in the handleUpgrade callback so
   // there is no need to taint the IncomingMessage object with __host.
@@ -261,6 +274,10 @@ async function main(): Promise<void> {
           })
         )
           return;
+        // Accepted socket (gate passed): enrol it in the liveness heartbeat so a
+        // half-open client is reaped here. One call covers both branches below;
+        // gate-rejected sockets already returned.
+        heartbeat.register(ws);
         if (host === ADMIN_HOST_SENTINEL) {
           log("browser ws connect (admin)");
           ws.on("close", (code, reason) =>
@@ -297,6 +314,7 @@ async function main(): Promise<void> {
     log(`${sig}: destroying host sessions`);
     stopWakeMonitor();
     destroyAllSessions();
+    heartbeat.stop();
     wss.close();
     for (const ws of wss.clients) {
       try {


### PR DESCRIPTION
**A browser tab whose WebSocket goes *silently half-open* — TCP dead with no FIN/RST (laptop sleep, Wi-Fi roam, a NAT/proxy evicting an idle connection) — used to freeze a terminal until a manual reload, and leak a zombie socket on the parent.** This bumps the kolu pin to pick up [juspay/kolu#1235](https://github.com/juspay/kolu/pull/1235) (the half-open heartbeat, now merged to `master`) and wires the server half into drishti's WS loop. The client half comes for free.

### What changes

| Half | drishti change | How it recovers |
| --- | --- | --- |
| **Server reaper** | `startWsHeartbeat(wss)` + one `heartbeat.register(ws)` after the gate | pings accepted sockets every 30s, `terminate()`s any that stop ponging — frees the zombie socket + its stream subscriptions |
| **Client (admin socket)** | *none — automatic* | the admin socket rides `<SurfaceAppProvider>`'s turnkey `{ ws, probe }` source, which (as of #1235) starts a `createHeartbeat` watchdog itself: a probe unanswered within 10s forces `ws.reconnect()` and the connection recovers **with no reload** |

`register(ws)` sits once right after `gateStaleSocket` so it covers **both** the admin control-plane socket and every per-host socket; gate-rejected stale tabs already returned and never enrol. Stopped on shutdown beside `wss.close()`.

### The pin

kolu pin → `master` @ `485bbb5c` (where #1235 merged). The vendored `@kolu/*` package tree is unchanged apart from the heartbeat landing in `@kolu/surface-app`.

> **Follow-up (not in this PR):** the per-host sockets self-retire on a stale-close but have *no client-side heartbeat* — no lifecycle/probe watches them. The server reaper frees their server end, but a half-open per-host socket still needs a manual reconnect until a per-host probe is wired. Tracked separately.

### Validation

`just typecheck` (common + agent + app) and `just fmt-check` green against the master pin — which also confirms drishti's `App.tsx` turnkey `ws={adminSocket()}` satisfies the provider's widened socket type, so the admin-socket watchdog is wired with zero drishti code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)