### PR TITLE
feat: adopt mirrorRemoteSurface total dual + Kill-process proof (kolu #1505)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "r7",
+      "branch": "master",
       "submodules": false,
-      "revision": "4e6f9bc72b5062cdc4f8a412db37a52882c207f6",
-      "url": "https://github.com/juspay/kolu/archive/4e6f9bc72b5062cdc4f8a412db37a52882c207f6.tar.gz",
-      "hash": "sha256-LfwLdVD39SVlDCXUAcS8fXEA4CpMCvPqY0oV78+kQbA="
+      "revision": "3af71cbbc4a3394bcbe47e78e68bd6348b3a2c25",
+      "url": "https://github.com/juspay/kolu/archive/3af71cbbc4a3394bcbe47e78e68bd6348b3a2c25.tar.gz",
+      "hash": "sha256-wwd/xk2CPMaymjtjuj0gMGY/D7aUcZzGxgEeGs6wzzY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "054df6305a47454d0302467532b8d2e88caf02b0",
-      "url": "https://github.com/juspay/kolu/archive/054df6305a47454d0302467532b8d2e88caf02b0.tar.gz",
-      "hash": "sha256-jUSDzLy+lgF/wn82ryuGYP8cJddTwLGy0ttT1LCgESw="
+      "revision": "5cc42d0134034af2da3a10067f431a8e7638af0f",
+      "url": "https://github.com/juspay/kolu/archive/5cc42d0134034af2da3a10067f431a8e7638af0f.tar.gz",
+      "hash": "sha256-S85UGCmmZEHDnnH9dlh9xqnwvcxkd26fbxSIOVTkFpo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "r7",
       "submodules": false,
-      "revision": "5cc42d0134034af2da3a10067f431a8e7638af0f",
-      "url": "https://github.com/juspay/kolu/archive/5cc42d0134034af2da3a10067f431a8e7638af0f.tar.gz",
-      "hash": "sha256-S85UGCmmZEHDnnH9dlh9xqnwvcxkd26fbxSIOVTkFpo="
+      "revision": "4e6f9bc72b5062cdc4f8a412db37a52882c207f6",
+      "url": "https://github.com/juspay/kolu/archive/4e6f9bc72b5062cdc4f8a412db37a52882c207f6.tar.gz",
+      "hash": "sha256-LfwLdVD39SVlDCXUAcS8fXEA4CpMCvPqY0oV78+kQbA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -229,6 +229,23 @@ export async function serveAgent(
         },
       },
     },
+    // The one PROCEDURE on this surface — `kill` runs HERE, on the host that owns
+    // the pids (the parent has none; it forwards through the mirror's stub, kolu
+    // #1505 R7). `process.kill` raising (ESRCH gone, EPERM not permitted) is a
+    // normal, reportable outcome, not a crash — caught and returned as
+    // `{ ok: false, error }` so the browser can surface it.
+    procedures: {
+      process: {
+        kill: ({ input }) => {
+          try {
+            process.kill(input.pid, `SIG${input.signal}`);
+            return { ok: true };
+          } catch (err) {
+            return { ok: false, error: (err as Error).message };
+          }
+        },
+      },
+    },
   });
 
   // Poll loop: refresh system + processes, diff against current

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -939,6 +939,9 @@ function HostView(props: { host: string }) {
                   ? () => setSelectedPid(s().proc.ppid)
                   : null
               }
+              onKill={(signal) =>
+                app.rpc.surface.process.kill({ pid: s().pid, signal })
+              }
             />
           )}
         </Show>
@@ -1364,8 +1367,24 @@ function ProcessDetail(props: {
   // close. It's a prop (not SelectionContext) because `ProcessDetail` is a
   // sibling of the table, rendered before the context provider in the tree.
   onSelectParent: (() => void) | null;
+  // R7 (kolu #1505): signal this process. Forwarded browser → parent → (mirror
+  // procedure stub) → agent → kill(pid). Resolves with the agent's `{ ok, error }`.
+  onKill: (signal: "TERM" | "KILL") => Promise<{ ok: boolean; error?: string }>;
 }) {
   const p = () => props.process;
+  // Kill-action state: "idle" | "killing" | <error message to show inline>.
+  const [killState, setKillState] = createSignal<string>("idle");
+  const runKill = async (signal: "TERM" | "KILL"): Promise<void> => {
+    setKillState("killing");
+    try {
+      const r = await props.onKill(signal);
+      // On success the process leaves the live set and this panel unmounts; if it
+      // lingers (EPERM, already gone), surface the agent's reason — never silent.
+      setKillState(r.ok ? "idle" : (r.error ?? "kill failed"));
+    } catch (err) {
+      setKillState((err as Error).message);
+    }
+  };
   // Resident memory as a share of host RAM — the same guarded "part of a
   // total" formula `memPct` uses for the host header.
   const memShare = () => pctOf(p().rssBytes, props.memTotal);
@@ -1448,6 +1467,31 @@ function ProcessDetail(props: {
           )}
         </Show>
       </dl>
+      <div class="mt-2 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => runKill("TERM")}
+          disabled={killState() === "killing"}
+          class="cursor-pointer rounded border border-red-300 px-2 py-0.5 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
+          title="Send SIGTERM to this process"
+        >
+          {killState() === "killing" ? "Killing…" : "Kill"}
+        </button>
+        <button
+          type="button"
+          onClick={() => runKill("KILL")}
+          disabled={killState() === "killing"}
+          class="cursor-pointer rounded px-2 py-0.5 text-xs text-red-600 hover:underline disabled:opacity-50 dark:text-red-400"
+          title="Send SIGKILL (force kill)"
+        >
+          Force
+        </button>
+        <Show when={killState() !== "idle" && killState() !== "killing"}>
+          <span class="text-xs text-red-600 dark:text-red-400">
+            {killState()}
+          </span>
+        </Show>
+      </div>
     </div>
   );
 }

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -27,7 +27,10 @@ import {
   inMemoryChannelByName,
   inMemoryStore,
 } from "@kolu/surface/server";
