### PR TITLE
Adapt to @kolu/surface's settled serveOverStdio (unix-socket upstreaming)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "r4-phase1-kolu-tui-list",
       "submodules": false,
-      "revision": "485bbb5cbb09e470d9544c39decea02d90f5015c",
-      "url": "https://github.com/juspay/kolu/archive/485bbb5cbb09e470d9544c39decea02d90f5015c.tar.gz",
-      "hash": "sha256-umdVGdx8dNMj57vzVSCOUFeiu19jZjP5wxQKCrlj9kA="
+      "revision": "ce2b040e085c727f4a01ffa277fb197254d53ae5",
+      "url": "https://github.com/juspay/kolu/archive/ce2b040e085c727f4a01ffa277fb197254d53ae5.tar.gz",
+      "hash": "sha256-rxV+GoGq0IYli762v+WzPeDQe+zpYpqjAx06pVlkJgA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "r4-phase1-kolu-tui-list",
+      "branch": "master",
       "submodules": false,
-      "revision": "ce2b040e085c727f4a01ffa277fb197254d53ae5",
-      "url": "https://github.com/juspay/kolu/archive/ce2b040e085c727f4a01ffa277fb197254d53ae5.tar.gz",
-      "hash": "sha256-rxV+GoGq0IYli762v+WzPeDQe+zpYpqjAx06pVlkJgA="
+      "revision": "4f8c3ced3067cc50159fdedf24e92d6e0da1c290",
+      "url": "https://github.com/juspay/kolu/archive/4f8c3ced3067cc50159fdedf24e92d6e0da1c290.tar.gz",
+      "hash": "sha256-WsmrbvKVRl/o2Uu2RgLjeGfIH5rZiCovNbJ9tvz0XJg="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -98,12 +98,16 @@ function processChanged(a: Process, b: Process): boolean {
  *  uses, so a test can inject a fake (the default is the real stdio
  *  transport, which is assignable to this). Module-private and named for the
  *  *role*, not the `serveOverStdio` implementation: nothing outside this file
- *  consumes it, and the test passes an inline, contextually-typed fake. */
+ *  consumes it, and the test passes an inline, contextually-typed fake.
+ *  Resolves to `unknown` because the agent only awaits serving's *end*, not
+ *  its value: the real `serveOverStdio` settles with a `ServeOverStdioEnd`
+ *  (`{ reason: "end" | "error" }` — it never rejects on a peer transport
+ *  death), while a test fake may simply resolve void. */
 type Serve = (opts: {
   // biome-ignore lint/suspicious/noExplicitAny: the kolu handler's router type; the real serveOverStdio is invoked with the same `as any` cast at the call site below.
   router: any;
   onFirstRequest: () => void;
-}) => Promise<void>;
+}) => Promise<unknown>;
 
 /**
  * Build the surface fragment + poll loop for `reader`, then serve it.


### PR DESCRIPTION
**Tracks juspay/kolu#1084's upstreaming of the unix-socket transport into `@kolu/surface`** — the mirror PR kolu's surface-sharing rule requires for API-facing surface changes.

Two things changed upstream:

| Upstream change | Effect on drishti |
| --- | --- |
| `serveOverStdio` now resolves with `ServeOverStdioEnd` (`{ reason: "end" \| "error" }`) and **never rejects** on a read-stream error | The agent's injectable `Serve` type widens its resolution to `Promise<unknown>` — it only awaits serving's *end*. Behaviorally better: a peer reset no longer risks an unhandled rejection in the agent. |
| New exports `@kolu/surface/unix-socket` (`serveOverUnixSocket`, `getRuntimeSocketPath`) + `@kolu/surface/links/unix-socket` (`unixSocketLink`), and `isContractVersionCompatible` in `/define` | Purely additive — nothing in drishti consumes them yet (they're the local-IPC link family member kolu-tui uses). |

juspay/kolu#1084 has merged, and the kolu pin now points at master (`4f8c3ce`, the merge revision) — the interim `r4-phase1-kolu-tui-list` branch pin served only to prove compatibility pre-merge.

Verified locally: `just typecheck` green across all three workspace members; `bun test packages/agent` 27/27.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-fable-5`)._
