### PR TITLE
refactor(app): adopt @kolu/surface-nix-host per-host fan-out (kolu#1524)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "feat/pulam-web-framework",
       "submodules": false,
-      "revision": "fb8fcb549485718cde91b54f6954f15d8a7dd8bb",
-      "url": "https://github.com/juspay/kolu/archive/fb8fcb549485718cde91b54f6954f15d8a7dd8bb.tar.gz",
-      "hash": "sha256-oOlz58AvvC9qVSNzgMoVg3BHESsP4XCkww+31RN0C1A="
+      "revision": "37540892b875c4e42d472979d330b467dc90aa6c",
+      "url": "https://github.com/juspay/kolu/archive/37540892b875c4e42d472979d330b467dc90aa6c.tar.gz",
+      "hash": "sha256-3HVBsSfndfck009S0BVcLeI8RJ3VgMEG1RVLgjWkPS8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "feat/pulam-web-framework",
+      "branch": "master",
       "submodules": false,
-      "revision": "37540892b875c4e42d472979d330b467dc90aa6c",
-      "url": "https://github.com/juspay/kolu/archive/37540892b875c4e42d472979d330b467dc90aa6c.tar.gz",
-      "hash": "sha256-3HVBsSfndfck009S0BVcLeI8RJ3VgMEG1RVLgjWkPS8="
+      "revision": "d8cd75c3c03c39c1e32e83518e20913497091abe",
+      "url": "https://github.com/juspay/kolu/archive/d8cd75c3c03c39c1e32e83518e20913497091abe.tar.gz",
+      "hash": "sha256-xBtF0Q2dQblGULtCoY+egAY0w3dKIWI5d2WRoxCTq0M="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "feat/pulam-web-framework",
       "submodules": false,
-      "revision": "3af71cbbc4a3394bcbe47e78e68bd6348b3a2c25",
-      "url": "https://github.com/juspay/kolu/archive/3af71cbbc4a3394bcbe47e78e68bd6348b3a2c25.tar.gz",
-      "hash": "sha256-wwd/xk2CPMaymjtjuj0gMGY/D7aUcZzGxgEeGs6wzzY="
+      "revision": "fb8fcb549485718cde91b54f6954f15d8a7dd8bb",
+      "url": "https://github.com/juspay/kolu/archive/fb8fcb549485718cde91b54f6954f15d8a7dd8bb.tar.gz",
+      "hash": "sha256-oOlz58AvvC9qVSNzgMoVg3BHESsP4XCkww+31RN0C1A="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/hostRegistry.ts
+++ b/packages/app/src/server/hostRegistry.ts
@@ -17,12 +17,26 @@
  *
  * Insertion order is preserved (JavaScript `Map` semantics) so the
  * tab strip displays hosts in the order the user added them.
+ *
+ * R7 keystone (kolu #1505): the keyed `Map<host, {session, handler}>`
+ * mechanism + its add/remove/reconnect/recheckAll + per-host socket
+ * eviction lifecycle now live in `@kolu/surface-nix-host`'s
+ * `buildHostRegistry` — lifted verbatim-in-shape from this very file, so
+ * pulam-web's terminal-awareness server can share it. drishti keeps a
+ * THIN wrapper here: it owns only the app-specific knowledge the shared
+ * registry deliberately doesn't hold — how a host becomes a `{ session,
+ * handler }` (`buildEntry`: `getHostSession` + `buildRouter` + `new
+ * RPCHandler`), where the host set persists (`saveHosts`), and the
+ * admin-surface wire-shape projection (`snapshot()`). The wrapper's async
+ * signature and `resolveDrvPath`/`hostsFile` options are preserved so
+ * `main.ts` and `admin-router.ts` call it exactly as before.
  */
 
 import { RPCHandler } from "@orpc/server/ws";
 import {
+  buildHostRegistry as buildSharedHostRegistry,
   getHostSession,
-  type HostSession,
+  type HostRegistry as SharedHostRegistry,
 } from "@kolu/surface-nix-host";
 import type { WebSocket as WsConn } from "ws";
 import type { HostEntry } from "../common/admin-surface";
@@ -45,19 +59,18 @@ const log = makeLogger("registry");
 // it answers to, rather than buried in the library's default.
 const CONNECT_TIMEOUT_MS = 30_000;
 
-interface HostHandle {
-  session: HostSession<typeof surface.contract>;
-  // biome-ignore lint/suspicious/noExplicitAny: matches existing router-handler cast (see implementSurface fragment shape).
-  handler: RPCHandler<any>;
-}
+// The shared registry stores a generic handler `H`; drishti's is the
+// oRPC ws `RPCHandler`. Pin `H` to that here so `getHandler` hands back a
+// concrete handler at the upgrade dispatch in `main.ts`.
+// biome-ignore lint/suspicious/noExplicitAny: matches existing router-handler cast (see implementSurface fragment shape).
+type DrishtiHandler = RPCHandler<any>;
 
 export interface HostRegistry {
   has(host: string): boolean;
   /** Project the live host set into the admin surface's wire shape.
    *  Called by the admin router's `readAll` on every new subscriber. */
   snapshot(): Map<string, HostEntry>;
-  // biome-ignore lint/suspicious/noExplicitAny: matches existing router-handler cast.
-  getHandler(host: string): RPCHandler<any> | undefined;
+  getHandler(host: string): DrishtiHandler | undefined;
   /** Spawn a new host session and persist the host set. Throws if the
    *  host already exists. The admin router publishes the per-key channel
    *  update AFTER this resolves, so a new subscriber never sees a host
@@ -99,96 +112,65 @@ export interface HostRegistryOptions {
 export async function buildHostRegistry(
   opts: HostRegistryOptions,
 ): Promise<HostRegistry> {
-  const entries = new Map<string, HostHandle>();
-  const wsConnectionsByHost = new Map<string, Set<WsConn>>();
-
-  const buildEntry = (host: string): HostHandle => {
-    const session = getHostSession<typeof surface.contract>({
-      host,
-      // Resolve the agent .drv lazily, inside the session's spawn cycle,
-      // rather than awaiting the arch probe here. A host that's
-      // unreachable at probe time makes the resolver reject, which the
-      // session treats as an ordinary connection failure (disconnected →
-      // backoff → failed, re-armable via Reconnect) — so it can't throw
-      // out of here before the session exists. That's what keeps one
-      // unreachable initial host from crashing the whole server at boot.
-      resolveDrvPath: () => opts.resolveDrvPath(host),
-      binary: "drishti-agent",
-      connectTimeoutMs: CONNECT_TIMEOUT_MS,
+  // The shared registry owns the keyed map + its full lifecycle. drishti
+  // supplies only `buildEntry` (how a host becomes a session + handler)
+  // and `persist` (where the host set lands on disk). Both stay SYNC for
+  // `buildEntry`: `getHostSession` defers the spawn into the session's own
+  // reconnect machinery, so a host unreachable at boot surfaces as a
+  // per-host `failed` connection state — never a throw that takes the
+  // whole registry (and with it the parent's HTTP port, never bound until
+  // this resolves) down.
+  const shared: SharedHostRegistry<typeof surface.contract, DrishtiHandler> =
+    buildSharedHostRegistry({
+      initialHosts: opts.initialHosts,
+      buildEntry: (host) => {
+        const session = getHostSession<typeof surface.contract>({
+          host,
+          // Resolve the agent .drv lazily, inside the session's spawn
+          // cycle, rather than awaiting the arch probe here. A host that's
+          // unreachable at probe time makes the resolver reject, which the
+          // session treats as an ordinary connection failure (disconnected
+          // → backoff → failed, re-armable via Reconnect) — so it can't
+          // throw out of here before the session exists. That's what keeps
+          // one unreachable initial host from crashing the whole server at
+          // boot.
+          resolveDrvPath: () => opts.resolveDrvPath(host),
+          binary: "drishti-agent",
+          connectTimeoutMs: CONNECT_TIMEOUT_MS,
+        });
+        const { router } = buildRouter({ host, session });
+        // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
+        const handler = new RPCHandler(router as any);
+        return { session, handler };
+      },
+      // Persist after every add/remove, awaited before the call resolves
+      // (the shared registry guarantees the ordering) — so the admin
+      // router's announce never races ahead of the on-disk store.
+      persist: (hosts) => saveHosts(opts.hostsFile, hosts),
+      log: (line) => log(line),
     });
-    const { router } = buildRouter({ host, session });
-    // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
-    const handler = new RPCHandler(router as any);
-    return { session, handler };
-  };
-
-  // Seed every configured host synchronously. `buildEntry` no longer
-  // awaits anything — the per-host arch probe it used to run up front now
-  // lives inside the session's spawn cycle — so seeding can't reject, and
-  // a host that's unreachable at boot surfaces as a per-host `failed`
-  // connection state instead of taking the whole registry (and with it
-  // the parent's HTTP port, never bound until this resolves) down. The
-  // old code awaited `Promise.all`, whose first rejection propagated to
-  // `main()`'s top-level catch and exited the process before `serve()`.
-  for (const host of opts.initialHosts) entries.set(host, buildEntry(host));
 
   return {
-    has: (host) => entries.has(host),
+    has: (host) => shared.has(host),
+    // The admin surface's wire shape is `Map<host, { host }>`; the shared
+    // registry exposes only the host strings (`hosts()`), so project them
+    // back into the keyed map here. Same projection the old in-file
+    // registry did — admin and registry still can't diverge, because both
+    // read the one `entries` map inside the shared registry.
     snapshot: () => {
       const out = new Map<string, HostEntry>();
-      for (const host of entries.keys()) out.set(host, { host });
+      for (const host of shared.hosts()) out.set(host, { host });
       return out;
     },
-    getHandler: (host) => entries.get(host)?.handler,
-
-    async add(host) {
-      if (entries.has(host)) {
-        throw new Error("host already exists");
-      }
-      entries.set(host, buildEntry(host));
-      await saveHosts(opts.hostsFile, [...entries.keys()]);
-      log(`added host: ${host} (total ${entries.size})`);
-    },
-
-    async remove(host) {
-      const entry = entries.get(host);
-      if (entry === undefined) return;
-      const sockets = wsConnectionsByHost.get(host);
-      if (sockets !== undefined) {
-        for (const ws of sockets) {
-          try {
-            ws.close(1000, "host removed");
-          } catch {
-            /* best-effort */
-          }
-        }
-        wsConnectionsByHost.delete(host);
-      }
-      entry.session.destroy();
-      entries.delete(host);
-      await saveHosts(opts.hostsFile, [...entries.keys()]);
-      log(`removed host: ${host} (total ${entries.size})`);
-    },
-
-    reconnect(host) {
-      entries.get(host)?.session.reconnect();
-    },
-
-    recheckAll() {
-      for (const entry of entries.values()) entry.session.recheck();
-    },
-
-    registerConnection(host, ws) {
-      let set = wsConnectionsByHost.get(host);
-      if (set === undefined) {
-        set = new Set();
-        wsConnectionsByHost.set(host, set);
-      }
-      set.add(ws);
-    },
-
-    unregisterConnection(host, ws) {
-      wsConnectionsByHost.get(host)?.delete(ws);
-    },
+    getHandler: (host) => shared.getHandler(host),
+    add: (host) => shared.add(host),
+    remove: (host) => shared.remove(host),
+    reconnect: (host) => shared.reconnect(host),
+    recheckAll: () => shared.recheckAll(),
+    // `WsConn` (ws's WebSocket) structurally satisfies the shared
+    // registry's `ClosableSocket` (`close(code, reason?)`), so it passes
+    // through without a cast.
+    registerConnection: (host, ws) => shared.registerConnection(host, ws),
+    unregisterConnection: (host, ws) => shared.unregisterConnection(host, ws),
   };
 }

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -16,6 +16,15 @@
  * The surface is strictly read-only — it carries no procedures, so the
  * parent only ever mirrors agent data inward; it never forwards a
  * mutation back to the host.
+ *
+ * R7 keystone (kolu #1505): the reconnect-mirror loop that used to live
+ * here as `bridgeAgentToParent` is now `@kolu/surface-nix-host`'s
+ * `pumpRemoteSurface` — lifted verbatim-in-shape from this file so
+ * pulam-web's terminal-awareness server can share it. drishti keeps only
+ * the surface-specific knowledge the pump deliberately doesn't hold: the
+ * per-spawn sink (`makeSink`) that folds the agent's `system` / `cpuCores`
+ * / `networkInterfaces` / `processesSnapshot` frames into the parent's
+ * local surface, and the `liveProcedures` holder the `kill` forward reads.
  */
 
 import { implement } from "@orpc/server";
@@ -27,14 +36,10 @@ import {
   inMemoryChannelByName,
   inMemoryStore,
 } from "@kolu/surface/server";
+import { type ProcedureForwarders } from "@kolu/surface/mirror";
 import {
-  mirrorRemoteSurface,
-  type ProcedureForwarders,
-} from "@kolu/surface/mirror";
-import {
-  type AgentClient,
   type HostSession,
-  makeClientCursor,
+  pumpRemoteSurface,
 } from "@kolu/surface-nix-host";
 import {
   type ConnectionInfo,
@@ -58,8 +63,6 @@ import {
   pushSample,
 } from "../common/history";
 import { type Logger, makeLogger } from "./log";
-
-type DrishtiAgent = AgentClient<typeof surface.contract>;
 
 export interface BuildRouterOptions {
   /** The host this router bridges — used only to tag the bridge's log
@@ -108,7 +111,7 @@ export function buildRouter(opts: BuildRouterOptions) {
   // R7 (kolu #1505): the browser's `process.kill` is forwarded to the agent
   // through the MIRROR's procedure stub — the first forwarded procedure on a
   // mirrored surface. The mirror is re-issued per spawn (stdio doesn't recover
-  // mid-stream), so the live stub set lives in this holder: the bridge sets it
+  // mid-stream), so the live stub set lives in this holder: the pump sets it
   // on each connect and clears it when the link dies. A kill with no live agent
   // reports `{ ok: false }` rather than silently no-op'ing.
   const liveProcedures: {
@@ -210,14 +213,18 @@ export function buildRouter(opts: BuildRouterOptions) {
   });
 
   // Compile-time guard for the least-privilege narrowing: the real
-  // fragment must satisfy the pumps' write-only view. Stated here (not only
-  // implied by the bridgeAgentToParent call) so a refactor of that call
+  // fragment must satisfy the pump sink's write-only view. Stated here (not
+  // only implied by the `makeSink` closure below) so a refactor of that sink
   // can't quietly drop the check — a surface collection rename surfaces as
   // an error on this line.
   const _pumpCtx: FragmentCtx = fragment;
   void _pumpCtx;
 
   // ── Mirror session connection state → parent's `connection` cell ──
+  // Lives OUTSIDE the pump: the connection cell tracks the *session's*
+  // state (copying / connecting / failed), not any frame the agent sends,
+  // so it's wired straight off `session.onState` and never flows through
+  // the mirror sink.
   session.onState((s) => {
     fragment.ctx.cells.connection.set({
       state: s.connection,
@@ -243,135 +250,32 @@ export function buildRouter(opts: BuildRouterOptions) {
   };
 
   // ── Bridge remote agent surface → parent's local surface ──────────
-  // Start a background pump that pins the session, then loops over each
-  // successive AgentClient the session produces — each time the agent
-  // process is respawned (after a transport drop), the bridge fetches
-  // the new client and re-issues ONE `mirrorRemoteSurface` against it. The
-  // framework's `ClientRetryPlugin` is NOT load-bearing here: stdio links
-  // don't recover mid-stream (the underlying streams die with the process),
-  // so the only reliable recovery is to re-mirror on the *new* client. The
-  // outer loop is what implements "reconnect → state reconciles, no ghosts".
-  void bridgeAgentToParent(
-    log,
+  // `pumpRemoteSurface` (R7 keystone) pins the session, then loops over
+  // each successive AgentClient the session produces — each time the agent
+  // process is respawned (after a transport drop), the pump fetches the new
+  // client and re-issues ONE `mirrorRemoteSurface` against the sink built
+  // below. The framework's `ClientRetryPlugin` is NOT load-bearing here:
+  // stdio links don't recover mid-stream (the underlying streams die with
+  // the process), so the only reliable recovery is to re-mirror on the
+  // *new* client. The pump's outer loop is what implements "reconnect →
+  // state reconciles, no ghosts"; drishti supplies only the per-spawn sink.
+  void pumpRemoteSurface({
+    source: surface,
     session,
-    fragment,
-    processCache,
-    browserSnapshotBus,
-    recordSample,
-    liveProcedures,
-  );
-
-  // `implementSurface` returns a router *fragment* — `{ surface: ... }`
-  // wrapping the per-key namespaces. Passing it directly to RPCHandler
-  // produces a `surface/surface/...` double-prefix in the matcher tree
-  // (no procedure matches what the client sends). Wrap once via
-  // `implement(contract).router({...fragment})` to flatten the prefix.
-  const router = implement(surface.contract).router({ ...fragment.router });
-  return { router, session };
-}
-
-/** The write-side methods the bridge pumps are allowed to touch — a
- *  deliberate least-privilege narrowing of `implementSurface(...).ctx`,
- *  not the full ctx. Pumps only ever mirror remote data inward, so they
- *  get `set` / `upsert` / `remove`; `readAll` and the underlying stores
- *  stay out of reach. This is a boundary, not a maintenance chore: the
- *  `_pumpCtx` guard below assigns the real fragment to this type, so a
- *  collection renamed or retyped on the surface becomes a compile error
- *  here rather than silent drift. */
-type FragmentCtx = {
-  ctx: {
-    cells: {
-      system: { set: (v: SystemInfo) => void };
-      connection: { set: (v: ConnectionInfo) => void };
-    };
-    collections: {
-      processes: {
-        upsert: (k: Pid, v: Process) => void;
-        remove: (k: Pid) => void;
-      };
-      cpuCores: {
-        upsert: (k: CoreId, v: CpuCore) => void;
-        remove: (k: CoreId) => void;
-      };
-      networkInterfaces: {
-        upsert: (k: IfaceName, v: NetInterface) => void;
-        remove: (k: IfaceName) => void;
-      };
-    };
-  };
-};
-
-/** Pin the session, then loop: fetch the current AgentClient, mirror the
- *  WHOLE agent surface into the parent with one `mirrorRemoteSurface` call,
- *  wait for it to settle (which happens when the link errors — stdio process
- *  death), then wait for the session to provide a fresh client
- *  (post-reconnect) and repeat.
- *
- *  Each loop iteration owns one client — a fresh ssh subprocess. The
- *  `clientSeq` counter labels them (`#1`, `#2`, …) so the otherwise
- *  identical per-reconnect log lines can be traced to a specific spawn:
- *  if the mirror against `#2` never yields a `system` frame while the agent
- *  on the far end logged `serving surface over stdio`, the handoff — not the
- *  remote — is where a stuck reconnect lives.
- *
- *  The four hand-rolled pumps (system cell, cpuCores + networkInterfaces
- *  collections, processesSnapshot stream) collapse into one declarative sink
- *  — the consume-side dual of the `implementSurface` call that built the
- *  parent's own surface above. The reconnect-loop primitive
- *  (`makeClientCursor`) and the per-client re-mirror stay the bridge's job,
- *  because stdio links don't recover mid-stream. */
-async function bridgeAgentToParent(
-  log: Logger,
-  session: HostSession<typeof surface.contract>,
-  fragment: FragmentCtx,
-  processCache: Map<Pid, Process>,
-  browserSnapshotBus: Channel<ProcessesSnapshotMsg>,
-  recordSample: (system: SystemInfo) => void,
-  liveProcedures: {
-    current: ProcedureForwarders<typeof surface.spec> | null;
-  },
-): Promise<void> {
-  log("pinning HostSession (parent-lifetime ref)…");
-  // Pin once. Swallow the initial promise — we'll fetch a fresh client
-  // (possibly a re-spawned one) in the loop below regardless of whether
-  // this first spawn succeeded.
-  session.pin().catch(() => {
-    /* logged via state cell; loop handles recovery */
-  });
-
-  // A cursor over the session's spawn lifecycle — `next()` blocks until a
-  // genuinely new spawn appears and resolves with its live client (it owns
-  // the stable-clientPromise comparison that keeps the loop from busy-
-  // spinning once a dead link fails fast).
-  const cursor = makeClientCursor(session);
-  let clientSeq = 0;
-  while (!session.isDestroyed()) {
-    let client: DrishtiAgent;
-    try {
-      client = await cursor.next();
-    } catch (err) {
-      log(`bridge: waiting for next client failed: ${(err as Error).message}`);
-      break;
-    }
-    clientSeq += 1;
-    const seq = clientSeq;
-    log(`agent client ready (client #${seq}); starting mirror`);
-    // Per-client mirror state — the agent leads each (re)connect with a fresh
-    // `system` snapshot, so the first-frame handshake markers and the frame
-    // counter reset with the client.
-    let firstSystemFrame = true;
-    let frames = 0;
-    const issuedAt = Date.now();
-    // R7 (kolu #1505): `mirrorRemoteSurface` returns the total-dual handle
-    // `{ procedures, done }`, no longer `Promise<void>`. The streaming sinks
-    // fold below; the procedure stubs are published to `liveProcedures` so the
-    // parent's `kill` handler can forward through them, and the loop blocks on
-    // `.done` until the link dies (a bare `await mirrorRemoteSurface(...)` would
-    // await a non-thenable handle and resolve at once, spinning the loop).
-    const mirror = mirrorRemoteSurface(
-      surface,
-      client,
-      {
+    // Build the mirror sink for ONE freshly-spawned client. Called once per
+    // (re)spawn, so the per-client state below resets naturally each
+    // reconnect: the agent leads every (re)connect with a fresh `system`
+    // snapshot, so the first-frame handshake marker and the frame counter
+    // re-arm with the client. `seq` labels successive spawns (`#1`, `#2`, …)
+    // so the otherwise-identical per-reconnect log lines trace to a specific
+    // spawn — if the mirror against `#2` never yields a `system` frame while
+    // the agent logged `serving surface over stdio`, the handoff (not the
+    // remote) is where a stuck reconnect lives.
+    makeSink: (_client, { seq }) => {
+      let firstSystemFrame = true;
+      let frames = 0;
+      const issuedAt = Date.now();
+      return {
         cells: {
           // The agent's `system` cell → the parent's. The first yield is also
           // the connection handshake: it flips the session to `connected`
@@ -420,24 +324,54 @@ async function bridgeAgentToParent(
             },
           },
         },
-      },
-      { log },
-    );
-    // Publish this spawn's forwarding stubs for the parent's `kill` handler;
-    // clear them the instant the link dies so a kill in the gap fails honestly
-    // rather than calling into a dead client.
-    liveProcedures.current = mirror.procedures;
-    try {
-      await mirror.done;
-    } finally {
-      liveProcedures.current = null;
-    }
-    log(
-      `bridge: mirror ended for client #${seq} (link likely died) — awaiting next client`,
-    );
-  }
-  log("bridge: session destroyed — exiting reconnect loop");
+      };
+    },
+    // Publish each spawn's forwarding stubs for the parent's `kill` handler;
+    // the pump clears them the instant the link dies, so a kill in the gap
+    // fails honestly rather than calling into a dead client.
+    liveProcedures,
+    log,
+  });
+
+  // `implementSurface` returns a router *fragment* — `{ surface: ... }`
+  // wrapping the per-key namespaces. Passing it directly to RPCHandler
+  // produces a `surface/surface/...` double-prefix in the matcher tree
+  // (no procedure matches what the client sends). Wrap once via
+  // `implement(contract).router({...fragment})` to flatten the prefix.
+  const router = implement(surface.contract).router({ ...fragment.router });
+  return { router, session };
 }
