### PR TITLE
chore(deps): bump kolu pin for onLinkDown surface API (kolu#1550)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "fix/pulam-web-stale-awareness-reconnect",
       "submodules": false,
-      "revision": "d8cd75c3c03c39c1e32e83518e20913497091abe",
-      "url": "https://github.com/juspay/kolu/archive/d8cd75c3c03c39c1e32e83518e20913497091abe.tar.gz",
-      "hash": "sha256-xBtF0Q2dQblGULtCoY+egAY0w3dKIWI5d2WRoxCTq0M="
+      "revision": "950ad6d1bce6dfcfc40ce22d87799595f144440b",
+      "url": "https://github.com/juspay/kolu/archive/950ad6d1bce6dfcfc40ce22d87799595f144440b.tar.gz",
+      "hash": "sha256-cJOfxYB8ZanOaRfWpi7c/Lh5e+pXoBYhEOnkkRoOOYE="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Re-validates drishti against the additive `onLinkDown` field added to `PumpRemoteSurfaceOptions` in `@kolu/surface-nix-host` by **[kolu#1550](https://github.com/juspay/kolu/pull/1550)** — the [`.claude/rules/surface.md`](https://github.com/juspay/kolu/blob/master/.claude/rules/surface.md) shared-surface gate.

The change is **purely additive**: `onLinkDown` is an optional field on `PumpRemoteSurfaceOptions`, and drishti's only `pumpRemoteSurface` call (`packages/app/src/server/router.ts`) never passes it. Verified the consumer compiles unchanged (all three workspace members `tsc --noEmit` clean against the new `hostFanout.ts`); this PR bumps the npins kolu pin to that PR's HEAD so drishti's **full CI** proves it on both platforms.

Pinned to the kolu feature branch HEAD (`fix/pulam-web-stale-awareness-reconnect` @ `950ad6d1b`) for the gate; re-pin to master once kolu#1550 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)