### PR TITLE
Update odu APM dep to master (runner-from-own-flake + teardown EPIPE fix)

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -166,10 +166,14 @@ host daemon corrupts CA-derivation handling).
   state does not survive a runner restart — the per-SHA log files do.
 - **Skipped nodes post no status**: an absent required context is what
   blocks the merge.
-- The coordinator resolves the lane runner via
-  `nix eval <snapshot>#packages.<platform>.odu-runner.drvPath` — the
-  consuming repo's flake must expose `odu-runner` (re-export odu's, as
-  kolu does) until odu threads its own runner derivation.
+- The coordinator resolves the **generic lane runner from odu's own flake**,
+  not the repo under test:
+  `nix eval $ODU_RUNNER_FLAKE#packages.<platform>.odu-runner.drvPath`, where
+  `ODU_RUNNER_FLAKE` is baked onto the `odu` wrapper from `self.outPath` at
+  build time. A consuming repo no longer re-exports `odu-runner`. There is no
+  override or fallback — the runner is the exact build that shipped the
+  coordinator (they share an RPC contract); a binary built without the baked
+  flake refuses to run.
 
 ## When NOT to use this skill
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -29,7 +29,7 @@ dependencies:
   content_hash: sha256:51308bd8cc8b6ae24781a77b67a7c8140bdea5d793e35427e7b8fcbeb0662074
 - repo_url: juspay/odu
   host: github.com
-  resolved_commit: 5929073bc87bb447f0180722d34c094f5c0eb50c
+  resolved_commit: 2dc6be008b64f1c02e96a3798b05fc8114cb1c80
   package_type: apm_package
   deployed_files:
   - .claude/skills/ci
@@ -38,10 +38,10 @@ dependencies:
   - .claude/skills/odu-mcp/SKILL.md
   - .claude/skills/odu-mcp/bin/serve
   deployed_file_hashes:
-    .claude/skills/ci/SKILL.md: sha256:a06a58c057a3d19e03e44725ba7454fc154851381d707b93293a2b4197fad8ca
+    .claude/skills/ci/SKILL.md: sha256:017232b5ec61da86ecc36babef51ff99477ccded0052f97d396825819b1461fb
     .claude/skills/odu-mcp/SKILL.md: sha256:25cd14d47aa082fb4061e793d3b74095eeb6749672356eea6b9acde9f9de6863
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-  content_hash: sha256:b2fb52475f4a6f8fb550378355980f10e4e9b10eb23fc08b0a075a70d198625d
+  content_hash: sha256:02caa03100102d54c6ff9a7e90a630d5f2e6bdde1127f06823f9cbf0f09d34d3
 - repo_url: juspay/skills
   host: github.com
   resolved_commit: e5791cf388499456c8083a1667ecc1bd6c35fe2c


### PR DESCRIPTION
Refreshes the vendored **odu** APM package (`5929073` → `2dc6be0`) so drishti's deployed `/ci` skill matches the odu it actually runs (`github:juspay/odu`, floating master). Two merged odu changes land in the skill docs:

- **[juspay/odu#31](https://github.com/juspay/odu/pull/31)** — odu resolves its lane runner from its **own** flake (`ODU_RUNNER_FLAKE`, baked from `self.outPath`); a consumer no longer re-exports `odu-runner`. The previous skill text still told readers to re-export it — the exact model #61 removed from this repo — so this corrects now-wrong guidance.
- **[juspay/odu#33](https://github.com/juspay/odu/pull/33)** — kolu-pin bump for the stdio-teardown `EPIPE` fix ([juspay/kolu#1333](https://github.com/juspay/kolu/pull/1333), closing [odu#32](https://github.com/juspay/odu/issues/32)): a fully-green run no longer crashes the coordinator on lane teardown.

## Scope

APM-only refresh — **2 files**: the `ci` skill text and odu's lockfile entry.

```
.claude/skills/ci/SKILL.md | 12 ++++++++----
apm.lock.yaml              |  6 +++---
```

- `odu-mcp` is byte-identical between the two odu revisions, so it's untouched.
- The other APM deps (`agency`, `frontend-design`, `nix-chrome-devtools-mcp`, `juspay/skills`) are held at their current lock commits — **no incidental drift** (`apm update` would have bumped all of them; this isolates odu).
- **No runtime/nix change** — odu is invoked from upstream, not pinned in the flake, so this only updates the vendored agent docs + lock metadata.

The skill diff, in one line: *"the consuming repo's flake must expose `odu-runner` (re-export odu's)"* → *"the coordinator resolves the generic lane runner from odu's own flake … a consuming repo no longer re-exports `odu-runner`."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
