### PR TITLE
Replace justci with odu (juspay/odu) as the CI runner

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -10,11 +10,25 @@ just fmt
 bun test
 
 ## CI command
-Use the `/ci` skill.
+The runner is **odu** (`github:juspay/odu`, which replaced justci — it ships
+its own lane runner, so this repo re-exports nothing). Prefer odu's MCP server
+to start and watch runs —
+`mcp__odu__run` then `mcp__odu__wait_for_settle` (fail-fast), drilling into a
+red node's log and `mcp__odu__rerun_node` to close a check. Use the `/ci` skill
+for the underlying CLI, flags, and run mechanics.
 
-<!-- Host routing comes from `~/.config/justci/hosts.json`
-(aarch64-darwin → rasam). For the x86_64-linux lane, provision a fresh Linux
-box with `pu create <NAME>` and route the platform to it. -->
+<!-- Host routing: `$ODU_HOSTS` → `~/.config/odu/hosts.json` (falls back to
+`~/.config/justci/hosts.json`). aarch64-darwin → rasam. For the x86_64-linux
+lane, route the platform to one of the `pu` boxes (`pu create <NAME>` to
+provision a fresh one if none is warm). -->
+
+<!-- Push before CI: odu's remote lanes `git fetch` the pushed HEAD SHA from
+origin (no git-bundle transport), so an unpushed commit can't run on rasam or a
+pu box. The /do flow pushes before the CI step — keep it that way. -->
+
+<!-- Never pass `--no-post` / `--no-strict` / `--no-snapshot` for a real CI run:
+those skip the GitHub status posts that update the PR's checks. -->
+
 
 
 ## Documentation

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -1,132 +1,182 @@
 ---
 name: ci
-description: Reference for the `justci` runner — how to invoke a full pipeline, a single recipe, or a platform-pinned node from a project that depends on `juspay/justci`. Trigger when the user asks to "run justci", "run the pipeline", "re-run a check", or names a specific recipe by `<recipe>@<platform>`.
+description: Reference for the `odu` runner — how to invoke a full pipeline, a single recipe, or a platform-pinned node, and how to attach to a live run, from a project whose CI odu runs. Trigger when the user asks to "run CI", "run the pipeline", "re-run a check", or names a specific recipe by `<recipe>@<platform>`.
 ---
 
-# justci
+# odu
 