-import { mirrorRemoteSurface } from "@kolu/surface/mirror";
+import {
+  mirrorRemoteSurface,
+  type ProcedureForwarders,
+} from "@kolu/surface/mirror";
 import {
   type AgentClient,
   type HostSession,
@@ -101,6 +104,16 @@ export function buildRouter(opts: BuildRouterOptions) {
   let historyRing: MetricSample[] = [];
   const historyBus: Channel<MetricHistoryMsg> =
     inMemoryChannel<MetricHistoryMsg>();
+
+  // R7 (kolu #1505): the browser's `process.kill` is forwarded to the agent
+  // through the MIRROR's procedure stub — the first forwarded procedure on a
+  // mirrored surface. The mirror is re-issued per spawn (stdio doesn't recover
+  // mid-stream), so the live stub set lives in this holder: the bridge sets it
+  // on each connect and clears it when the link dies. A kill with no live agent
+  // reports `{ ok: false }` rather than silently no-op'ing.
+  const liveProcedures: {
+    current: ProcedureForwarders<typeof surface.spec> | null;
+  } = { current: null };
 
   const fragment = implementSurface(surface, {
     // Name-keyed in-memory channel factory — publish/subscribe sites
@@ -179,6 +192,21 @@ export function buildRouter(opts: BuildRouterOptions) {
         },
       },
     },
+    // The browser-facing `kill` is a pure FORWARD: the parent owns no pids, so it
+    // relays to the agent through the live mirror's procedure stub (the R7 proof).
+    // No live link → an honest `{ ok: false }`, surfaced to the user; a stub call
+    // against a just-dropped link rejects and the rejection reaches the browser.
+    procedures: {
+      process: {
+        kill: async ({ input }) => {
+          const procs = liveProcedures.current;
+          if (!procs) {
+            return { ok: false, error: "no live agent connection" };
+          }
+          return procs.process.kill(input);
+        },
+      },
+    },
   });
 
   // Compile-time guard for the least-privilege narrowing: the real
@@ -230,6 +258,7 @@ export function buildRouter(opts: BuildRouterOptions) {
     processCache,
     browserSnapshotBus,
     recordSample,
+    liveProcedures,
   );
 
   // `implementSurface` returns a router *fragment* — `{ surface: ... }`