+
+/** The write-side methods the pump sink is allowed to touch — a
+ *  deliberate least-privilege narrowing of `implementSurface(...).ctx`,
+ *  not the full ctx. The sink only ever mirrors remote data inward, so it
+ *  gets `set` / `upsert` / `remove`; `readAll` and the underlying stores
+ *  stay out of reach. This is a boundary, not a maintenance chore: the
+ *  `_pumpCtx` guard above assigns the real fragment to this type, so a
+ *  collection renamed or retyped on the surface becomes a compile error
+ *  here rather than silent drift. */
+type FragmentCtx = {
+  ctx: {
+    cells: {
+      system: { set: (v: SystemInfo) => void };
+      connection: { set: (v: ConnectionInfo) => void };
+    };
+    collections: {
+      processes: {
+        upsert: (k: Pid, v: Process) => void;
+        remove: (k: Pid) => void;
+      };
+      cpuCores: {
+        upsert: (k: CoreId, v: CpuCore) => void;
+        remove: (k: CoreId) => void;
+      };
+      networkInterfaces: {
+        upsert: (k: IfaceName, v: NetInterface) => void;
+        remove: (k: IfaceName) => void;
+      };
+    };
+  };
+};
 
 /** Apply one `processesSnapshot` frame to the parent's local
  *  collection — full reset on `snapshot`, incremental delta on

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -271,7 +271,7 @@ export function buildRouter(opts: BuildRouterOptions) {
     // spawn — if the mirror against `#2` never yields a `system` frame while
     // the agent logged `serving surface over stdio`, the handoff (not the
     // remote) is where a stuck reconnect lives.
-    makeSink: (_client, { seq }) => {
+    makeSink: ({ seq }) => {
       let firstSystemFrame = true;
       let frames = 0;
       const issuedAt = Date.now();


### PR DESCRIPTION
Adopts the shared per-host fan-out extracted in juspay/kolu#1524 — deletes drishti's hand-rolled `bridgeAgentToParent` + `hostRegistry` copies and consumes the new additive exports `pumpRemoteSurface` + `buildHostRegistry` from `@kolu/surface-nix-host`.

## What changed

- **`packages/app/src/server/hostRegistry.ts`** — drops the local keyed `Map` + `add`/`remove`/`reconnect`/`recheckAll` + per-host socket-eviction lifecycle; delegates to the shared `buildHostRegistry`, supplying only `buildEntry` (`getHostSession` + `buildRouter` + `new RPCHandler`) and `persist` (`saveHosts`). The wrapper keeps its async signature, `resolveDrvPath`/`hostsFile` options, the `snapshot()` admin projection (now over `shared.hosts()`), and `WsConn` param types — so `main.ts` and `admin-router.ts` need **zero** changes.
- **`packages/app/src/server/router.ts`** — replaces the hand-rolled `bridgeAgentToParent` reconnect-mirror loop with `pumpRemoteSurface`. The four per-spawn sinks move into the pump's `makeSink` closure (per-client `firstSystemFrame` / `frames` / `issuedAt` reset per reconnect); `markConnected`, `recordSample`, `browserSnapshotBus.publish`, and the `liveProcedures` set/clear are preserved verbatim. Drops the now-unused `mirrorRemoteSurface` / `makeClientCursor` / `AgentClient` imports.
- **`npins/sources.json`** — bumps the kolu pin to `feat/pulam-web-framework` (`fb8fcb549485718cde91b54f6954f15d8a7dd8bb`), the branch carrying the new exports.

Net: **+164 / −248** across the two server files (a de-dup of the fan-out mechanism that now has a single source of truth in `@kolu/surface-nix-host`).

## Verification

`just typecheck` is clean (common, agent, app all `tsc --noEmit` green) against the bumped pin.

Linked: juspay/kolu#1524