### PR TITLE
Bump kolu pin: stdio-teardown EPIPE fix (#32)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "38649db417dd7dadb4b20cc05d2ad595b9bbf61e",
-      "url": "https://github.com/juspay/kolu/archive/38649db417dd7dadb4b20cc05d2ad595b9bbf61e.tar.gz",
-      "hash": "sha256-ReaTS25J3zVR3svN8+2CPmcMxLwS+FBlazp6ro/1zys="
+      "revision": "5b5722cf79edd817e77c520cd141371ca3eb0fdf",
+      "url": "https://github.com/juspay/kolu/archive/5b5722cf79edd817e77c520cd141371ca3eb0fdf.tar.gz",
+      "hash": "sha256-hrVTpaNBNZO+L67LRgv9hrtEuoM/7Rqh/Nvno3RfvVo="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Picks up [juspay/kolu#1333](https://github.com/juspay/kolu/pull/1333) — `@kolu/surface`'s framed send now swallows a benign dead-pipe write (`EPIPE` / `ERR_STREAM_DESTROYED`) during stdio teardown, fixing the unhandled `write EPIPE` crash on lane/session teardown after a clean run ([juspay/odu#32](https://github.com/juspay/odu/issues/32)).

drishti consumes the same stdio link/peer-server code in its monitor's `HostSession`, so this hardens drishti's own teardown too — and drishti was the consumer in the #32 repro (odu running against it over two remote ssh lanes).

`npins update kolu` → `5b5722cf`. Verified locally: `nix build .#default` rebuilds clean against the bumped surface. odu CI (the now-fixed coordinator running drishti's DAG on both platforms) is the end-to-end proof on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)