@@ -298,6 +327,9 @@ async function bridgeAgentToParent(
   processCache: Map<Pid, Process>,
   browserSnapshotBus: Channel<ProcessesSnapshotMsg>,
   recordSample: (system: SystemInfo) => void,
+  liveProcedures: {
+    current: ProcedureForwarders<typeof surface.spec> | null;
+  },
 ): Promise<void> {
   log("pinning HostSession (parent-lifetime ref)…");
   // Pin once. Swallow the initial promise — we'll fetch a fresh client
@@ -331,12 +363,12 @@ async function bridgeAgentToParent(
     let frames = 0;
     const issuedAt = Date.now();
     // R7 (kolu #1505): `mirrorRemoteSurface` returns the total-dual handle
-    // `{ procedures, done }`, no longer `Promise<void>`. The bridge loop must
-    // block until the link dies, so await `.done` — a bare `await
-    // mirrorRemoteSurface(...)` would await a non-thenable handle and resolve
-    // at once, spinning the reconnect loop. (This consumer mirrors streaming
-    // sinks only; `.procedures` is unused here.)
-    await mirrorRemoteSurface(
+    // `{ procedures, done }`, no longer `Promise<void>`. The streaming sinks
+    // fold below; the procedure stubs are published to `liveProcedures` so the
+    // parent's `kill` handler can forward through them, and the loop blocks on
+    // `.done` until the link dies (a bare `await mirrorRemoteSurface(...)` would
+    // await a non-thenable handle and resolve at once, spinning the loop).
+    const mirror = mirrorRemoteSurface(
       surface,
       client,
       {
@@ -390,7 +422,16 @@ async function bridgeAgentToParent(
         },
       },
       { log },
-    ).done;
+    );
+    // Publish this spawn's forwarding stubs for the parent's `kill` handler;
+    // clear them the instant the link dies so a kill in the gap fails honestly
+    // rather than calling into a dead client.
+    liveProcedures.current = mirror.procedures;
+    try {
+      await mirror.done;
+    } finally {
+      liveProcedures.current = null;
+    }
     log(
       `bridge: mirror ended for client #${seq} (link likely died) — awaiting next client`,
     );

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -330,6 +330,12 @@ async function bridgeAgentToParent(
     let firstSystemFrame = true;
     let frames = 0;
     const issuedAt = Date.now();
+    // R7 (kolu #1505): `mirrorRemoteSurface` returns the total-dual handle
+    // `{ procedures, done }`, no longer `Promise<void>`. The bridge loop must
+    // block until the link dies, so await `.done` — a bare `await
+    // mirrorRemoteSurface(...)` would await a non-thenable handle and resolve
+    // at once, spinning the reconnect loop. (This consumer mirrors streaming
+    // sinks only; `.procedures` is unused here.)
     await mirrorRemoteSurface(
       surface,
       client,
@@ -384,7 +390,7 @@ async function bridgeAgentToParent(
         },
       },
       { log },
-    );
+    ).done;
     log(
       `bridge: mirror ended for client #${seq} (link likely died) — awaiting next client`,
     );

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -7,9 +7,11 @@
  *   - `system`     — singleton cell with load averages, memory, uptime.
  *   - `processes`  — keyed collection (PID → per-process snapshot).
  *
- * The surface is **strictly read-only**: it exposes cells, collections,
- * and streams, but no procedures — there is no way to mutate the
- * monitored host through it.
+ * One imperative escape hatch: the `process.kill` **procedure** — the
+ * first *forwarded procedure* on a mirrored surface (kolu #1505, R7). It
+ * runs on the agent (the host that owns the pids) and the parent forwards
+ * the browser's call to it through `mirrorRemoteSurface`'s total-dual
+ * procedure stub; everything else is read-only cells/collections/streams.
  *
  * Plus a `connection` cell so the parent can stream "copying agent to
  * remote…" lifecycle to the browser while `nix copy` is in flight.
@@ -284,6 +286,23 @@ export const surface = defineSurface({
     metricHistory: {
       inputSchema: z.object({}),
       outputSchema: MetricHistoryMessage,
+    },
+  },
+  procedures: {
+    process: {
+      // Signal a process on the monitored host. The agent owns the pids, so the
+      // handler lives there; the parent forwards the browser's call through the
+      // mirror's procedure stub (kolu #1505 R7). `signal` is the bare name; the
+      // agent maps it to `SIG<name>`. Returns `{ ok }`, with `error` carrying the
+      // reason on failure (ESRCH gone / EPERM not permitted) — surfaced to the
+      // user, never silently swallowed.
+      kill: {
+        input: z.object({
+          pid: PidSchema,
+          signal: z.enum(["TERM", "KILL", "HUP", "INT"]).default("TERM"),
+        }),
+        output: z.object({ ok: z.boolean(), error: z.string().optional() }),
+      },
     },
   },
 });


### PR DESCRIPTION
Two things, both riding kolu's R7 (`mirrorRemoteSurface` → a **total dual**, [juspay/kolu#1505](https://github.com/juspay/kolu/pull/1505) — **now merged**):

**1. Adopt the total-dual handle (the migration).** kolu's R7 made `mirrorRemoteSurface` return `{ procedures, done }` instead of `Promise<void>` and removed the per-key `mirrorRemoteCollection`. The parent bridge collapses onto one `mirrorRemoteSurface(...)` call and awaits `.done` (a bare `await` would await a non-thenable handle and spin the reconnect loop).

**2. Kill a process — the forwarded-procedure proof.** drishti's surface was strictly read-only. It now carries its first **procedure**, `process.kill`, exercised end-to-end:

```
browser "Kill" / "Force" button
  → app.rpc.surface.process.kill({ pid, signal })
  → parent's handler → liveProcedures.current.process.kill   ← the mirror's procedure stub
  → ssh → agent → process.kill(pid, SIG…)
  → { ok, error? } back to the browser (inline error on failure)
```

This is the first *forwarded procedure on a mirrored surface* — the proof R7 was built for. Notable seams:

- **agent** owns the pids, so `kill` runs there; a raise (ESRCH gone / EPERM not permitted) returns `{ ok: false, error }`, never a crash.
- **parent** holds no pids — its `kill` handler is a pure forward through the *live* mirror's `.procedures`. Because stdio re-mirrors per spawn, each connection's stub set is published into a holder the handler reads; no live link → an honest `{ ok: false }`.

**Pin:** now that kolu#1505 is merged, npins tracks **master HEAD** (`3af71cbb`, which carries the squashed R7 landing `f760d6b3`), restoring the normal master-tracking pin — so this validates the **merged** surface API, not a pre-merge branch commit.

Full odu CI is green across `x86_64-linux` + `aarch64-darwin` — the `surface.md` merge-gate. kolu#1505 is merged; this is ready to merge.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._