### PR TITLE
Bump kolu pin to arivu-p3-pr2b (surface-nix-host onLog) + hydrate @kolu/shell-quote

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -32,6 +32,7 @@ install:
     {{ nix_shell }} sh -c 'sh scripts/hydrate-kolu-packages.sh \
       "$DRISHTI_KOLU_SURFACE" @kolu/surface \
       "$DRISHTI_KOLU_SURFACE_NIX_HOST" @kolu/surface-nix-host \
+      "$DRISHTI_KOLU_SHELL_QUOTE" @kolu/shell-quote \
       "$DRISHTI_KOLU_SURFACE_APP" @kolu/surface-app'
 
 # Pre-populate the nix store with crates.io tarballs that nixpkgs' fetchurl

--- a/justfile
+++ b/justfile
@@ -26,6 +26,7 @@ install:
     {{ nix_shell }} sh -c 'sh scripts/hydrate-kolu-packages.sh \
       "$DRISHTI_KOLU_SURFACE" @kolu/surface \
       "$DRISHTI_KOLU_SURFACE_NIX_HOST" @kolu/surface-nix-host \
+      "$DRISHTI_KOLU_SHELL_QUOTE" @kolu/shell-quote \
       "$DRISHTI_KOLU_SURFACE_APP" @kolu/surface-app \
       "$DRISHTI_KOLU_SOLID_PWA_INSTALL" @kolu/solid-pwa-install'
 

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -10,8 +10,10 @@
 #   DRISHTI_KOLU_SURFACE_APP      — /nix/store path to @kolu/surface-app source.
 #   DRISHTI_KOLU_SOLID_PWA_INSTALL — /nix/store path to @kolu/solid-pwa-install
 #                                    source (the install-card adapter; TODO(pin)).
+#   DRISHTI_KOLU_SHELL_QUOTE      — /nix/store path to @kolu/shell-quote source
+#                                    (the zero-dep POSIX leaf surface-nix-host imports).
 #
-# All are hydrated into node_modules/@kolu/{surface,surface-nix-host,surface-app,solid-pwa-install}
+# All are hydrated into node_modules/@kolu/{surface,surface-nix-host,shell-quote,surface-app,solid-pwa-install}
 # by scripts/hydrate-kolu-packages.sh (three callers: shell.nix
 # shellHook, the justfile install recipe, and the build derivations'
 # postBunNodeModulesInstallPhase).
@@ -21,4 +23,5 @@
   DRISHTI_KOLU_SURFACE_NIX_HOST = pkgs.kolu-surface-nix-host;
   DRISHTI_KOLU_SURFACE_APP = pkgs.kolu-surface-app;
   DRISHTI_KOLU_SOLID_PWA_INSTALL = pkgs.kolu-solid-pwa-install;
+  DRISHTI_KOLU_SHELL_QUOTE = pkgs.kolu-shell-quote;
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,7 +1,8 @@
 # Exposes kolu workspace packages as Nix-store sources.
 #
-# Three leaves today (surface, surface-nix-host, surface-app). A fourth
-# arrival is a one-line addition: `kolu-foo = mkKoluPackage "foo";`. The factory keeps
+# Several leaves today (surface, surface-nix-host, shell-quote, surface-app,
+# solid-pwa-install). A new arrival is a one-line addition: `kolu-foo =
+# mkKoluPackage "foo";`. The factory keeps
 # the recipe single-sourced; the per-leaf overlay entry keeps each
 # package's volatility axis independently encapsulated.
 final: _prev:
@@ -14,4 +15,7 @@ in
   kolu-surface-app = mkKoluPackage "surface-app";
   # The install-card adapter; shipped via juspay/kolu#1199 (merged to master).
   kolu-solid-pwa-install = mkKoluPackage "solid-pwa-install";
+  # The zero-dep POSIX shell-quote leaf surface-nix-host imports (kolu P2,
+  # juspay/kolu#1439) — hydrated so its `@kolu/shell-quote` import resolves.
+  kolu-shell-quote = mkKoluPackage "shell-quote";
 }

--- a/nix/packages/drishti/default.nix
+++ b/nix/packages/drishti/default.nix
@@ -9,7 +9,7 @@
 # Client bundling: re-uses `packages/app/src/server/build.ts` — the same
 # TS code path the dev server invokes when DRISHTI_DIST_DIR is unset.
 # One bundle pipeline; two callers.