-`justci` translates a project's `just` recipe DAG into a `process-compose` pipeline and runs it. Multi-platform lanes fan out via SSH; commit statuses get posted (in strict mode) under `<recipe>@<platform>` contexts. Full background in the [repo README](https://github.com/juspay/justci/blob/main/README.md); the subcommand surface below is what you'll reach for most often.
+[`odu`](https://github.com/juspay/odu) (Tamil ஓடு — "run") runs the `just`
+recipe DAG tagged `[metadata("ci")]` across platforms and posts GitHub
+commit statuses per `<recipe>@<platform>` context. Unlike batch runners,
+the run is **live state you attach to**: the coordinator serves a typed
+surface on `.ci/odu.sock`, so `status`/`logs`/`attach` are in-band — no
+process-compose, no separately-versioned socket client.
+
+> **Prefer the MCP face for runs.** When the `odu-mcp` skill is present (the
+> `mcp__odu__*` tools — check for an odu MCP server before shelling out), drive
+> runs through it — `run` → `wait_for_settle` (fail-fast) → read the red node's
+> log → `node_rerun`, with `cancel` / `run({supersede})` to call off or replace
+> a run. It spawns the same coordinator but gives you structured results and the
+> fail-fast loop instead of scraping terminal output. The `nix run … -- run`
+> CLI below is the reference and the fallback when no MCP server is wired.
+>
+> **Logs are a resource, not a tool.** Don't look for a log-tail tool — there
+> isn't one. A node's output is the MCP **resource** `surface://collections/logs/{id}`
+> (`{id}` is the node, e.g. `ci::unit@aarch64-darwin`), read with
+> `ReadMcpResourceTool`: the live buffered tail while the run is up, else the
+> durable per-SHA log on disk. So when `wait_for_settle` returns a red node, the
+> "read the log" step is `ReadMcpResourceTool` on that node's
+> `surface://collections/logs/{id}` — subscribe for push updates, or just re-read
+> to poll. (`surface://streams/nodes` is the pipeline snapshot resource alongside
+> it.)
 
 ## Invoking
 
-Always invoke via the flake — the consumer may not have `justci` installed on PATH:
-
 ```sh
-nix run github:juspay/justci -- <subcommand> [args]
+nix run github:juspay/odu -- <subcommand> [args]
 ```
 
-Pin to a tag (e.g. `github:juspay/justci/v0.2.0`) for reproducibility, or omit the ref to follow `main`. Every command in this skill is shown in the `nix run` form; substitute a pinned ref if your project requires one.
+Pin a ref for reproducibility, or — if the consuming repo npins-pins odu
+and re-exports it (kolu does) — prefer its own flake output so the version
+is repo-controlled:
+
+```sh
+nix run .#odu -- <subcommand> [args]
+```
 
 ## Modes
 
-| Variable | Effect |
-| --- | --- |
-| `CI` unset (default) | **Local mode.** Runs against the live working tree. No GitHub status posts, no clean-tree refuse. Use for iterating. |
-| `CI=true` | **Strict mode.** Refuses a dirty tree, snapshots `HEAD` via `git worktree`, posts commit statuses, splits per-recipe logs into `.ci/<sha>/<plat>/<recipe>.log`. Use for "real" CI runs. |
+**Strict by default** — `odu run` refuses a dirty tree, pins `HEAD` via
+`git worktree`, posts commit statuses, and splits per-recipe logs into
+`.ci/<sha>/<plat>/<recipe>.log`. Three flags relax that policy:
 
-Both modes share the same verdict-summary at the end (`── ci run summary ──`) and exit non-zero if any node failed.
+| Flags | Tree | HEAD pin | Status posts | Use for |
+| --- | --- | --- | --- | --- |
+| _(none — default)_ | clean (refuses dirty) | `git worktree` at HEAD | posted | "real" CI runs |
+| `--no-post` | clean | `git worktree` at HEAD | _none_ | non-GitHub strict consumers; debugging strict without writing the PR's check list |
+| `--no-snapshot` (implies `--no-post`) | live working tree | none | _none_ | strict-mode dev iteration without clean-tree refuse |
+| `--no-strict` (meta — same as `--no-snapshot --no-post`) | live working tree | none | _none_ | dev iteration; the one-flag opt-out for "just run the pipeline" |
+
+Every mode ends with the same `── ci run summary @ <sha7> ──` verdict block
+(the sha reads `<sha7>+dirty` for a live-tree run on uncommitted changes)
+and exits non-zero if any node failed or errored.
 
 ## Common invocations
 
 ```sh
-# Full pipeline (canonical [metadata("ci")] root, every platform in the fanout)
-nix run github:juspay/justci -- run                # local mode
-CI=true nix run github:juspay/justci -- run        # strict mode
+# Full pipeline (the [metadata("ci")] root, every configured platform).
+nix run github:juspay/odu -- run
 
-# Re-run a single failed recipe on a specific lane — overwrites the same
-# GitHub commit-status context the full run wrote (closes the red check).
-nix run github:juspay/justci -- run e2e@x86_64-linux
+# Dev iteration on a dirty tree: no clean-tree refuse, no HEAD pin, no posts.
+nix run github:juspay/odu -- run --no-strict
 
-# Re-run a single recipe across every pipeline platform.
-nix run github:juspay/justci -- run e2e
+# Re-run a single failed recipe on one lane — overwrites the same GitHub
+# commit-status context the full run wrote (closes the red check).
+nix run github:juspay/odu -- run e2e@x86_64-linux
 
-# Multiple positional selectors compose — `e2e` AND `lint` both run.
-nix run github:juspay/justci -- run e2e lint
+# One recipe across every pipeline platform; selectors compose.
+nix run github:juspay/odu -- run e2e lint
 
-# Skip the dependency closure; run ONLY the named nodes. Setup nodes
-# auto-ride for remote-platform recipes regardless.
-nix run github:juspay/justci -- run --no-deps e2e@aarch64-darwin
+# Restrict the WHOLE fanout to one platform (repeatable).
+nix run github:juspay/odu -- run --platform x86_64-linux
 
-# Use a different DAG root instead of the [metadata("ci")] recipe.
-nix run github:juspay/justci -- run --root release-pipeline
+# Skip the dependency closure; run ONLY the named nodes (_ci-setup still rides).
+nix run github:juspay/odu -- run --no-deps e2e@aarch64-darwin
 
-# One-shot redirect of a platform to a throwaway host (LXC container,
-# alternate SSH alias). Repeatable per platform.
-nix run github:juspay/justci -- run --host x86_64-linux=root@lxc-foo
+# A different DAG root instead of the [metadata("ci")] recipe.
+nix run github:juspay/odu -- run --root ci::e2e
 
-# Drive process-compose's interactive TUI instead of headless logs.
-nix run github:juspay/justci -- run --tui
+# One-shot redirect of a platform's host (how a pool-lease wrapper pins a box).
+nix run github:juspay/odu -- run --host x86_64-linux=my-build-box
 
-# Forward arbitrary args to `process-compose up` after --.
-nix run github:juspay/justci -- run -- -t=false
+# One NDJSON line per node transition, for agents/tools driving CI:
+# {"node":"ci::e2e@x86_64-linux","recipe":"ci::e2e","platform":"x86_64-linux",
+#  "status":"running|success|failed|skipped|errored","exit_code":1,
+#  "log":".ci/<sha7>/x86_64-linux/ci::e2e.log"}
+nix run github:juspay/odu -- run --progress json
 ```
+
+Without `--progress json`, output adapts to where stdout points: a live
+colour lane-matrix with a log-tail footer on a TTY; quiet transition lines
+plus a once-a-minute "… still running" heartbeat when piped.
 
 ## Inspection subcommands (no side effects)
 
 ```sh
-# Print the assembled process-compose YAML — no host prompts, no git
-# rev-parse, works offline.
-nix run github:juspay/justci -- dump-yaml
-
-# Print the dependency graph in Mermaid flowchart syntax.
-nix run github:juspay/justci -- graph
-
-# PATCH GitHub branch-protection's required_status_checks to the
-# (recipe, platform) contexts the canonical DAG produces. --dry-run
-# prints what would be PATCHed without touching the API.
-nix run github:juspay/justci -- protect --dry-run
-nix run github:juspay/justci -- protect                  # writes to default branch
-nix run github:juspay/justci -- protect --branch develop
+nix run github:juspay/odu -- dump            # resolved pipeline as JSON
+nix run github:juspay/odu -- graph           # dependency graph (Mermaid)
+nix run github:juspay/odu -- protect --dry-run   # the (recipe × platform) contexts
+nix run github:juspay/odu -- protect             # PATCH branch protection to them
 ```
 
-## Live introspection (during a backgrounded run)
+## Live introspection (attach to a run in progress)
 
-When `justci run` is in progress — typically because the agent backgrounded it (e.g. `loop until /ci passes`) — these subcommands report fine-grained per-node state without disturbing the run. Each resolves the socket and process-compose binary from the same source `justci run` itself uses, so the client version never drifts from the server.
+While `odu run` is live in a checkout, these attach to its surface over
+`.ci/odu.sock`:
 
 ```sh
-# Snapshot every node's current state. Pipe `-o json` into jq for
-# fields like name / status / exit_code / restarts.
-nix run github:juspay/justci -- status
-nix run github:juspay/justci -- status -o json
-
-# Live state-transition stream — one line per (recipe, platform)
-# transition, no polling. `-o json` emits one event per line.
-nix run github:juspay/justci -- monitor
-
-# Tail one node's stdout/stderr; `-f` follows.
-nix run github:juspay/justci -- logs ci::e2e@aarch64-darwin
-nix run github:juspay/justci -- logs -f ci::e2e@aarch64-darwin
+nix run github:juspay/odu -- status          # snapshot; -o json for tooling
+nix run github:juspay/odu -- attach          # live TUI dashboard on a tty
+                                             # (digits attach · n/p cycle ·
+                                             #  r rerun · q quit); -o json
+                                             # = transition stream
+nix run github:juspay/odu -- logs -f e2e@x86_64-linux
+nix run github:juspay/odu -- cancel          # stop the live run, cleanly
 ```
 
-If no run is in progress in this checkout, the subcommand exits non-zero with `no justci run in progress in this checkout (no socket at .ci/pc.sock)`.
+No run in progress ⇒ exit non-zero with `no run in progress in this
+checkout (no live socket at .ci/odu.sock)`. One run per checkout — a
+second `odu run` refuses while the socket is live.
 
-### Anti-pattern: do not reach for raw process-compose
-
-If you find yourself typing `nix run nixpkgs#process-compose --` or hunting through `/nix/store/...-process-compose-*/bin/` for a binary, stop — that path is not guaranteed to match the version the running pipeline uses, and the JSON shapes (e.g. `process list -o json`) may disagree. Always go through `nix run github:juspay/justci -- {status,logs,monitor}` so client and server stay version-pinned.
-
-## Decision flow
-
-1. **Full canonical run?** → `nix run github:juspay/justci -- run` (or `CI=true …` for strict mode).
-2. **Flaky check on a PR, only one lane is red?** → `nix run github:juspay/justci -- run <recipe>@<platform>` — same status context, overwrites the failure.
-3. **Iterating on one recipe locally?** → `nix run github:juspay/justci -- run <recipe>` (no platform pin = fans out to every pipeline platform; `<recipe>@<localPlat>` if you only want the local lane).
-4. **Investigating "what would this run?"** → `nix run github:juspay/justci -- dump-yaml` or `… -- graph`.
-5. **Setting up a new repo?** → run `… -- protect --dry-run` after at least one full run, verify the contexts look right, then `… -- protect` to lock them in.
-6. **Checking on a backgrounded run?** → `nix run github:juspay/justci -- status` for a snapshot, `… -- logs -f <recipe>@<platform>` to follow one node, `… -- monitor` for the live event stream.
+**Cancel / supersede / linger.** `odu cancel` drives the live run's teardown
+from a second process (finalize posted statuses, close lanes, drop the socket)
+and waits until it's gone — no need to wait out a doomed run or `pkill` the
+coordinator. `odu run --supersede` cancels whatever's live here first, then
+starts ("stop this, run the fixed commit"). By default a run exits the instant
+it drains; `odu run --linger` keeps it serving past settle so a node can be
+rerun later (retry a flake), self-reaping after an idle period or on `cancel`.
 
 ## Hosts config
 
-`justci` reads `~/.config/justci/hosts.json`:
+`$ODU_HOSTS` (a file path) → `~/.config/odu/hosts.json` → fallback
+`~/.config/justci/hosts.json` (zero-config migration from justci):
 
 ```json
 {
-  "x86_64-linux":   "srid1",
-  "aarch64-darwin": "sincereintent"
+  "x86_64-linux": "my-linux-builder",
+  "aarch64-darwin": "me@mac-mini.local"
 }
 ```
 
-Keys are full Nix system tuples (`x86_64-linux`, `aarch64-linux`, `aarch64-darwin`). Values are anything `ssh` knows how to dial — bare hostname, `user@host`, alias from `~/.ssh/config`. Missing platforms silently drop from the fanout (the user opts in by adding the entry). Override per-run with `--host PLATFORM=ADDR`.
+Keys are Nix system tuples; values are anything ssh dials, or `localhost`
+(runs directly against the snapshot, no closure copy). Missing platforms
+silently drop from the fanout. `--host PLAT=ADDR` overrides per run.
+
+A lane host needs only **ssh + Nix + outbound https**: the runner ships as
+a Nix closure (`nix copy` → realise on the host), and the source arrives by
+`git fetch` of the **pushed** SHA — remote lanes cannot test unpushed
+commits (no git-bundle transport; push first). The lane host's own nix is
+used on the runner's PATH (never a pinned client — version skew against the
+host daemon corrupts CA-derivation handling).
+
+## Semantics worth knowing
+
+- **Lanes are one-shot**: a lane whose ssh link dies mid-run fails as
+  `errored` (GitHub state `error`, `Errored (<dur>)` description); live
+  state does not survive a runner restart — the per-SHA log files do.
+- **Skipped nodes post no status**: an absent required context is what
+  blocks the merge.
+- The coordinator resolves the lane runner via
+  `nix eval <snapshot>#packages.<platform>.odu-runner.drvPath` — the
+  consuming repo's flake must expose `odu-runner` (re-export odu's, as
+  kolu does) until odu threads its own runner derivation.
 
 ## When NOT to use this skill
 
