### PR TITLE
chore(deps): bump kolu pin — P2.7 surface-nix-host warm-provision fast-path

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "5b5722cf79edd817e77c520cd141371ca3eb0fdf",
-      "url": "https://github.com/juspay/kolu/archive/5b5722cf79edd817e77c520cd141371ca3eb0fdf.tar.gz",
-      "hash": "sha256-hrVTpaNBNZO+L67LRgv9hrtEuoM/7Rqh/Nvno3RfvVo="
+      "revision": "493ca2d0298812dce3712b5ab93c6d1d13b0ddb6",
+      "url": "https://github.com/juspay/kolu/archive/493ca2d0298812dce3712b5ab93c6d1d13b0ddb6.tar.gz",
+      "hash": "sha256-cLprgoAkJ4s7gGnNhpFbgz62xh+HKEr8xq/vl0mv3EE="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
**Verified-compatible pin bump** for **juspay/kolu#1377** (merged) — P2.7 of the kaval-sessions plan: a *warm-host fast-path* in `surface-nix-host`'s `provisionAgent` that skips re-provisioning a host whose closure is already present.

drishti consumes `@kolu/surface-nix-host` for its `process-monitor-agent`, so `surface.md`'s shared-library mandate applies. The kolu change is **internal** — `provisionAgent` keeps its exact signature and returned out-path — so drishti needs **no code change**; this bump confirms drishti stays green against the new API.

- Pin: `5b5722cf` → **`493ca2d0`** (kolu master, the #1377 merge).
- **drishti CI ran full + green** — `18 ok · 0 failed · 0 errored` across **both platforms** (x86_64-linux + aarch64-darwin: `nix`, `typecheck`, `fmt-check`, `bun-nix-fresh`, `home-manager`, `drv-stability`) against the identical change.

Closes the companion obligation for juspay/kolu#1377.