-{ stdenv, lib, bun, bun2nix, kolu-surface, kolu-surface-nix-host, kolu-surface-app, kolu-solid-pwa-install, surfaceAppCommit ? "dev" }:
+{ stdenv, lib, bun, bun2nix, kolu-surface, kolu-surface-nix-host, kolu-shell-quote, kolu-surface-app, kolu-solid-pwa-install, surfaceAppCommit ? "dev" }:
 # `@tailwindcss/cli` transitively dlopen()s `@parcel/watcher`'s native
 # binding, which requires `libstdc++.so.6` at runtime even when we don't
 # use --watch. Expose stdenv's libstdc++ via LD_LIBRARY_PATH during the
@@ -81,6 +81,7 @@ stdenv.mkDerivation {
     sh scripts/hydrate-kolu-packages.sh \
       ${kolu-surface} @kolu/surface \
       ${kolu-surface-nix-host} @kolu/surface-nix-host \
+      ${kolu-shell-quote} @kolu/shell-quote \
       ${kolu-surface-app} @kolu/surface-app \
       ${kolu-solid-pwa-install} @kolu/solid-pwa-install
   '';

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "arivu-p3-pr2b",
+      "branch": "master",
       "submodules": false,
-      "revision": "cd34925fa8dc68b85279e760a24afbcc0a8ec9ef",
-      "url": "https://github.com/juspay/kolu/archive/cd34925fa8dc68b85279e760a24afbcc0a8ec9ef.tar.gz",
-      "hash": "sha256-KhmjfNpSym+5AqV39NnCRkyyiUHHWRKICLX5nMQMio4="
+      "revision": "e1370a8f2728306a3fcce47ab851f8cec23e4de6",
+      "url": "https://github.com/juspay/kolu/archive/e1370a8f2728306a3fcce47ab851f8cec23e4de6.tar.gz",
+      "hash": "sha256-GXi6cAC/TZXeiEZRW1kmr33rIp8E2WMcjPwydn9jqyA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "arivu-p3-pr2b",
       "submodules": false,
-      "revision": "f035cbf5adb60b9189f05eef02a8133417fbe5fc",
-      "url": "https://github.com/juspay/kolu/archive/f035cbf5adb60b9189f05eef02a8133417fbe5fc.tar.gz",
-      "hash": "sha256-t5TPH1rH2XcTnWHlJF2tRIy7VsFEizL3gRFbrnlCcMs="
+      "revision": "cd34925fa8dc68b85279e760a24afbcc0a8ec9ef",
+      "url": "https://github.com/juspay/kolu/archive/cd34925fa8dc68b85279e760a24afbcc0a8ec9ef.tar.gz",
+      "hash": "sha256-KhmjfNpSym+5AqV39NnCRkyyiUHHWRKICLX5nMQMio4="
     },
     "nixpkgs": {
       "type": "Git",

--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,7 @@ pkgs.mkShell {
       (cd "$root" && sh scripts/hydrate-kolu-packages.sh \
         "$DRISHTI_KOLU_SURFACE" @kolu/surface \
         "$DRISHTI_KOLU_SURFACE_NIX_HOST" @kolu/surface-nix-host \
+        "$DRISHTI_KOLU_SHELL_QUOTE" @kolu/shell-quote \
         "$DRISHTI_KOLU_SURFACE_APP" @kolu/surface-app \
         "$DRISHTI_KOLU_SOLID_PWA_INSTALL" @kolu/solid-pwa-install)
     fi


### PR DESCRIPTION
**Paired with [juspay/kolu#1486](https://github.com/juspay/kolu/pull/1486)** (arivu P3 · PR2b) per kolu's `.claude/rules/surface.md` — that PR adds an **additive, optional `onLog` sink** to `@kolu/surface-nix-host`'s `HostSession`/`dialAgentOnce` (default unchanged = `process.stderr`). drishti imports **none** of the new symbols, so its **source is unchanged** — this is a pin-bump + a build-config catch-up.

The kolu pin here sat on a pre-P2 commit, predating [juspay/kolu#1439](https://github.com/juspay/kolu/pull/1439), which made `surface-nix-host` import the zero-dep `@kolu/shell-quote` leaf. Bumping to PR2b surfaces that requirement, so this also **hydrates `@kolu/shell-quote`**:

- `nix/overlay.nix` + `nix/env.nix` — expose `kolu-shell-quote`.
- All four hydrate callers that pull `surface-nix-host` (`justfile`, `shell.nix`, `ci/mod.just`, `nix/packages/drishti`) now also hydrate `@kolu/shell-quote`. (`drishti-agent` hydrates only `@kolu/surface`, so it's untouched.)

**Verified locally** against kolu `cd34925fa`: `just typecheck` ✅ and `nix build .#default` ✅.

> Re-pin to `juspay/kolu` **master** once #1486 merges (this temporarily pins the PR branch so CI can verify the surface change).

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._