-- The user is asking *about* justci's internals (how the YAML is shaped, what the setup node does, why `[metadata("ci")]` matters) — that's a docs question, point them at the [repo README](https://github.com/juspay/justci/blob/main/README.md).
-- The user wants the runner to do something it doesn't support (parallel cross-platform within one recipe, mid-run config reload) — those are not supported today; check the README's Roadmap section.
+- Questions about odu's internals or design history — read the
+  [README](https://github.com/juspay/odu/blob/master/README.md) and the
+  kolu Atlas note
+  [*A CI runner you attach to*](https://github.com/juspay/kolu/blob/master/docs/atlas/dist/mini-ci-vs-justci.html).
+- Project-specific CI operations (warm pools, host leases, banned flags)
+  — that's the consuming repo's operational docs, layered on top of this
+  reference.

--- a/.claude/skills/odu-mcp/SKILL.md
+++ b/.claude/skills/odu-mcp/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: odu-mcp
+description: odu MCP server launcher — drive CI from a coding agent. `bin/serve` resolves odu via Nix and runs `odu mcp` in the cwd. See the repo README for the tools/resources and override knobs.
+user-invocable: false
+---
+
+# odu-mcp
+
+The agent face of [odu](https://github.com/juspay/odu) — an MCP stdio server
+that re-exposes a live CI run as agent tools (`run`, `node_rerun`,
+`wait_for_settle`, `cancel`) and subscribable resources (`surface://streams/nodes`,
+`surface://collections/logs/{id}`), so Claude Code / Codex / opencode / Gemini
+CLI drive CI with structured calls instead of scraping terminal output.
+
+`cancel` stops the live run and waits until it's torn down; `run`'s `supersede`
+cancels a run already live here before starting (the "stop this, run the fixed
+commit" move), and `linger` keeps the coordinator serving past settle so a node
+can be rerun afterwards. Together they let the agent loop call off or replace a
+run instead of stranding it or hitting "a run is already in progress".
+
+`bin/serve` is self-contained — it resolves odu via `nix run` and serves over
+stdio in the consumer's repo (dialing `.ci/odu.sock`). Set `ODU_FLAKE` to
+override the odu flake-ref (default `github:juspay/odu`); a repo that
+re-exports odu can point it at its own pinned output with `ODU_FLAKE=.#odu`.
+
+Full docs in the [repo README](https://github.com/juspay/odu/blob/master/README.md).
+
+This skill primitive exists for APM's deployment convention — it lands
+`bin/serve` at `.agents/skills/odu-mcp/bin/serve` in the consumer's working
+tree (APM's skills-convergence path), which keeps the launcher available even
+before `apm install` runs on a fresh clone. The package is mechanically a
+"skill" in APM's primitive vocabulary; semantically it's a tool launcher.

--- a/.claude/skills/odu-mcp/bin/serve
+++ b/.claude/skills/odu-mcp/bin/serve
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Launch the odu MCP server — odu's agent face. Resolves odu via Nix and runs
+# `odu mcp` in the current directory: the server dials `.ci/odu.sock` and
+# starts / attaches to runs in the cwd, so an MCP host launching this from the
+# repo root drives that repo's CI. Self-contained — no surrounding devshell
+# required. Requires flakes (`experimental-features = nix-command flakes`).
+#
+# Override knobs (env vars):
+#   ODU_FLAKE   — flake-ref for odu (default: github:juspay/odu). A consuming
+#                 repo that re-exports odu can point this at its pinned output,
+#                 e.g. ODU_FLAKE=.#odu
+set -euo pipefail
+exec nix run --accept-flake-config "${ODU_FLAKE:-github:juspay/odu}" -- mcp "$@"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,11 @@
       "type": "stdio",
       "command": ".claude/skills/nix-chrome-devtools-mcp/bin/serve",
       "args": []
+    },
+    "odu": {
+      "type": "stdio",
+      "command": ".claude/skills/odu-mcp/bin/serve",
+      "args": []
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The client bundler is a hand-rolled `Bun.build` pipeline (`packages/app/src/serv
 
 ### CI
 
-CI runs via [`juspay/justci`](https://github.com/juspay/justci). The canonical pipeline lives in `ci/mod.just`; runners are configured in `~/.config/justci/hosts.json`.
+CI runs via [odu](https://github.com/juspay/odu) — "a CI runner you attach to" — invoked straight from upstream (`nix run github:juspay/odu -- run`). odu ships its own generic lane runner (`nix copy`d to remote lanes), so this repo re-exports nothing. The canonical pipeline is the `[metadata("ci")]` DAG in `ci/mod.just`; it builds every flake output, type-checks, checks formatting + `bun.nix` freshness, asserts agent `.drv` stability, and boots the home-manager example. Lane hosts come from `~/.config/odu/hosts.json` (falling back to `~/.config/justci/hosts.json`); a live run is attachable (`nix run github:juspay/odu -- attach`) and agents drive it through odu's MCP server (`mcp__odu__*`).
 
 One upstream issue currently shapes how CI runs:
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,6 +1,6 @@
 lockfile_version: '1'
-generated_at: '2026-05-27T21:07:00.412990+00:00'
-apm_version: 0.15.0
+generated_at: '2026-06-13T15:01:42.893566+00:00'
+apm_version: 0.20.0
 dependencies:
 - repo_url: anthropics/claude-code
   host: github.com
@@ -11,25 +11,37 @@ dependencies:
   package_type: claude_skill
   deployed_files:
   - .claude/skills/frontend-design
-  content_hash: sha256:e8118284a6365753790d44bb2758a6032b3af27fa84696428d9233f2be0f4e78
-- repo_url: juspay/justci
-  host: github.com
-  resolved_commit: 6165126f4bdd1aae7ee5453fcdaf73b4e6200456
-  resolved_ref: main
-  package_type: apm_package
-  deployed_files:
-  - .claude/rules/workflow.md
-  - .claude/skills/ci
+  - .claude/skills/frontend-design/SKILL.md
   deployed_file_hashes:
-    .claude/rules/workflow.md: sha256:babf61cdd29cfc8f03b3d20f17b4bf13ef5f173dc05640bc83c505dca4b42010
-  content_hash: sha256:60745725e99f0ca9de52b079a325dfc9640c8b1404b5f988951833218b50130e
+    .claude/skills/frontend-design/SKILL.md: sha256:d39adf3a983de7dafc75991590d54f091755f7e4163d5a5ed085ecd719157184
+  content_hash: sha256:e8118284a6365753790d44bb2758a6032b3af27fa84696428d9233f2be0f4e78
 - repo_url: juspay/nix-chrome-devtools-mcp
   host: github.com
   resolved_commit: a202612693800c9d9ac9035ca0df80f2e92ded3b
   package_type: apm_package
   deployed_files:
   - .claude/skills/nix-chrome-devtools-mcp
+  - .claude/skills/nix-chrome-devtools-mcp/SKILL.md
+  - .claude/skills/nix-chrome-devtools-mcp/bin/serve
+  deployed_file_hashes:
+    .claude/skills/nix-chrome-devtools-mcp/SKILL.md: sha256:78f9b651b1c832b4db6fe6aa9d588c2a84521c2d9ab0f60432813c98352d3ce0
+    .claude/skills/nix-chrome-devtools-mcp/bin/serve: sha256:d8988c3305ba7faf43293c911c47beb7df09b72ed00b324a58e73abe253820a8
   content_hash: sha256:51308bd8cc8b6ae24781a77b67a7c8140bdea5d793e35427e7b8fcbeb0662074
+- repo_url: juspay/odu
+  host: github.com
+  resolved_commit: 5929073bc87bb447f0180722d34c094f5c0eb50c
+  package_type: apm_package
+  deployed_files:
+  - .claude/skills/ci
+  - .claude/skills/ci/SKILL.md
+  - .claude/skills/odu-mcp
+  - .claude/skills/odu-mcp/SKILL.md
+  - .claude/skills/odu-mcp/bin/serve
+  deployed_file_hashes:
+    .claude/skills/ci/SKILL.md: sha256:a06a58c057a3d19e03e44725ba7454fc154851381d707b93293a2b4197fad8ca
+    .claude/skills/odu-mcp/SKILL.md: sha256:25cd14d47aa082fb4061e793d3b74095eeb6749672356eea6b9acde9f9de6863
+    .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
+  content_hash: sha256:b2fb52475f4a6f8fb550378355980f10e4e9b10eb23fc08b0a075a70d198625d
 - repo_url: juspay/skills
   host: github.com
   resolved_commit: e5791cf388499456c8083a1667ecc1bd6c35fe2c
@@ -38,6 +50,9 @@ dependencies:
   package_type: claude_skill
   deployed_files:
   - .claude/skills/nix-for-dev
+  - .claude/skills/nix-for-dev/SKILL.md
+  deployed_file_hashes:
+    .claude/skills/nix-for-dev/SKILL.md: sha256:28267fd00f8961e5bbb960af1c9bce875ff03efb05d1dbeb56dc57b56614a169
   content_hash: sha256:222bee6d02ef727eff965ae224683604c59d387c3e4ce47582543a8550b86bc4
 - repo_url: juspay/skills
   host: github.com
@@ -47,6 +62,9 @@ dependencies:
   package_type: claude_skill
   deployed_files:
   - .claude/skills/nix-justfile
+  - .claude/skills/nix-justfile/SKILL.md
+  deployed_file_hashes:
+    .claude/skills/nix-justfile/SKILL.md: sha256:730345294a6536793ede474dc7f624faa83af6e97dbcbeb10fed1954a0d408fd
   content_hash: sha256:8f48e067e59da48c3ac90b4e2228ebb4ecfd988375b40efe831339d9a493accd
 - repo_url: srid/agency
   host: github.com
@@ -59,25 +77,57 @@ dependencies:
   - .claude/hooks/agency/scripts/do-stop-guard.sh
   - .claude/rules/apm-sources.md
   - .claude/skills/code-police
+  - .claude/skills/code-police/SKILL.md
   - .claude/skills/do
+  - .claude/skills/do/SKILL.md
+  - .claude/skills/do/scripts/do-results
+  - .claude/skills/do/scripts/steps/done
+  - .claude/skills/do/scripts/steps/sync
   - .claude/skills/elegance
+  - .claude/skills/elegance/SKILL.md
   - .claude/skills/fact-check
+  - .claude/skills/fact-check/SKILL.md
   - .claude/skills/forge-pr
+  - .claude/skills/forge-pr/SKILL.md
   - .claude/skills/hickey
+  - .claude/skills/hickey/SKILL.md
+  - .claude/skills/hickey/transcript.md
   - .claude/skills/lowy
+  - .claude/skills/lowy/SKILL.md
   - .claude/skills/ralph
+  - .claude/skills/ralph/SKILL.md
   - .claude/skills/talk
+  - .claude/skills/talk/SKILL.md
   deployed_file_hashes:
     .claude/agents/hickey.md: sha256:10d9a4350a85752dc6658af8e0efb3d8be41803a2b6c73464e3d5b7a840435ad
     .claude/agents/lowy.md: sha256:05aff7f6a91149a42c1fb9a3ca382a6f77bc39ac8a8d45436d443dd3349fb11e
     .claude/hooks/agency/scripts/do-stop-guard.sh: sha256:cb033f86c15ffd3d09d8e4b74a61f55a70def4cc4131cc013b7368a2d23f3f33
     .claude/rules/apm-sources.md: sha256:0d34f182279b93803855bd7f7b27a57e7cf3117ce4291d31a46294c629ee75d5
+    .claude/skills/code-police/SKILL.md: sha256:5a9f4ec8c2c2c44aaf7305561ee44884fbf551d45b27f94373eec49a18e5ad1f
+    .claude/skills/do/SKILL.md: sha256:d3c384a216c2c6f27506c65d6b2070617048577d3b5260195640fe5886913627
+    .claude/skills/do/scripts/do-results: sha256:2684dfce9cc7e4314d56c39edd5495628ac65d0631860e27e11f17fdcc0c7d49
+    .claude/skills/do/scripts/steps/done: sha256:03513d90bea1357eef3379c5b4fee5e46fe2d67b41fe8cf8b52d4beba4c73c72
+    .claude/skills/do/scripts/steps/sync: sha256:88fc95c548b183b766df02285038bf12d43fd06ae32b9a15f57dd741d9c83466
+    .claude/skills/elegance/SKILL.md: sha256:f330bf7e37034587f717e3a3d6453bd04ba80522fd9bdf8921a7140c7d5d3a3c
+    .claude/skills/fact-check/SKILL.md: sha256:6c4280ef618d27c278fc34365d336b1f889afb5b92f06ef6199fafe5a11304c0
+    .claude/skills/forge-pr/SKILL.md: sha256:78c66fbcb5146dbd83d856540eb810978fd9236e2d66cb4ebf14a2a012b9cda6
+    .claude/skills/hickey/SKILL.md: sha256:6eccc8ef4a2368c8ca898abde4b8a94451b844bb9cc082767a718fa2796c29ef
+    .claude/skills/hickey/transcript.md: sha256:c7da3fda455cc17adc5788984954baf95a354f2e83367bff0efd1b01f45a96a3
+    .claude/skills/lowy/SKILL.md: sha256:082aa643189b3b31fa90fb185a01239cfb5e437cdd7b1afb122de1e533ac48eb
+    .claude/skills/ralph/SKILL.md: sha256:1b2c547102584c87384b90b291536bedc0494dcb8382ac776bd0a3cec0fe1b4a
+    .claude/skills/talk/SKILL.md: sha256:ba059751cd4b3c1c52221554719bfe1fc5da56540694cb8e793ae0c19e210377
   content_hash: sha256:5a4a4d50e6298dc5015412eb1000e8c233cf6d872cc27b902b07979c466127b2
 mcp_servers:
 - chrome-devtools
+- odu
 mcp_configs:
   chrome-devtools:
     name: chrome-devtools
     transport: stdio
     registry: false
     command: .agents/skills/nix-chrome-devtools-mcp/bin/serve
+  odu:
+    name: odu
+    transport: stdio
+    registry: false
+    command: .agents/skills/odu-mcp/bin/serve

--- a/apm.yml
+++ b/apm.yml
@@ -14,7 +14,7 @@ target: claude
 dependencies:
   apm:
     - srid/agency#master
-    - juspay/justci#main
+    - juspay/odu
     - anthropics/claude-code/plugins/frontend-design/skills/frontend-design#main
     - juspay/skills/skills/nix-for-dev
     - juspay/skills/skills/nix-justfile

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -1,8 +1,13 @@
-# drishti CI pipeline — consumed by github:juspay/justci.
+# drishti CI pipeline — consumed by odu (github.com/juspay/odu).
 #
 # The runner discovers the recipe tagged [metadata("ci")] (exactly one across
 # this justfile and its submodules), expands its reachable dependency subgraph,
-# and fans every (recipe × platform) pair out into a process-compose node.
+# and fans every (recipe × platform) pair out as a pipeline node odu holds as
+# live state on `.ci/odu.sock` (attach with `nix run github:juspay/odu -- attach`).
+# odu ships its own generic lane runner, so this repo re-exports nothing. Lane
+# hosts come from hosts.json ($ODU_HOSTS → ~/.config/odu/hosts.json →
+# ~/.config/justci/hosts.json); a `localhost` lane runs against the HEAD
+# snapshot, remote lanes `git fetch` the pushed SHA into a per-SHA workspace.
 
 set working-directory := '..'
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,8 +61,11 @@
     in
     {
       packages = eachSystem ({ pkgs, b2n }:
-        let drvs = import ./default.nix { inherit pkgs b2n agentDrvBySystem rev; };
-        in {
+        let
+          drvs = import ./default.nix { inherit pkgs b2n agentDrvBySystem rev; };
+
+        in
+        {
           # `nix run github:srid/drishti -- user@host` → the monitor.
           default = drvs.drishti;
           inherit (drvs) drishti drishti-agent drishti-client drishtiBuilt drishtiAgentBuilt;

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -14,7 +14,7 @@
 # `nix flake update` in this directory makes standalone evaluation work.
 {
   inputs = {
-    # In CI, justci builds this with --override-input drishti pointing to the repo root.
+    # In CI, odu builds this with --override-input drishti pointing to the repo root.
     drishti.url = "github:srid/drishti";
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     home-manager.url = "github:nix-community/home-manager";


### PR DESCRIPTION
Swaps drishti's CI runner from [`juspay/justci`](https://github.com/juspay/justci) to [`juspay/odu`](https://github.com/juspay/odu) — justci's successor, "a CI runner you attach to." The pipeline contract is unchanged: same `[metadata("ci")]` just-DAG, the same `<recipe>@<platform>` status contexts, the same per-SHA log layout, and the same strict-by-default flag table. What's new is a live, attachable run surface (`nix run github:juspay/odu -- attach`) on `.ci/odu.sock`, and a first-class MCP face (`mcp__odu__*`) for agents.

odu is invoked **straight from upstream** — `nix run github:juspay/odu -- run`, which is also the `odu-mcp` launcher's default. odu resolves and `nix copy`s its **own** generic lane runner, so this repo re-exports nothing and adds no flake input or npins pin.

## What changed

| Area | Change |
| --- | --- |
| `apm.yml` / lock / `.claude` / `.mcp.json` | `juspay/justci#main` → `juspay/odu`; `apm install` drops justci's `ci` skill and deploys odu's `ci` + `odu-mcp` skills and the `odu` MCP server |
| `ci/mod.just`, `README.md`, `.agency/do.md`, `nix/home/example/flake.nix` | Docs/comments point at `github:juspay/odu`; host routing notes `~/.config/odu/hosts.json` (rasam for darwin, a `pu` box for linux), falling back to the old justci path |
| `.claude/rules/workflow.md` | Kept as a repo-owned rule — justci had shipped it ("keep `README.md` in sync"); odu ships no equivalent to consumers |

## Requires: [juspay/odu#31](https://github.com/juspay/odu/pull/31) on master

This PR relies on odu resolving its lane runner from **its own** flake (`ODU_RUNNER_FLAKE` / `--runner-flake`) instead of from the repo under test — odu#31, which closes [odu#30](https://github.com/juspay/odu/issues/30). Until that's on `master`, `nix run github:juspay/odu` still expects the consumer to re-export `odu-runner`. **Merge odu#31 first; then this PR's CI is green.**

<details>
<summary>History: why no re-export (the odu#30 round-trip)</summary>

The first cut of this PR re-exported odu's `odu` + `odu-runner` from `flake.nix` (the kolu pattern), because odu's coordinator evaluated `<consumer>#packages.<plat>.odu-runner.drvPath` — proven by removing the re-export and watching a github-launched run die at `_ci-setup` with `nix eval odu-runner drv failed`. That was confusing (the coordinator runs from github, yet wanted the consumer's flake), so it became [odu#30](https://github.com/juspay/odu/issues/30) → fixed by odu#31. With #31, the runner is baked onto the odu binary from `self.outPath`, so the re-export is deleted here.
</details>

## Verification

Against PR #31 (`github:juspay/odu/<#31>`), with **no** `odu`/`odu-runner` in drishti's flake:

```
$ nix run github:juspay/odu/<#31> -- run --no-strict --no-deps \
    --host x86_64-linux=localhost fmt-check@x86_64-linux
[host:localhost] realising '/nix/store/xn9bi4ci…-odu-runner.drv'…   # ← from ODU's flake
✔ success _ci-setup@x86_64-linux 2s
✔ success ci::fmt-check@x86_64-linux 3s
2 ok · 0 failed · 0 errored · 0 skipped — OK
```

`xn9bi4ci…-odu-runner.drv` is byte-identical to `github:juspay/odu/<#31>#packages.x86_64-linux.odu-runner.drvPath` — the runner came from odu, not this repo. The full multi-platform pipeline runs on PR via `nix run github:juspay/odu -- run` (rasam + a linux `pu` box), posting the per-`(recipe, platform)` commit statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
