### PR TITLE
feat: adopt @kolu/surface default-on connection liveness

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "pulam-conn",
       "submodules": false,
-      "revision": "d8cd75c3c03c39c1e32e83518e20913497091abe",
-      "url": "https://github.com/juspay/kolu/archive/d8cd75c3c03c39c1e32e83518e20913497091abe.tar.gz",
-      "hash": "sha256-xBtF0Q2dQblGULtCoY+egAY0w3dKIWI5d2WRoxCTq0M="
+      "revision": "3903995b9d273962d44bdb5814cce5256f6666a2",
+      "url": "https://github.com/juspay/kolu/archive/3903995b9d273962d44bdb5814cce5256f6666a2.tar.gz",
+      "hash": "sha256-wfvQUmiy9EtbIcN4m6ZvOstH2d+epdXTnmtzgbuVYBM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "pulam-conn",
+      "branch": "master",
       "submodules": false,
-      "revision": "3903995b9d273962d44bdb5814cce5256f6666a2",
-      "url": "https://github.com/juspay/kolu/archive/3903995b9d273962d44bdb5814cce5256f6666a2.tar.gz",
-      "hash": "sha256-wfvQUmiy9EtbIcN4m6ZvOstH2d+epdXTnmtzgbuVYBM="
+      "revision": "5856eb537fc97c9e7650e7a93c84e3a173683e60",
+      "url": "https://github.com/juspay/kolu/archive/5856eb537fc97c9e7650e7a93c84e3a173683e60.tar.gz",
+      "hash": "sha256-nuOkOPLji4M1a1Pc1ErxBr9YBKoF03jrCPoy3Zi8e3M="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -133,12 +133,16 @@ export function surfaceForHost(host: string): HostSurfaceClient {
 /** Close the host's socket and drop the cached client. Call when the
  *  admin collection signals the host was removed — otherwise the
  *  PartySocket keeps trying to reconnect into a server slot that no
- *  longer exists. */
+ *  longer exists. `dispose()` stops the liveness watchdog `connectSurface`
+ *  started: unlike a page-lifetime socket, a removed host's socket is torn
+ *  down mid-session, so the heartbeat's interval/probe timers must be
+ *  cleared here or they leak (and keep probing a closed socket). */
 export function disposeHostSurface(host: string): void {
   const entry = hostCache.get(host);
   if (entry === undefined) return;
   hostCache.delete(host);
   try {
+    entry.dispose();
     entry.ws.close();
   } catch {
     /* best-effort */

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -11,15 +11,30 @@
  * from the admin collection so the cache doesn't leak.
  */
 
+import type { ContractRouterClient } from "@orpc/contract";
 import { websocketLink } from "@kolu/surface/links/websocket";
-import { surfaceClient, surfaceClients } from "@kolu/surface/solid";
+import { type SurfaceClient, surfaceClients } from "@kolu/surface/solid";
 import {
   createProcessIdEcho,
   createSurfaceSocket,
 } from "@kolu/surface-app/connect";
+import { connectSurface } from "@kolu/surface-app/solid";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
 import { ADMIN_HOST_SENTINEL } from "../common/host";
 import { surface } from "drishti-common";
+
+// The per-host client's typed imperative `.rpc` — `app.rpc.surface.<prim>.<verb>`
+// for `metricHistory` / `processesSnapshot` / `process.kill`. `connectSurface`
+// builds the link internally and so returns `SurfaceClient<S>` with `.rpc: unknown`
+// (kolu's `SurfaceClient` infers `Rpc` from the link argument, which only a call
+// site that constructs the link can pin — see the typing note on `SurfaceClient`).
+// The runtime `.rpc` IS a `websocketLink<typeof surface.contract>`, so re-pinning
+// the contract type here is sound; the bound `.cells`/`.collections`/`.streams`
+// hooks are already typed off the surface spec and need no help.
+type HostSurfaceClient = SurfaceClient<
+  typeof surface.spec,
+  ContractRouterClient<typeof surface.contract>
+>;
 
 // ONE shared `pid` echo across every socket (per-host + admin). The parent mints
 // a fresh `processId` per boot; the echo threads the last-known one back as the
@@ -42,21 +57,20 @@ function wsBaseFor(host: string): string {
 // `nix copy`, so the connect deadline is bumped well past partysocket's 4s
 // default — without this, the socket flaps repeatedly during the first connect.
 //
-// `retire` controls who tears the socket down on a stale-close: the per-host
-// sockets have no provider lifecycle, so they self-retire on a stale-close
-// (`retire: true`). The admin socket is owned by `<SurfaceAppProvider>`'s turnkey
-// `{ ws, probe }` source, which retires it itself — so it opts out (`retire:
-// false`) to avoid a double-retire.
-function makeSocket(host: string, retire: boolean) {
+// The admin socket does NOT self-retire on a stale-close: it's owned by
+// `<SurfaceAppProvider>`'s turnkey `{ ws, probe }` source, which retires it
+// itself — so `retireOnStaleClose` is omitted here to avoid a double-retire.
+// (The per-host sockets, which have no provider, self-retire — see
+// `buildHostSurface`.)
+function makeAdminSocket() {
   return createSurfaceSocket({
-    url: () => wsBaseFor(host),
+    url: () => wsBaseFor(ADMIN_HOST_SENTINEL),
     echo,
     socketOptions: {
       connectionTimeout: 60_000,
       minReconnectionDelay: 2_000,
       maxReconnectionDelay: 15_000,
     },
-    retireOnStaleClose: retire,
   }).ws;
 }
 
@@ -64,19 +78,33 @@ type HostClient = ReturnType<typeof buildHostSurface>;
 type AdminClient = ReturnType<typeof buildAdminSurface>;
 
 function buildHostSurface(host: string) {
-  // Per-host sockets own their stale-close retirement — no provider watches them.
-  const ws = makeSocket(host, true);
-  const client = surfaceClient(
+  // The per-host seam (kolu#1545): `connectSurface` builds the socket + reactive
+  // client AND a DEFAULT-ON half-open liveness watchdog (probes the framework-
+  // reserved `system.live` round-trip — no probe to supply) in one call. These
+  // per-host sockets are the blind spot the admin socket never had: they had no
+  // client-side half-open detection, so a wedged-but-not-closed link (laptop
+  // sleep, Wi-Fi roam, a NAT dropping an idle connection) went unnoticed until a
+  // user interaction failed. The watchdog now reaps it. They self-retire on a
+  // stale-close (`retireOnStaleClose: true`) — no provider lifecycle watches them.
+  // `status` (connecting / live / reconnecting / down) is available for a
+  // per-host connection indicator if a host card wants one.
+  return connectSurface({
     surface,
-    websocketLink<typeof surface.contract>(ws as unknown as WebSocket),
-  );
-  return { ws, client };
+    url: () => wsBaseFor(host),
+    echo,
+    socketOptions: {
+      connectionTimeout: 60_000,
+      minReconnectionDelay: 2_000,
+      maxReconnectionDelay: 15_000,
+    },
+    retireOnStaleClose: true,
+  });
 }
 
 function buildAdminSurface() {
   // The admin socket is owned by `<SurfaceAppProvider>`'s turnkey source, which
   // retires it on a stale-restart itself (kolu#1231) — so it opts out here.
-  const ws = makeSocket(ADMIN_HOST_SENTINEL, false);
+  const ws = makeAdminSocket();
   // The admin transport multiplexes TWO sibling surfaces (kolu#1197/#1201):
   // drishti's own `admin` surface (the host set + procedures) and surface-app's
   // complete surface (`buildInfo` + the `identity.info` probe). `surfaceClients`
@@ -93,13 +121,13 @@ const hostCache = new Map<string, HostClient>();
 /** Get the (cached) surface client for `host`. The first call opens
  *  the PartySocket; subsequent calls return the same instance so a tab
  *  remount preserves the live connection. */
-export function surfaceForHost(host: string) {
+export function surfaceForHost(host: string): HostSurfaceClient {
   let entry = hostCache.get(host);
   if (entry === undefined) {
     entry = buildHostSurface(host);
     hostCache.set(host, entry);
   }
-  return entry.client;
+  return entry.client as HostSurfaceClient;
 }
 
 /** Close the host's socket and drop the cached client. Call when the

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -30,9 +30,8 @@ import { z } from "zod";
 import { destroyAllSessions } from "@kolu/surface-nix-host";
 import { gateWsOrigin, parseAllowedOrigins } from "@kolu/surface/ws-origin";
 import {
-  gateStaleSocket,
+  acceptSurfaceSocket,
   installSurfaceApp,
-  startWsHeartbeat,
 } from "@kolu/surface-app/server";
 import { ADMIN_HOST_SENTINEL, isValidHost } from "../common/host";
 import { BRAND_DARK } from "../client/brand";
@@ -239,14 +238,29 @@ async function main(): Promise<void> {
     maxPayload: 8 * 1024 * 1024,
   });
 
-  // Liveness heartbeat (@kolu/surface-app): ping accepted sockets and terminate
-  // any that stop ponging, reaping the server-side zombie a half-open browser
-  // (laptop sleep, Wi-Fi roam, a NAT/proxy dropping an idle connection) would
-  // otherwise leak. Covers BOTH the admin control-plane socket and every per-host
-  // socket — each registers below, after the stale-tab gate. The browser's own
-  // recovery is automatic: the admin socket rides `<SurfaceAppProvider>`'s turnkey
-  // source, which now starts a `createHeartbeat` watchdog itself.
-  const heartbeat = startWsHeartbeat(wss);
+  // Acceptance seam (@kolu/surface-app, kolu#1545): `acceptSurfaceSocket` owns the
+  // liveness reaper AND sequences stale-gate → enrol → dispatch in one
+  // `accept(ws, requestUrl, onAccepted)` call. The reaper pings accepted sockets
+  // and terminates any that stop ponging, reaping the server-side zombie a
+  // half-open browser (laptop sleep, Wi-Fi roam, a NAT/proxy dropping an idle
+  // connection) would otherwise leak — covering BOTH the admin control-plane
+  // socket and every per-host socket. `liveProcessId` is the id the
+  // `identity.info` probe reports, so the stale-tab gate and the probe
+  // single-source. `onError`/`onReject` receive the upgrade `requestUrl` so we
+  // re-derive `?host=` for the per-host log line. The browser's own recovery is
+  // automatic: the admin socket rides `<SurfaceAppProvider>`'s turnkey source,
+  // which starts a `createHeartbeat` watchdog itself; the per-host sockets now
+  // carry `connectSurface`'s default-on watchdog (see client/wire.ts).
+  const acceptor = acceptSurfaceSocket({
+    server: wss,
+    liveProcessId: admin.processId,
+    onError: (err, url) =>
+      log(`browser ws error (host=${url.searchParams.get("host")}): ${err.message}`),
+    onReject: (_pid, url) =>
+      log(
+        `rejecting stale browser ws (host=${url.searchParams.get("host")}) — parent restarted`,
+      ),
+  });
 
   // ── WebSocket upgrade: parse ?host=<id>, then dispatch directly ──────
   // The `host` variable is closed over in the handleUpgrade callback so
@@ -301,60 +315,45 @@ async function main(): Promise<void> {
       socket as Parameters<typeof wss.handleUpgrade>[1],
       head as Parameters<typeof wss.handleUpgrade>[2],
       (ws) => {
-        // Stale-tab handshake gate (@kolu/surface-app): a tab that reconnects
-        // after a PARENT restart still carries the previous process's `pid`.
-        // `gateStaleSocket` installs the `error` listener FIRST (the one crash-free
-        // order), reads the claimed `pid` off the request URL, and on a stale tab
-        // closes with STALE_PROCESS_CLOSE_CODE before the oRPC handler upgrades —
-        // so its live subscriptions never replay against a process that never had
-        // them. An absent `pid` (the first-ever connect) always passes.
-        // `admin.processId` is the live id the `identity.info` probe reports, so
-        // the gate and the probe single-source. The installed `error` listener
-        // persists for the connection lifetime — so the per-branch handlers below
-        // no longer re-install one.
-        if (
-          gateStaleSocket(ws, url, admin.processId, {
-            onError: (err) =>
-              log(`browser ws error (host=${host}): ${err.message}`),
-            onReject: () =>
+        // The acceptance seam (@kolu/surface-app, kolu#1545): one call runs the
+        // stale-tab gate (a tab that reconnects after a PARENT restart still
+        // carries the previous process's `pid` — gated and closed before the
+        // oRPC handler upgrades, so its live subscriptions never replay against
+        // a process that never had them; an absent `pid`, the first-ever
+        // connect, always passes), enrols the accepted socket in the liveness
+        // reaper, and only THEN runs the dispatch closure below — sequenced so a
+        // socket can't be dispatched without first being gated and enrolled. A
+        // stale tab is closed and the closure never runs.
+        acceptor.accept(ws, url, () => {
+          if (host === ADMIN_HOST_SENTINEL) {
+            log("browser ws connect (admin)");
+            ws.on("close", (code, reason) =>
               log(
-                `rejecting stale browser ws (host=${host}) — parent restarted`,
+                `browser ws disconnect (admin) (code=${code} reason=${reason.toString() || "<none>"})`,
               ),
-          })
-        )
-          return;
-        // Accepted socket (gate passed): enrol it in the liveness heartbeat so a
-        // half-open client is reaped here. One call covers both branches below;
-        // gate-rejected sockets already returned.
-        heartbeat.register(ws);
-        if (host === ADMIN_HOST_SENTINEL) {
-          log("browser ws connect (admin)");
-          ws.on("close", (code, reason) =>
+            );
+            void adminHandler.upgrade(
+              ws as unknown as Parameters<typeof adminHandler.upgrade>[0],
+            );
+            return;
+          }
+          const handler = registry.getHandler(host);
+          if (handler === undefined) {
+            ws.close(1008, `unknown host: ${host}`);
+            return;
+          }
+          registry.registerConnection(host, ws);
+          log(`browser ws connect (host=${host})`);
+          ws.on("close", (code, reason) => {
+            registry.unregisterConnection(host, ws);
             log(
-              `browser ws disconnect (admin) (code=${code} reason=${reason.toString() || "<none>"})`,
-            ),
-          );
-          void adminHandler.upgrade(
-            ws as unknown as Parameters<typeof adminHandler.upgrade>[0],
-          );
-          return;
-        }
-        const handler = registry.getHandler(host);
-        if (handler === undefined) {
-          ws.close(1008, `unknown host: ${host}`);
-          return;
-        }
-        registry.registerConnection(host, ws);
-        log(`browser ws connect (host=${host})`);
-        ws.on("close", (code, reason) => {
-          registry.unregisterConnection(host, ws);
-          log(
-            `browser ws disconnect (host=${host}) (code=${code} reason=${reason.toString() || "<none>"})`,
+              `browser ws disconnect (host=${host}) (code=${code} reason=${reason.toString() || "<none>"})`,
+            );
+          });
+          void handler.upgrade(
+            ws as unknown as Parameters<typeof handler.upgrade>[0],
           );
         });
-        void handler.upgrade(
-          ws as unknown as Parameters<typeof handler.upgrade>[0],
-        );
       },
     );
   });
@@ -363,7 +362,7 @@ async function main(): Promise<void> {
     log(`${sig}: destroying host sessions`);
     stopWakeMonitor();
     destroyAllSessions();
-    heartbeat.stop();
+    acceptor.stop();
     wss.close();
     for (const ws of wss.clients) {
       try {


### PR DESCRIPTION
Adopts kolu [#1545](https://github.com/juspay/kolu/pull/1545)'s default-on connection-liveness seams into drishti's per-host and admin WebSocket wiring.

## What changed

**Client — `packages/app/src/client/wire.ts`.** The per-host sockets (`buildHostSurface`) now build through `connectSurface` from `@kolu/surface-app/solid`. These were drishti's blind spot: they had **no client-side half-open detection**, so a wedged-but-not-closed link (laptop sleep, Wi-Fi roam, a NAT/proxy dropping an idle connection) went unnoticed until a user interaction failed. `connectSurface` builds the socket + reactive client AND a **default-on** liveness watchdog (it probes the framework-reserved `system.live` round-trip — there's no probe left to forget) in one call — the exact blind spot kolu #1545 fixes for pulam-web's per-host fleet sockets. It also returns a reactive `status` (`connecting` / `live` / `reconnecting` / `down`) available for a per-host indicator if a host card ever wants one. The admin socket keeps `createSurfaceSocket` + `surfaceClients` — it multiplexes two sibling surfaces over a dual link, which the single-surface `connectSurface` doesn't fit.

**Server — `packages/app/src/server/main.ts`.** The per-socket `gateStaleSocket` → `heartbeat.register` → dispatch sequence collapses onto `acceptSurfaceSocket` from `@kolu/surface-app/server`. It owns the liveness reaper internally (no `startWsHeartbeat` call to forget) and sequences stale-gate → enrol → dispatch in one `accept(ws, requestUrl, onAccepted)` call — a socket can no longer be dispatched without first being gated and enrolled. `onError`/`onReject` now receive the upgrade `requestUrl`, so the per-host `?host=` log context is re-derived from it. The origin gate, `?host=` parse, `registry.has` pre-check, the `__admin__` sentinel branch, and `registerConnection`/`unregisterConnection` are all preserved verbatim inside the dispatch closure.

drishti's `HostSession` ssh-leg watchdog is inherited transparently — it's default-on in the kolu API with no code change in `hostRegistry.ts` / `router.ts`.

## Pin

Bumps the kolu npins pin to `pulam-conn@3903995b9`. No new third-party npm dep (the kolu change reuses `ws` / `partysocket` / `orpc`), so `bun.nix` is unchanged and no `just regenerate-bun-nix` was needed — the `@kolu/*` packages hydrate from the Nix store.

## Verification

- `just typecheck` — green (a typed `.rpc` re-pin was needed: `connectSurface` returns `SurfaceClient<S>` with `.rpc: unknown` because it builds the link internally and kolu's `SurfaceClient` infers `Rpc` from the link argument; drishti calls imperative procedures on the per-host client — `metricHistory` / `processesSnapshot` / `process.kill` — so the contract type is re-pinned at the wire boundary, sound because the runtime `.rpc` *is* that link).
- `nix build` (devour-flake, the CI `nix` lane) — green.
- `fmt-check`, `bun-nix-fresh` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up (`fix: stop the per-host liveness watchdog on host removal`).** `connectSurface`'s watchdog runs an interval/probe-timeout that only stops on `dispose()`. drishti tears a per-host socket down mid-session when a host is removed from the admin collection (pulam-web never removes a host, so it never disposes) — so `disposeHostSurface` now calls `entry.dispose()` before closing the socket. Closing only the socket leaked the heartbeat timers, which would keep probing a closed socket.
