### PR TITLE
feat: adopt kolu's shared connection cell + client.health() (the second policy)

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -20,7 +20,7 @@ nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accep
 [macos]
 [parallel]
 [metadata("ci")]
-default: nix typecheck fmt-check bun-nix-fresh home-manager drv-stability
+default: nix typecheck fmt-check bun-nix-fresh home-manager drv-stability agent-boots
 
 # Single per-platform `bun install`. Funnel every bun consumer through this
 # node so concurrent `bun install` runs against the same workspace don't race.
@@ -84,6 +84,29 @@ drv-stability:
       echo "drv-stability: FAIL — a client edit churned the agent .drv"
       echo "  before: $base"
       echo "  after:  $after"
+      exit 1
+    fi
+
+# Boot the BUILT agent to prove its runtime module graph resolves — the guard
+# this pipeline lacked. `typecheck` resolves `@kolu/*` from the dev node_modules
+# (which has everything) and `nix build` only COPIES the agent's tree, so a
+# runtime-only missing dependency stays invisible until the agent actually runs:
+# the agent-shared `drishti-common` (common/surface.ts) must import NOTHING from
+# `@kolu/surface-nix-host`, because the agent's scoped build deliberately hydrates
+# only `@kolu/surface` (nix/packages/drishti-agent) — a stray import crashes the
+# remote agent with "Cannot find module" on every connect. A bare invocation
+# loads `common/surface.ts` at import (before printing usage), so a broken module
+# graph fails HERE with that error instead of the banner.
+agent-boots:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nix build .#drishti-agent
+    out=$(./result/bin/drishti-agent 2>&1 || true)
+    if printf '%s' "$out" | grep -q "drishti-agent — exposes"; then
+      echo "agent-boots: PASS — the built agent's module graph resolves at runtime"
+    else
+      echo "agent-boots: FAIL — the built agent did not boot (runtime module error?):"
+      printf '%s\n' "$out"
       exit 1
     fi
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "4be640db8279bc3b29490dda926d711cd5bac10e",
-      "url": "https://github.com/juspay/kolu/archive/4be640db8279bc3b29490dda926d711cd5bac10e.tar.gz",
-      "hash": "sha256-XYo99buGoL8P/OKld5MZyfxgMf0CpVYrZzexf0mJ8Ck="
+      "revision": "fcae0db1e80203afba39a38c06f9fc674d68b39c",
+      "url": "https://github.com/juspay/kolu/archive/fcae0db1e80203afba39a38c06f9fc674d68b39c.tar.gz",
+      "hash": "sha256-HQvXP9A3SwHpV7Wd4wPAFHWWhvEkjDj91vuvah74Bes="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "pulam-conn-bug",
+      "branch": "master",
       "submodules": false,
-      "revision": "10ea6946f8ff29bc7de7b0b874b4c30a8da01d13",
-      "url": "https://github.com/juspay/kolu/archive/10ea6946f8ff29bc7de7b0b874b4c30a8da01d13.tar.gz",
-      "hash": "sha256-EvMng1UDxY3K7ISgaFomA46uCwmvEsL19M+hKCSJmb4="
+      "revision": "85ca242b37105ea34ccdc7f826aef19b809af41c",
+      "url": "https://github.com/juspay/kolu/archive/85ca242b37105ea34ccdc7f826aef19b809af41c.tar.gz",
+      "hash": "sha256-EDGKHclK0+g/MHIF/p/iHxgX0YBWgMpLIytNg/NTHCk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "5c0dc022ecf62f7afee22d13538b92919c141557",
-      "url": "https://github.com/juspay/kolu/archive/5c0dc022ecf62f7afee22d13538b92919c141557.tar.gz",
-      "hash": "sha256-uGeHdTFwUMpkVOhp8EvQt0QFM0hZV/VzVs3jDShRzYI="
+      "revision": "d5838d2cac96378df3102581affd8fd91f349b04",
+      "url": "https://github.com/juspay/kolu/archive/d5838d2cac96378df3102581affd8fd91f349b04.tar.gz",
+      "hash": "sha256-3fIbr1vrNPkd+ZCyC4zfdxaNeBo7mZdumAQoj6UBnCw="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "01b7b779678cb16a7b230fc755783257e0186956",
-      "url": "https://github.com/juspay/kolu/archive/01b7b779678cb16a7b230fc755783257e0186956.tar.gz",
-      "hash": "sha256-D/CifTAfOjkcEIzAB/GhvT6uMkkTJE02a9e9/DJGwUE="
+      "revision": "0735caf165b0f395fcd30fd1f311e7b6311e2c69",
+      "url": "https://github.com/juspay/kolu/archive/0735caf165b0f395fcd30fd1f311e7b6311e2c69.tar.gz",
+      "hash": "sha256-y0rr0oDQxBDEtm956fPov+bYbOVFfct986ry004wv0s="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "4e19d28fbcbeb0d4b6d6bfc6633fd771c57612f7",
-      "url": "https://github.com/juspay/kolu/archive/4e19d28fbcbeb0d4b6d6bfc6633fd771c57612f7.tar.gz",
-      "hash": "sha256-c2SOcKg41b1bx0z5tb+9woKz/XvSCbRO1y8tXIx9KYQ="
+      "revision": "ff15c2bb3cafca3510029fad7eefe22d15dc944f",
+      "url": "https://github.com/juspay/kolu/archive/ff15c2bb3cafca3510029fad7eefe22d15dc944f.tar.gz",
+      "hash": "sha256-ghwytMfOAQWId1L6zki0QAxCJx3/KdQ7tqT6bpnBWM8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "0bb255c2ab36d9f0ccb2f489ab5a0b67a62d091d",
-      "url": "https://github.com/juspay/kolu/archive/0bb255c2ab36d9f0ccb2f489ab5a0b67a62d091d.tar.gz",
-      "hash": "sha256-kt/DUUDpBdaidqTWmF1sH9TBgZ3WGRkJF16MSI8Nt/8="
+      "revision": "4e19d28fbcbeb0d4b6d6bfc6633fd771c57612f7",
+      "url": "https://github.com/juspay/kolu/archive/4e19d28fbcbeb0d4b6d6bfc6633fd771c57612f7.tar.gz",
+      "hash": "sha256-c2SOcKg41b1bx0z5tb+9woKz/XvSCbRO1y8tXIx9KYQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "fcae0db1e80203afba39a38c06f9fc674d68b39c",
-      "url": "https://github.com/juspay/kolu/archive/fcae0db1e80203afba39a38c06f9fc674d68b39c.tar.gz",
-      "hash": "sha256-HQvXP9A3SwHpV7Wd4wPAFHWWhvEkjDj91vuvah74Bes="
+      "revision": "ba51c99772ad115716dc364366e5f57a6189a82d",
+      "url": "https://github.com/juspay/kolu/archive/ba51c99772ad115716dc364366e5f57a6189a82d.tar.gz",
+      "hash": "sha256-aq+CARd6bhb3t0pguw/AQ9nUJQqdfWimltFtrvy1kKY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "ea0faf623effb14cb5bc03a4a64cb59c7eeca674",
-      "url": "https://github.com/juspay/kolu/archive/ea0faf623effb14cb5bc03a4a64cb59c7eeca674.tar.gz",
-      "hash": "sha256-1zo1DYzbBOXd/TcBtqS7FmDyWOaS3dDiK8dGDUXg/L0="
+      "revision": "4be640db8279bc3b29490dda926d711cd5bac10e",
+      "url": "https://github.com/juspay/kolu/archive/4be640db8279bc3b29490dda926d711cd5bac10e.tar.gz",
+      "hash": "sha256-XYo99buGoL8P/OKld5MZyfxgMf0CpVYrZzexf0mJ8Ck="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "0735caf165b0f395fcd30fd1f311e7b6311e2c69",
-      "url": "https://github.com/juspay/kolu/archive/0735caf165b0f395fcd30fd1f311e7b6311e2c69.tar.gz",
-      "hash": "sha256-y0rr0oDQxBDEtm956fPov+bYbOVFfct986ry004wv0s="
+      "revision": "5c0dc022ecf62f7afee22d13538b92919c141557",
+      "url": "https://github.com/juspay/kolu/archive/5c0dc022ecf62f7afee22d13538b92919c141557.tar.gz",
+      "hash": "sha256-uGeHdTFwUMpkVOhp8EvQt0QFM0hZV/VzVs3jDShRzYI="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "9ec1b553eb0ca12b0a30f7e7e302548a554853fe",
-      "url": "https://github.com/juspay/kolu/archive/9ec1b553eb0ca12b0a30f7e7e302548a554853fe.tar.gz",
-      "hash": "sha256-7sMNPz0s4AwYYRLSN0QnNn0wlPjOdRZRkmOsdKNrQjo="
+      "revision": "b9a5cf2d6b123bfe7a812ca4541fbbf0fcaada48",
+      "url": "https://github.com/juspay/kolu/archive/b9a5cf2d6b123bfe7a812ca4541fbbf0fcaada48.tar.gz",
+      "hash": "sha256-4/rv3A4MbHg3YI3G+OU8k1Xb0H9N5/WT9/bJrPculUw="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "ba51c99772ad115716dc364366e5f57a6189a82d",
-      "url": "https://github.com/juspay/kolu/archive/ba51c99772ad115716dc364366e5f57a6189a82d.tar.gz",
-      "hash": "sha256-aq+CARd6bhb3t0pguw/AQ9nUJQqdfWimltFtrvy1kKY="
+      "revision": "01b7b779678cb16a7b230fc755783257e0186956",
+      "url": "https://github.com/juspay/kolu/archive/01b7b779678cb16a7b230fc755783257e0186956.tar.gz",
+      "hash": "sha256-D/CifTAfOjkcEIzAB/GhvT6uMkkTJE02a9e9/DJGwUE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "fix/pulam-web-stale-awareness-reconnect",
+      "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "950ad6d1bce6dfcfc40ce22d87799595f144440b",
-      "url": "https://github.com/juspay/kolu/archive/950ad6d1bce6dfcfc40ce22d87799595f144440b.tar.gz",
-      "hash": "sha256-cJOfxYB8ZanOaRfWpi7c/Lh5e+pXoBYhEOnkkRoOOYE="
+      "revision": "8371d1e6d3566d1469b6f3c8caa907400bfcc75b",
+      "url": "https://github.com/juspay/kolu/archive/8371d1e6d3566d1469b6f3c8caa907400bfcc75b.tar.gz",
+      "hash": "sha256-+k8fM2ivZnoFKjzoQlShcn6AOh91SN7ABeiNTUSW384="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "d5838d2cac96378df3102581affd8fd91f349b04",
-      "url": "https://github.com/juspay/kolu/archive/d5838d2cac96378df3102581affd8fd91f349b04.tar.gz",
-      "hash": "sha256-3fIbr1vrNPkd+ZCyC4zfdxaNeBo7mZdumAQoj6UBnCw="
+      "revision": "10ea6946f8ff29bc7de7b0b874b4c30a8da01d13",
+      "url": "https://github.com/juspay/kolu/archive/10ea6946f8ff29bc7de7b0b874b4c30a8da01d13.tar.gz",
+      "hash": "sha256-EvMng1UDxY3K7ISgaFomA46uCwmvEsL19M+hKCSJmb4="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "b9a5cf2d6b123bfe7a812ca4541fbbf0fcaada48",
-      "url": "https://github.com/juspay/kolu/archive/b9a5cf2d6b123bfe7a812ca4541fbbf0fcaada48.tar.gz",
-      "hash": "sha256-4/rv3A4MbHg3YI3G+OU8k1Xb0H9N5/WT9/bJrPculUw="
+      "revision": "ea0faf623effb14cb5bc03a4a64cb59c7eeca674",
+      "url": "https://github.com/juspay/kolu/archive/ea0faf623effb14cb5bc03a4a64cb59c7eeca674.tar.gz",
+      "hash": "sha256-1zo1DYzbBOXd/TcBtqS7FmDyWOaS3dDiK8dGDUXg/L0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "ff15c2bb3cafca3510029fad7eefe22d15dc944f",
-      "url": "https://github.com/juspay/kolu/archive/ff15c2bb3cafca3510029fad7eefe22d15dc944f.tar.gz",
-      "hash": "sha256-ghwytMfOAQWId1L6zki0QAxCJx3/KdQ7tqT6bpnBWM8="
+      "revision": "9ec1b553eb0ca12b0a30f7e7e302548a554853fe",
+      "url": "https://github.com/juspay/kolu/archive/9ec1b553eb0ca12b0a30f7e7e302548a554853fe.tar.gz",
+      "hash": "sha256-7sMNPz0s4AwYYRLSN0QnNn0wlPjOdRZRkmOsdKNrQjo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "pulam-conn-bug",
       "submodules": false,
-      "revision": "8371d1e6d3566d1469b6f3c8caa907400bfcc75b",
-      "url": "https://github.com/juspay/kolu/archive/8371d1e6d3566d1469b6f3c8caa907400bfcc75b.tar.gz",
-      "hash": "sha256-+k8fM2ivZnoFKjzoQlShcn6AOh91SN7ABeiNTUSW384="
+      "revision": "0bb255c2ab36d9f0ccb2f489ab5a0b67a62d091d",
+      "url": "https://github.com/juspay/kolu/archive/0bb255c2ab36d9f0ccb2f489ab5a0b67a62d091d.tar.gz",
+      "hash": "sha256-kt/DUUDpBdaidqTWmF1sH9TBgZ3WGRkJF16MSI8Nt/8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -36,7 +36,6 @@ import { serveOverStdio } from "@kolu/surface/peer-server";
 import {
   type CoreId,
   type CpuCore,
-  DEFAULT_CONNECTION,
   type IfaceName,
   type MetricHistoryMsg,
   type NetInterface,
@@ -160,16 +159,11 @@ export async function serveAgent(
   const fragment = implementSurface(surface, {
     channel: inMemoryChannelByName(),
     cells: {
+      // The agent serves the connection-FREE base surface. Link health is the
+      // PARENT's observation of the parent↔agent link (the agent can't see its
+      // own SSH transport from the inside), so it's composed only at the parent's
+      // re-serve via `mirroredSurface`, never here.
       system: { store: systemStore },
-      // ⚠ **INERT STUB — DO NOT WRITE TO THIS CELL.**
-      // `connection` is declared on the shared surface so the browser
-      // can subscribe to parent-published lifecycle. The agent has no
-      // visibility into its own SSH transport state from the inside,
-      // so this store stays at `DEFAULT_CONNECTION` for the lifetime
-      // of the process. The parent's router has independent write
-      // authority on its own implementation of the same surface.
-      // (See the warning in common/surface.ts on `ConnectionSchema`.)
-      connection: { store: inMemoryStore({ ...DEFAULT_CONNECTION }) },
     },
     collections: {
       processes: {

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -346,6 +346,11 @@ export default function App() {
       clientCommit={shellCommit()}
       ws={adminSocket()}
       probe={() => surfaceAppProbe(surfaceAppClient())}
+      // `wire.ts`'s `connectSurfaces` already wires the half-open watchdog over
+      // this admin socket (minting the branded `{ live }` the clients require), so
+      // the lifecycle opts ITS watchdog out — one watchdog on the socket, not two.
+      // (The lifecycle mints no brand, so this is ownership coordination only.)
+      heartbeat={false}
       onProcessId={rememberServerProcessId}
       restartCloseCode={STALE_PROCESS_CLOSE_CODE}
     >

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -15,7 +15,7 @@
  */
 
 import { streamCall } from "@kolu/surface/client";
-import { createSubscription } from "@kolu/surface/solid";
+import { createSubscription, surfaceClientsHealth } from "@kolu/surface/solid";
 import { STALE_PROCESS_CLOSE_CODE } from "@kolu/surface-app";
 import { shellCommit } from "@kolu/surface-app/lifecycle";
 import { SurfaceAppProvider, surfaceAppProbe } from "@kolu/surface-app/solid";
@@ -181,6 +181,17 @@ function subscribeMetricHistory(
 } {
   const [history, setHistory] = createSignal<MetricSample[]>([]);
   const [streamError, setStreamError] = createSignal<Error | null>(null);
+  const [pending, setPending] = createSignal(true);
+  // Leak A: a RAW `streamCall` owns its loop, so the framework can't enrol it.
+  // JOIN it to `app.health()` by hand (`enroll` — it already owns its
+  // pending/error), so a dead metric feed surfaces in the one FACT (drishti's
+  // per-host degraded badge) and not ONLY this widget's sparkline. Auto-disposes
+  // with the calling component's owner; the reactive `error()` supersedes the old
+  // per-channel `console.error`.
+  app.enroll("metricHistory", {
+    pending,
+    error: () => streamError() ?? undefined,
+  });
   void (async () => {
     try {
       const stream = await streamCall(
@@ -189,6 +200,7 @@ function subscribeMetricHistory(
         { signal },
       );
       for await (const msg of stream) {
+        if (pending()) setPending(false);
         if (msg.kind === "snapshot") setHistory(msg.samples);
         else
           setHistory((prev) =>
@@ -197,7 +209,7 @@ function subscribeMetricHistory(
       }
     } catch (err) {
       if (!signal.aborted) {
-        console.error("metricHistory stream failed", err);
+        setPending(false);
         setStreamError(err instanceof Error ? err : new Error(String(err)));
       }
     }
@@ -356,6 +368,23 @@ function MultiHostApp() {
   // order, and the admin collection's keys stream is order-preserving.
   // Sorting here would silently override the upstream invariant.
   const hostList = createMemo<string[]>(() => [...hosts.keys()]);
+
+  // Y6 (Leak D): the admin transport multiplexes TWO sibling surfaces — drishti's
+  // own `admin` and surface-app — built by `surfaceClients`, each with its OWN
+  // independent `health()`. `surfaceClientsHealth` folds them into ONE fact (the
+  // multi-surface closure), so a degraded control-plane sibling surfaces in a
+  // single read instead of N hand-assembled ones (each easy to forget — the
+  // partial-gate hazard the fold exists to kill). This is the real CONSUMER of
+  // that fold: kolu surfaces health per-cell via colocated toasts, so kolu's own
+  // `surfaceClients` doesn't fold; drishti's always-open control plane is the
+  // natural place to ask "is the fleet's spine healthy?" as one answer. Rendered
+  // stale-while-degraded (drishti's policy) — a non-blocking strip, never blanking.
+  const controlPlaneError = createMemo(
+    () =>
+      surfaceClientsHealth({ admin, surfaceApp: surfaceAppClient() }).subs.find(
+        (s) => s.error,
+      )?.error?.message ?? null,
+  );
 
   // Drive per-host socket disposal from the parent that owns the admin
   // subscription, NOT from inside `TabChip`. The chip is pure display;
@@ -532,6 +561,14 @@ function MultiHostApp() {
           theme={theme()}
           onToggleTheme={toggleTheme}
         />
+        {/* The folded control-plane health (Leak D): a degraded admin sibling
+            shows a non-blocking strip, never blanking the fleet (drishti's
+            stale-while-degraded policy). */}
+        <Show when={controlPlaneError()}>
+          <div class="border-b border-amber-500/40 bg-amber-500/10 px-4 py-1 text-xs text-amber-700 dark:text-amber-400">
+            Control plane degraded — {controlPlaneError()}.
+          </div>
+        </Show>
         <Show
           when={hostList().length > 0}
           fallback={
@@ -759,9 +796,15 @@ function HostView(props: { host: string }) {
       reduce: foldProcessesMessage,
       initial: {},
       signal: processesCtl.signal,
-      onError: (err) => console.error("processesSnapshot stream failed", err),
     },
   );
+  // Leak A: this raw stream is a hand-driven `createSubscription` over a surface
+  // PROCEDURE (`processesSnapshot.get` is not a Stream primitive), so the
+  // framework can't enrol it — JOIN it to `app.health()` directly (a
+  // `createSubscription` already owns its pending/error). A dead process feed now
+  // surfaces in the one FACT (the per-host degraded badge) instead of a private
+  // `console.error` — the reactive `error()` supersedes the one-shot callback.
+  app.enroll("processesSnapshot", processesSub);
   const processes = (): Record<Pid, Process> => processesSub() ?? {};
 
   // Which PID is expanded into the detail panel (null = none). Ephemeral —
@@ -810,6 +853,17 @@ function HostView(props: { host: string }) {
   const currentSystem = createMemo(() => system.value() ?? DEFAULT_SYSTEM);
   const currentConnection = createMemo(
     () => connection.value() ?? DEFAULT_CONNECTION,
+  );
+
+  // R3: drishti READS the SAME `client.health()` fact pulam-web hard-gates on,
+  // but with the OPPOSITE policy — STALE-WHILE-DEGRADED. A subscription error (a
+  // per-key cell/core/nic sub, or the now-enrolled `metricHistory` /
+  // `processesSnapshot` raw streams) shows a NON-blocking strip and the body
+  // STAYS; pulam-web's `<SurfaceGate ready>` would blank the whole host. That
+  // divergence over ONE shared fact is exactly why the framework exposes the FACT
+  // and leaves the verdict to each consumer — the two-policy premise, exercised.
+  const degraded = createMemo(
+    () => app.health().subs.find((s) => s.error)?.error?.message ?? null,
   );
 
   const allPids = createMemo<Pid[]>(() =>
@@ -908,6 +962,14 @@ function HostView(props: { host: string }) {
         connection={currentConnection()}
         count={allPids().length}
       />
+      {/* Stale-while-degraded: a NON-blocking strip when any subscription errors;
+          the body below stays visible (drishti's policy — the opposite of
+          pulam-web's hard gate over the same `app.health()` fact). */}
+      <Show when={degraded()}>
+        <div class="border-b border-amber-500/40 bg-amber-500/10 px-4 py-1 text-xs text-amber-700 dark:text-amber-400">
+          Some data is stale — a subscription is reconnecting ({degraded()}).
+        </div>
+      </Show>
       <Show
         when={currentConnection().state === "connected"}
         fallback={

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -381,8 +381,13 @@ function MultiHostApp() {
   // socket's liveness through `surfaceClients`, a dead control-plane socket flips
   // the folded `live` false (the AND-reduce over both siblings) and the strip
   // says so — transport death wins over a per-sub error.
+  // The admin control-plane health fact, folded once and read by BOTH the
+  // degraded-strip memo below and the `StatusFooter`'s srv dot (`<HostStatusPip>`),
+  // so the strip's "is the spine healthy?" verdict and the dot's green can't drift.
+  const adminHealth = () =>
+    surfaceClientsHealth({ admin, surfaceApp: surfaceAppClient() });
   const controlPlaneError = createMemo(() => {
-    const h = surfaceClientsHealth({ admin, surfaceApp: surfaceAppClient() });
+    const h = adminHealth();
     if (!h.live) return "connection lost — reconnecting…";
     return h.subs.find((s) => s.error)?.error?.message ?? null;
   });
@@ -593,7 +598,7 @@ function MultiHostApp() {
           </Show>
         </Show>
       </div>
-      <StatusFooter />
+      <StatusFooter health={adminHealth} />
     </div>
   );
 }

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -57,7 +57,12 @@ import {
   type ConnectionState,
   DEFAULT_CONNECTION,
 } from "drishti-common/browser";
-import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
+import {
+  disconnectedMessage,
+  STATE,
+  statusTextClass,
+  withElapsed,
+} from "./connectionColors";
 import { HostDot } from "./HostDot";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";
@@ -667,13 +672,15 @@ function HostCard(props: { host: string; onSelect: () => void }) {
         <span class="truncate font-semibold" title={props.host}>
           {props.host}
         </span>
-        <span class={`ml-auto shrink-0 text-xs ${STATE[state()].text}`}>
+        <span
+          class={`ml-auto shrink-0 text-xs ${statusTextClass(state(), app.health())}`}
+        >
           {state()}
         </span>
       </div>
 
       <Show
-        when={state() === "connected"}
+        when={app.health().live}
         fallback={
           <div class="py-3 text-center text-xs text-gray-400 dark:text-gray-500">
             {STATE[state()].label}
@@ -1089,7 +1096,7 @@ function Header(props: {
             <span class="font-semibold">{props.system.hostname || "—"}</span>
           </span>
           <span
-            class={`flex items-center gap-1.5 ${STATE[props.connection.state].text}`}
+            class={`flex items-center gap-1.5 ${statusTextClass(props.connection.state, props.health())}`}
           >
             <HostDot
               health={props.health}

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -15,7 +15,11 @@
  */
 
 import { unenrolledStreamCall } from "@kolu/surface/client";
-import { createSubscription, surfaceClientsHealth } from "@kolu/surface/solid";
+import {
+  createSubscription,
+  type SurfaceHealth,
+  surfaceClientsHealth,
+} from "@kolu/surface/solid";
 import { SurfaceGate } from "@kolu/surface/solid/SurfaceGate";
 import { STALE_PROCESS_CLOSE_CODE } from "@kolu/surface-app";
 import { shellCommit } from "@kolu/surface-app/lifecycle";
@@ -54,6 +58,7 @@ import {
   DEFAULT_CONNECTION,
 } from "drishti-common/browser";
 import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
+import { HostDot } from "./HostDot";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";
 import {
@@ -658,9 +663,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
       class="flex flex-col gap-2 rounded border border-gray-200 bg-gray-50 p-3 text-left transition-colors hover:border-indigo-400 hover:bg-white dark:border-gray-800 dark:bg-gray-900/40 dark:hover:border-indigo-500 dark:hover:bg-gray-900"
     >
       <div class="flex items-center gap-2">
-        <span
-          class={`inline-block h-2 w-2 shrink-0 rounded-full ${STATE[state()].dotBg} ${STATE[state()].pending ? "animate-pulse" : ""}`}
-        />
+        <HostDot health={app.health} state={state} class="shrink-0" />
         <span class="truncate font-semibold" title={props.host}>
           {props.host}
         </span>
@@ -955,6 +958,7 @@ function HostView(props: { host: string }) {
       <Header
         system={currentSystem()}
         connection={currentConnection()}
+        health={app.health}
         count={allPids().length}
       />
       {/* drishti is a real component-level `<SurfaceGate>` ADOPTER, with the
@@ -1062,6 +1066,7 @@ function pidComparator(
 function Header(props: {
   system: ReturnType<() => typeof DEFAULT_SYSTEM>;
   connection: ReturnType<() => typeof DEFAULT_CONNECTION>;
+  health: Accessor<SurfaceHealth>;
   count: number;
 }) {
   // The component body runs ONCE at mount — when props.system is still
@@ -1083,8 +1088,14 @@ function Header(props: {
             <span class="text-gray-500">host:</span>{" "}
             <span class="font-semibold">{props.system.hostname || "—"}</span>
           </span>
-          <span class={STATE[props.connection.state].text}>
-            ● {props.connection.state}
+          <span
+            class={`flex items-center gap-1.5 ${STATE[props.connection.state].text}`}
+          >
+            <HostDot
+              health={props.health}
+              state={() => props.connection.state}
+            />
+            {props.connection.state}
           </span>
           <span class="text-gray-500">·</span>
           <span class="text-gray-500">

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -36,11 +36,8 @@ import {
   useContext,
 } from "solid-js";
 import {
-  type ConnectionInfo,
-  type ConnectionState,
   type CoreId,
   type CpuCore,
-  DEFAULT_CONNECTION,
   DEFAULT_SYSTEM,
   type IfaceName,
   type MetricSample,
@@ -50,6 +47,11 @@ import {
   type ProcessesSnapshotMsg,
   type SystemInfo,
 } from "drishti-common";
+import {
+  type ConnectionInfo,
+  type ConnectionState,
+  DEFAULT_CONNECTION,
+} from "drishti-common/browser";
 import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -14,8 +14,9 @@
  * The per-host data shape (cells/collections/streams) is unchanged.
  */
 
-import { streamCall } from "@kolu/surface/client";
+import { unenrolledStreamCall } from "@kolu/surface/client";
 import { createSubscription, surfaceClientsHealth } from "@kolu/surface/solid";
+import { SurfaceGate } from "@kolu/surface/solid/SurfaceGate";
 import { STALE_PROCESS_CLOSE_CODE } from "@kolu/surface-app";
 import { shellCommit } from "@kolu/surface-app/lifecycle";
 import { SurfaceAppProvider, surfaceAppProbe } from "@kolu/surface-app/solid";
@@ -172,49 +173,36 @@ function createPersistedSignal<T extends string>(
 // / cores / nics) already surfaces its `onError`; without this the metric
 // stream would be the lone one swallowing failure to the console, leaving an
 // empty ring to read identically as "no samples yet" and "stream died".
-function subscribeMetricHistory(
-  app: ReturnType<typeof surfaceForHost>,
-  signal: AbortSignal,
-): {
+function subscribeMetricHistory(app: ReturnType<typeof surfaceForHost>): {
   history: Accessor<MetricSample[]>;
   streamError: Accessor<Error | null>;
 } {
   const [history, setHistory] = createSignal<MetricSample[]>([]);
-  const [streamError, setStreamError] = createSignal<Error | null>(null);
-  const [pending, setPending] = createSignal(true);
-  // Leak A: a RAW `streamCall` owns its loop, so the framework can't enrol it.
-  // JOIN it to `app.health()` by hand (`enroll` — it already owns its
-  // pending/error), so a dead metric feed surfaces in the one FACT (drishti's
-  // per-host degraded badge) and not ONLY this widget's sparkline. Auto-disposes
-  // with the calling component's owner; the reactive `error()` supersedes the old
-  // per-channel `console.error`.
-  app.enroll("metricHistory", {
-    pending,
-    error: () => streamError() ?? undefined,
-  });
-  void (async () => {
-    try {
-      const stream = await streamCall(
-        app.rpc.surface.metricHistory.get,
-        {},
-        { signal },
-      );
-      for await (const msg of stream) {
-        if (pending()) setPending(false);
+  // 🔴2 (Leak A) — the STRUCTURAL raw-stream path. `app.rawStream` owns the
+  // consume loop, the `AbortController` (tied to THIS component's owner), the
+  // pending/error signals, AND the health enrolment — and THROWS if driven
+  // outside a reactive owner. So this raw metric feed cannot silently escape
+  // `app.health()` the way the old hand-rolled `unenrolledStreamCall` +
+  // `app.enroll` could: forgetting the enrol is now structurally impossible, not
+  // a convention an adopter can drop. Its returned `error()` carries a dead feed
+  // into THIS widget's own sparkline overlay; the same error is already in the
+  // FACT (drishti's per-host degraded badge), so a dead feed can no longer read
+  // identically to "no samples yet" while swallowing failure to the console.
+  const source = app.rawStream(
+    "metricHistory",
+    app.rpc.surface.metricHistory.get,
+    {},
+    {
+      onItem: (msg) => {
         if (msg.kind === "snapshot") setHistory(msg.samples);
         else
           setHistory((prev) =>
             pushSample(prev, msg.sample, HISTORY_RETENTION_MS),
           );
-      }
-    } catch (err) {
-      if (!signal.aborted) {
-        setPending(false);
-        setStreamError(err instanceof Error ? err : new Error(String(err)));
-      }
-    }
-  })();
-  return { history, streamError };
+      },
+    },
+  );
+  return { history, streamError: () => source.error() ?? null };
 }
 
 // Overlay text for a sparkline with no drawable point yet — the one place that
@@ -379,12 +367,15 @@ function MultiHostApp() {
   // `surfaceClients` doesn't fold; drishti's always-open control plane is the
   // natural place to ask "is the fleet's spine healthy?" as one answer. Rendered
   // stale-while-degraded (drishti's policy) — a non-blocking strip, never blanking.
-  const controlPlaneError = createMemo(
-    () =>
-      surfaceClientsHealth({ admin, surfaceApp: surfaceAppClient() }).subs.find(
-        (s) => s.error,
-      )?.error?.message ?? null,
-  );
+  // It DRINKS from the merged `live`: now that `wire.ts` threads the admin
+  // socket's liveness through `surfaceClients`, a dead control-plane socket flips
+  // the folded `live` false (the AND-reduce over both siblings) and the strip
+  // says so — transport death wins over a per-sub error.
+  const controlPlaneError = createMemo(() => {
+    const h = surfaceClientsHealth({ admin, surfaceApp: surfaceAppClient() });
+    if (!h.live) return "connection lost — reconnecting…";
+    return h.subs.find((s) => s.error)?.error?.message ?? null;
+  });
 
   // Drive per-host socket disposal from the parent that owns the admin
   // subscription, NOT from inside `TabChip`. The chip is pure display;
@@ -630,10 +621,9 @@ function HostCard(props: { host: string; onSelect: () => void }) {
   // Same parent-owned ring the open host view draws, streamed over the card's
   // already-warm socket. The card pins the widest window (WIDEST_HISTORY_WINDOW)
   // — it's a glanceable trend, not an interactive chart, so there's no per-card
-  // duration picker — and tears the stream down with the card via `ctl`.
-  const ctl = new AbortController();
-  onCleanup(() => ctl.abort());
-  const { history, streamError } = subscribeMetricHistory(app, ctl.signal);
+  // duration picker. `app.rawStream` ties the stream's teardown to this card's
+  // own reactive owner, so there's no hand-rolled AbortController to thread.
+  const { history, streamError } = subscribeMetricHistory(app);
   const { latest, points } = projectHistory(history, () =>
     windowMsFor(WIDEST_HISTORY_WINDOW),
   );
@@ -773,8 +763,8 @@ function HostView(props: { host: string }) {
   // The live process table, consumed as a declarative value-bearing reactive
   // subscription: `createSubscription` folds every snapshot|delta frame in-loop
   // (via `foldProcessesMessage`) into the full process map, replacing the
-  // hand-rolled `streamCall` + `for await` loop this used to be. The table
-  // renders FINE-GRAINED off `processes()` below (`processes()[pid].cpuPct`),
+  // hand-rolled `unenrolledStreamCall` + `for await` loop this used to be. The
+  // table renders FINE-GRAINED off `processes()` below (`processes()[pid].cpuPct`),
   // so an in-place `reconcile` leaf update re-notifies just that cell — reading
   // the whole map coarsely and copying it into a store would drop same-shape
   // deltas (the R8b lesson). `.streams.use()` exposes no `reduce`, so this
@@ -787,7 +777,15 @@ function HostView(props: { host: string }) {
     Record<Pid, Process>
   >(
     () =>
-      streamCall(
+      // The bare `unenrolledStreamCall` is the right primitive HERE — it is the
+      // raw stream FACTORY feeding `createSubscription`, which owns its own
+      // pending/error and is joined to the fact by `app.enroll` below. Its
+      // `unenrolled-` name flags that the raw call self-enrols nothing; the
+      // `createSubscription` + `enroll` pair is what carries it into `health()`.
+      // (A standalone surface-scoped raw stream would use `app.rawStream`, like
+      // `metricHistory` above; this one can't — `rawStream` returns only
+      // {pending,error}, not the value-bearing reconcile store the table needs.)
+      unenrolledStreamCall(
         app.rpc.surface.processesSnapshot.get,
         {},
         { signal: processesCtl.signal },
@@ -798,12 +796,13 @@ function HostView(props: { host: string }) {
       signal: processesCtl.signal,
     },
   );
-  // Leak A: this raw stream is a hand-driven `createSubscription` over a surface
-  // PROCEDURE (`processesSnapshot.get` is not a Stream primitive), so the
-  // framework can't enrol it — JOIN it to `app.health()` directly (a
-  // `createSubscription` already owns its pending/error). A dead process feed now
-  // surfaces in the one FACT (the per-host degraded badge) instead of a private
-  // `console.error` — the reactive `error()` supersedes the one-shot callback.
+  // Leak A: this is a hand-driven `createSubscription` over a surface PROCEDURE
+  // (`processesSnapshot.get` is not a Stream primitive), so the framework can't
+  // auto-enrol it — JOIN it to `app.health()` directly (a `createSubscription`
+  // already owns its pending/error). A dead process feed now surfaces in the one
+  // FACT (the per-host degraded badge) instead of a private `console.error` — the
+  // reactive `error()` supersedes the one-shot callback. The deliberate hand-join
+  // reads as deliberate because the factory call is named `unenrolledStreamCall`.
   app.enroll("processesSnapshot", processesSub);
   const processes = (): Record<Pid, Process> => processesSub() ?? {};
 
@@ -855,15 +854,14 @@ function HostView(props: { host: string }) {
     () => connection.value() ?? DEFAULT_CONNECTION,
   );
 
-  // R3: drishti READS the SAME `client.health()` fact pulam-web hard-gates on,
-  // but with the OPPOSITE policy — STALE-WHILE-DEGRADED. A subscription error (a
-  // per-key cell/core/nic sub, or the now-enrolled `metricHistory` /
-  // `processesSnapshot` raw streams) shows a NON-blocking strip and the body
-  // STAYS; pulam-web's `<SurfaceGate ready>` would blank the whole host. That
-  // divergence over ONE shared fact is exactly why the framework exposes the FACT
-  // and leaves the verdict to each consumer — the two-policy premise, exercised.
-  const degraded = createMemo(
-    () => app.health().subs.find((s) => s.error)?.error?.message ?? null,
+  // The connecting/failed overlay for the MIRROR axis (backend↔remote), reused
+  // as both the cold-connect fallback of the health `<SurfaceGate>` below and the
+  // inner connection-cell gate. Defined once so the two never drift.
+  const connectingView = () => (
+    <ConnectingOverlay
+      connection={currentConnection()}
+      onReconnect={onReconnect}
+    />
   );
 
   const allPids = createMemo<Pid[]>(() =>
@@ -935,13 +933,10 @@ function HostView(props: { host: string }) {
     );
   const windowMs = createMemo(() => windowMsFor(historyWindow()));
 
-  // metricHistory is still consumed imperatively (Step 0 graduates only the
-  // process list); its own AbortController tears the stream down on unmount.
-  // The fleet card runs the same step off its own controller (see
-  // `subscribeMetricHistory` / `projectHistory`).
-  const metricsCtl = new AbortController();
-  onCleanup(() => metricsCtl.abort());
-  const { history, streamError } = subscribeMetricHistory(app, metricsCtl.signal);
+  // metricHistory rides the structural `app.rawStream` path (it enrols into
+  // `app.health()` and owns its own teardown via this view's reactive owner —
+  // see `subscribeMetricHistory` / `projectHistory`).
+  const { history, streamError } = subscribeMetricHistory(app);
   const { latest: latestSample, points } = projectHistory(history, windowMs);
 
   // The currently-selected process resolved against the live store: null when
@@ -962,22 +957,35 @@ function HostView(props: { host: string }) {
         connection={currentConnection()}
         count={allPids().length}
       />
-      {/* Stale-while-degraded: a NON-blocking strip when any subscription errors;
-          the body below stays visible (drishti's policy — the opposite of
-          pulam-web's hard gate over the same `app.health()` fact). */}
-      <Show when={degraded()}>
-        <div class="border-b border-amber-500/40 bg-amber-500/10 px-4 py-1 text-xs text-amber-700 dark:text-amber-400">
-          Some data is stale — a subscription is reconnecting ({degraded()}).
-        </div>
-      </Show>
+      {/* drishti is a real component-level `<SurfaceGate>` ADOPTER, with the
+          framework DEFAULT policy = STALE-WHILE-DEGRADED (and, after the first
+          paint, stale-while-reconnecting): a sub error or a transport blip keeps
+          the body below VISIBLE under a NON-blocking amber notice; only a cold
+          connect blanks to `connectingView`. That is the OPPOSITE of pulam-web's
+          hard `<SurfaceGate ready>` over the SAME `app.health()` fact — the
+          two-policy premise exercised at the component level, not just the fact.
+          The connection CELL gate (the backend↔remote MIRROR axis, which the
+          health fact doesn't carry) stays nested INSIDE — `connectingView`
+          renders it for both the cold-health fallback and a not-yet-`connected`
+          mirror. The amber notice's `degraded` slot folds the first sub error (or
+          names a reconnect when the transport, not a sub, is the cause). */}
+      <SurfaceGate
+        health={app.health}
+        fallback={() => connectingView()}
+        degraded={(h) => {
+          const msg = h().subs.find((s) => s.error)?.error?.message;
+          return (
+            <div class="border-b border-amber-500/40 bg-amber-500/10 px-4 py-1 text-xs text-amber-700 dark:text-amber-400">
+              {msg
+                ? `Some data is stale — a subscription is reconnecting (${msg}).`
+                : "Reconnecting to this host…"}
+            </div>
+          );
+        }}
+      >
       <Show
         when={currentConnection().state === "connected"}
-        fallback={
-          <ConnectingOverlay
-            connection={currentConnection()}
-            onReconnect={onReconnect}
-          />
-        }
+        fallback={connectingView()}
       >
         <HistoryChart
           points={points()}
@@ -1026,6 +1034,7 @@ function HostView(props: { host: string }) {
           />
         </SelectionContext.Provider>
       </Show>
+      </SurfaceGate>
     </>
   );
 }

--- a/packages/app/src/client/HostDot.tsx
+++ b/packages/app/src/client/HostDot.tsx
@@ -1,0 +1,50 @@
+/**
+ * `<HostDot>` — drishti's per-host connection dot, single-sourced.
+ *
+ * Every host indicator (the fleet card, the tab chip, the open-host header) is
+ * this ONE component, which is itself a thin skin over the framework's
+ * `<HostStatusPip>`: the dot's GREEN is emitted ONLY from the pip's fact-`ready`
+ * branch (`gateStatus(health()) === "ready"` over the complete `health()` fact —
+ * transport ∧ mirror ∧ sub-errors), so a stale `connection.state === "connected"`
+ * cell can no longer paint a green dot over a dead link. That was the #1564 lie
+ * one viewer over: drishti's old dots read the raw cell `.state` and colored
+ * themselves directly, folding none of the fact.
+ *
+ * The RICH presentation stays app-local around the dot — the `state` label, the
+ * connecting overlay, the failed card — and feeds only the NOT-ready tone here
+ * (`failed → red`, else amber). It can't reach the green: that branch reads the
+ * fact alone. `state` is still read for the tone/pulse/title, never for green.
+ */
+
+import { HostStatusPip } from "@kolu/surface/solid/HostStatusPip";
+import type { SurfaceHealth } from "@kolu/surface/solid";
+import type { Accessor } from "solid-js";
+import type { ConnectionState } from "drishti-common/browser";
+import { DOT_HEX, STATE } from "./connectionColors";
+
+export function HostDot(props: {
+  /** The host client's complete health fact — the sole source of the green. */
+  health: Accessor<SurfaceHealth>;
+  /** The mirror cell's state — for the not-ready TONE, pulse, and tooltip only
+   *  (never the green, which is fact-gated). */
+  state: Accessor<ConnectionState>;
+  class?: string;
+}) {
+  return (
+    <HostStatusPip
+      health={props.health}
+      readyColor={DOT_HEX.connected}
+      // Not ready: red for a terminally-`failed` mirror, amber for every other
+      // not-ready state (connecting/copying/reconnecting, or a connected mirror
+      // with a stale/erroring sub). Structurally can't be the ready green.
+      notReadyTone={() =>
+        props.state() === "failed" ? DOT_HEX.failed : DOT_HEX.connecting
+      }
+      // Pulse while working; a terminally-failed mirror sits steady (nothing is
+      // happening until the user acts). A ready dot never pulses regardless.
+      pulse={props.state() !== "failed"}
+      title={STATE[props.state()].label}
+      class={props.class}
+    />
+  );
+}

--- a/packages/app/src/client/StatusFooter.tsx
+++ b/packages/app/src/client/StatusFooter.tsx
@@ -17,17 +17,19 @@
  */
 
 import { isCleanRef } from "@kolu/surface-app";
-import { type ConnectionStatus, useSurfaceApp } from "@kolu/surface-app/solid";
-import { Show } from "solid-js";
+import { useSurfaceApp } from "@kolu/surface-app/solid";
+import type { SurfaceHealth } from "@kolu/surface/solid";
+import { HostStatusPip } from "@kolu/surface/solid/HostStatusPip";
+import { type Accessor, Show } from "solid-js";
+import { DOT_HEX } from "./connectionColors";
 
-const SRV_DOT: Record<ConnectionStatus, string> = {
-  live: "bg-emerald-500",
-  reconnecting: "bg-amber-500 animate-pulse",
-  restarted: "bg-amber-500 animate-pulse",
-  down: "bg-red-500",
-};
-
-export function StatusFooter() {
+export function StatusFooter(props: {
+  /** The admin control-plane health fact (`surfaceClientsHealth({ admin,
+   *  surfaceApp })`) — the source of the srv dot's GREEN, so it can't be painted
+   *  from a raw status string. The admin surface has NO mirror leg, so its `live`
+   *  is transport-live alone (green == transport-live is honest here). */
+  health: Accessor<SurfaceHealth>;
+}) {
   const pwa = useSurfaceApp();
   return (
     <footer class="fixed inset-x-0 bottom-0 z-20 flex items-center justify-between border-t border-gray-200 bg-gray-50/95 px-3 pb-[max(0.25rem,env(safe-area-inset-bottom))] pt-1 font-mono text-xs backdrop-blur dark:border-gray-800 dark:bg-gray-950/95">
@@ -35,10 +37,24 @@ export function StatusFooter() {
         <span class="text-[9px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
           srv
         </span>
-        <span
+        {/* The srv dot is the framework `<HostStatusPip>` — the SAME component every
+            other connection dot uses, so "every connection dot is the pip" is
+            literally true and the green is single-sourced. GREEN ⇔ the lifecycle is
+            `live` (transport up AND not restarted/down) over the admin fact, whose
+            `live` is transport-only (no mirror leg). The amber/red/pulse stay raw
+            presentation off the lifecycle `pwa.status()` — the pip can't paint green
+            there (its ready branch is fact-gated, and a not-ready tone equal to the
+            ready color is refused), so `restarted`/`reconnecting` read amber and
+            `down` reads red, exactly as the old hand-rolled dot did. */}
+        <HostStatusPip
+          health={props.health}
+          ready={(h) => h.live && pwa.status() === "live"}
+          readyColor={DOT_HEX.connected}
+          notReadyTone={() =>
+            pwa.status() === "down" ? DOT_HEX.failed : DOT_HEX.connecting
+          }
+          pulse={pwa.status() === "reconnecting" || pwa.status() === "restarted"}
           title="Server connection"
-          data-ws-status={pwa.status()}
-          class={`inline-block h-[7px] w-[7px] rounded-full ${SRV_DOT[pwa.status()]}`}
         />
         <Commit sha={pwa.server()?.commit} />
       </span>

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -16,7 +16,7 @@
 import { useSurfaceApp } from "@kolu/surface-app/solid";
 import { createPwaInstall, installInstructions } from "@kolu/solid-pwa-install";
 import { createMemo, createSignal, For, Show } from "solid-js";
-import { type ConnectionState, DEFAULT_CONNECTION } from "drishti-common";
+import { type ConnectionState, DEFAULT_CONNECTION } from "drishti-common/browser";
 import type { View } from "./view";
 import { STATE } from "./connectionColors";
 import { otherTheme, type Theme } from "./theme";

--- a/packages/app/src/client/TabStrip.tsx
+++ b/packages/app/src/client/TabStrip.tsx
@@ -18,7 +18,7 @@ import { createPwaInstall, installInstructions } from "@kolu/solid-pwa-install";
 import { createMemo, createSignal, For, Show } from "solid-js";
 import { type ConnectionState, DEFAULT_CONNECTION } from "drishti-common/browser";
 import type { View } from "./view";
-import { STATE } from "./connectionColors";
+import { HostDot } from "./HostDot";
 import { otherTheme, type Theme } from "./theme";
 import { surfaceForHost } from "./wire";
 
@@ -184,9 +184,7 @@ function TabChip(props: {
         onClick={props.onSelect}
         title={`${props.host} — ${state()}`}
       >
-        <span
-          class={`inline-block h-2 w-2 rounded-full ${STATE[state()].dotBg} ${STATE[state()].pending ? "animate-pulse" : ""}`}
-        />
+        <HostDot health={app.health} state={state} />
         <span class="font-semibold">{props.host}</span>
       </button>
       <button

--- a/packages/app/src/client/connectionColors.test.ts
+++ b/packages/app/src/client/connectionColors.test.ts
@@ -42,18 +42,18 @@ describe("connection STATE presentation", () => {
     // so it pulses amber and reads "Reconnecting…" — not the old red,
     // non-pulsing "Disconnected. Retrying…" that also covered give-up.
     expect(STATE.disconnected.pending).toBe(true);
-    expect(STATE.disconnected.dotBg).toBe("bg-amber-500");
+    expect(STATE.disconnected.text).toBe("text-amber-500");
     expect(STATE.disconnected.message).toBe("Reconnecting…");
   });
 
   it("treats failed as terminal — red, not pulsing", () => {
     expect(STATE.failed.pending).toBe(false);
-    expect(STATE.failed.dotBg).toBe("bg-red-500");
+    expect(STATE.failed.text).toBe("text-red-500");
   });
 
   it("only connected is non-pending and emerald", () => {
     expect(STATE.connected.pending).toBe(false);
-    expect(STATE.connected.dotBg).toBe("bg-emerald-500");
+    expect(STATE.connected.text).toBe("text-emerald-500");
     // copying/connecting are in-flight → pending.
     expect(STATE.copying.pending).toBe(true);
     expect(STATE.connecting.pending).toBe(true);

--- a/packages/app/src/client/connectionColors.test.ts
+++ b/packages/app/src/client/connectionColors.test.ts
@@ -1,5 +1,31 @@
+import type { SurfaceHealth } from "@kolu/surface/solid";
 import { describe, expect, it } from "bun:test";
-import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
+import {
+  disconnectedMessage,
+  STATE,
+  statusTextClass,
+  withElapsed,
+} from "./connectionColors";
+
+// `health()` facts spanning the readiness verdicts `gateStatus` distinguishes —
+// the word's green must track the dot's, which greens ONLY on `ready`.
+const READY: SurfaceHealth = {
+  live: true,
+  subs: [{ name: "c", pending: false, error: undefined }],
+};
+const DEAD: SurfaceHealth = { live: false, subs: [] };
+const PENDING: SurfaceHealth = {
+  live: true,
+  subs: [{ name: "c", pending: true, error: undefined }],
+};
+// Live (transport ∧ mirror up) but a subscription is silently erroring — the
+// fact `gateStatus` calls `degraded` and the dot paints amber. `live` is still
+// `true` here, so the OLD bare-`live` word stayed GREEN: the #1564 lie relocated
+// from the dot to the status word.
+const DEGRADED: SurfaceHealth = {
+  live: true,
+  subs: [{ name: "c", pending: false, error: new Error("boom") }],
+};
 
 describe("connection STATE presentation", () => {
   it("covers every connection state", () => {
@@ -31,6 +57,42 @@ describe("connection STATE presentation", () => {
     // copying/connecting are in-flight → pending.
     expect(STATE.copying.pending).toBe(true);
     expect(STATE.connecting.pending).toBe(true);
+  });
+});
+
+describe("statusTextClass — the WORD's green tracks the dot's verdict (gateStatus), not a narrower signal", () => {
+  it("greens a connected word ONLY when the FACT is fully READY", () => {
+    // The dot greens on gateStatus === "ready" (live ∧ no error ∧ no pending);
+    // the word must use the SAME verdict so the two never diverge.
+    expect(statusTextClass("connected", READY)).toBe("text-emerald-500");
+  });
+
+  it("a 'connected' cell over a DEGRADED fact (a sub silently erroring while live) reads amber, never green", () => {
+    // The relocated #1564 lie: live === true here, so the OLD bare-`live` word
+    // painted green while the dot (gateStatus → degraded) turned amber. The word
+    // now reads the WHOLE fact, so it drops to amber WITH the dot.
+    expect(statusTextClass("connected", DEGRADED)).toBe(STATE.connecting.text);
+    expect(statusTextClass("connected", DEGRADED)).not.toBe("text-emerald-500");
+  });
+
+  it("a 'connected' cell still awaiting its first frame (pending) reads amber, not a premature green", () => {
+    // gateStatus(PENDING) === "connecting" — the dot is amber on every fresh
+    // connect, so the word must be too.
+    expect(statusTextClass("connected", PENDING)).toBe(STATE.connecting.text);
+    expect(statusTextClass("connected", PENDING)).not.toBe("text-emerald-500");
+  });
+
+  it("a stale 'connected' over a dead transport reads amber, never green", () => {
+    // live === false though the cell still says connected (a half-open/dropped
+    // browser↔backend socket). gateStatus → connecting → amber.
+    expect(statusTextClass("connected", DEAD)).toBe(STATE.connecting.text);
+    expect(statusTextClass("connected", DEAD)).not.toBe("text-emerald-500");
+  });
+
+  it("a non-connected state keeps its own (non-green) tone for its realistic not-ready fact", () => {
+    expect(statusTextClass("failed", DEAD)).toBe("text-red-500");
+    expect(statusTextClass("connecting", DEAD)).toBe("text-amber-500");
+    expect(statusTextClass("copying", DEAD)).toBe("text-amber-500");
   });
 });
 

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -8,7 +8,7 @@
  * single row, not five edits.
  */
 
-import type { ConnectionState, FailureCause } from "drishti-common";
+import type { ConnectionState, FailureCause } from "drishti-common/browser";
 
 type StatePresentation = {
   /** Status-dot background colour. */

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -8,6 +8,7 @@
  * single row, not five edits.
  */
 
+import { gateStatus, type SurfaceHealth } from "@kolu/surface/solid";
 import type { ConnectionState, FailureCause } from "drishti-common/browser";
 
 type StatePresentation = {
@@ -104,3 +105,25 @@ export const DOT_HEX = {
   connecting: "#f59e0b", // amber-500 — every non-`failed` not-ready state
   failed: "#ef4444", // red-500
 } as const;
+
+/** The status-WORD color class — green ONLY when the host's FACT is fully READY,
+ *  the SAME verdict the adjacent fact-gated `<HostDot>` emits its green from
+ *  (`gateStatus(health) === "ready"`: live ∧ no erroring sub ∧ no pending sub).
+ *
+ *  The word reads the raw mirror cell `state`; the dot reads the whole `health()`
+ *  fact. Gating the word's green on the bare `live` boolean was too LOOSE — `live`
+ *  is `transport ∧ mirror` and stays `true` while a subscription silently errors
+ *  (gateStatus → `degraded`) or is still loading (→ `connecting`). So a green
+ *  `connected` word would sit beside an amber dot whenever a sub was dead — the
+ *  #1564 lie merely relocated from the dot to the status WORD. Folding the WHOLE
+ *  fact through `gateStatus` (never a narrower slice the caller hand-picks) keeps
+ *  word and dot the same decision: a `connected` cell that is not ready (transport
+ *  down, OR a sub erroring/pending) reads amber, never green; every non-`connected`
+ *  state already carries its own non-green tone (`failed` → red). */
+export function statusTextClass(
+  state: ConnectionState,
+  health: SurfaceHealth,
+): string {
+  if (gateStatus(health) === "ready") return STATE.connected.text; // green — fully ready
+  return state === "connected" ? STATE.connecting.text : STATE[state].text;
+}

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -89,3 +89,18 @@ export const STATE: Record<ConnectionState, StatePresentation> = {
     pending: false,
   },
 };
+
+// The framework `<HostStatusPip>` colors its dot via an inline `style.background`
+// hex, not a tailwind class, so `<HostDot>` supplies the palette as hex. Only
+// THREE are needed, and the split is deliberate: `connected` (green) is passed
+// solely as the pip's `readyColor` — emitted only from its fact-`ready` branch,
+// so a stale `connected` cell can't paint it — while the not-ready tone is keyed
+// to the cell as `failed → red`, else `amber`. The not-ready branch NEVER reads
+// `DOT_HEX.connected`, because a `connected` mirror can still be not-ready (a
+// pending/erroring sub) and emitting its green there would forge the very lie the
+// pip exists to prevent.
+export const DOT_HEX = {
+  connected: "#10b981", // emerald-500 — the pip's readyColor (fact-gated)
+  connecting: "#f59e0b", // amber-500 — every non-`failed` not-ready state
+  failed: "#ef4444", // red-500
+} as const;

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -1,19 +1,22 @@
 /**
  * Per-connection-state presentation, single-sourced. Each state maps to
- * one `StatePresentation` row rather than living as five parallel
+ * one `StatePresentation` row rather than living as parallel
  * `Record<ConnectionState, …>` maps — `Record` totality already forces
  * every state to be present, but one map also forces every *aspect*
- * (dot colour, text colour, terse label, verbose message, pending flag)
- * to be filled in together, so they can't drift and adding a state is a
- * single row, not five edits.
+ * (text colour, terse label, verbose message, pending flag) to be filled
+ * in together, so they can't drift and adding a state is a single row,
+ * not four edits.
+ *
+ * The status DOT is NOT one of those aspects: it's the framework
+ * `<HostStatusPip>`, whose green is fact-gated (its hex palette is the
+ * three-entry `DOT_HEX` below), so this row carries no `dotBg` — there is
+ * no raw-state dot colour left for a widget to paint green from.
  */
 
 import { gateStatus, type SurfaceHealth } from "@kolu/surface/solid";
 import type { ConnectionState, FailureCause } from "drishti-common/browser";
 
 type StatePresentation = {
-  /** Status-dot background colour. */
-  dotBg: string;
   /** Inline "● connected" text colour. */
   text: string;
   /** Terse label — the fleet card's tight fallback. */
@@ -49,21 +52,18 @@ export function disconnectedMessage(failureCause: FailureCause | null): string {
 
 export const STATE: Record<ConnectionState, StatePresentation> = {
   connected: {
-    dotBg: "bg-emerald-500",
     text: "text-emerald-500",
     label: "connected",
     message: "Connected.",
     pending: false,
   },
   connecting: {
-    dotBg: "bg-amber-500",
     text: "text-amber-500",
     label: "connecting…",
     message: "Connecting…",
     pending: true,
   },
   copying: {
-    dotBg: "bg-amber-500",
     text: "text-amber-500",
     label: "provisioning agent…",
     message: "Copying agent to remote…",
@@ -73,7 +73,6 @@ export const STATE: Record<ConnectionState, StatePresentation> = {
   // another connect attempt. Amber + pulsing says "working on it" —
   // honest, unlike the old red "Retrying…" that also covered give-up.
   disconnected: {
-    dotBg: "bg-amber-500",
     text: "text-amber-500",
     label: "reconnecting…",
     message: "Reconnecting…",
@@ -83,7 +82,6 @@ export const STATE: Record<ConnectionState, StatePresentation> = {
   // nothing is happening until the user acts. The overlay pairs this
   // headline with `lastError` and a Reconnect button.
   failed: {
-    dotBg: "bg-red-500",
     text: "text-red-500",
     label: "failed",
     message: "Connection failed",

--- a/packages/app/src/client/processesStream.test.ts
+++ b/packages/app/src/client/processesStream.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { defineSurface } from "@kolu/surface/define";
 import { directLink } from "@kolu/surface/links/direct";
 import { implementSurface, inMemoryChannelByName } from "@kolu/surface/server";
-import { streamCall } from "@kolu/surface/client";
+import { unenrolledStreamCall } from "@kolu/surface/client";
 import { createSubscription } from "@kolu/surface/solid";
 import {
   type Pid,
@@ -146,7 +146,7 @@ describe("processesSnapshot consumer — createSubscription + reduce, read fine-
 
     await createRoot(async (dispose) => {
       const sub = createSubscription<ProcessesSnapshotMsg, Record<Pid, Process>>(
-        () => streamCall(link.surface.processesSnapshot.get, {}),
+        () => unenrolledStreamCall(link.surface.processesSnapshot.get, {}),
         { reduce: foldProcessesMessage, initial: {} },
       );
       const processes = (): Record<Pid, Process> => sub() ?? {};
@@ -183,7 +183,7 @@ describe("processesSnapshot consumer — createSubscription + reduce, read fine-
 
     await createRoot(async (dispose) => {
       const sub = createSubscription<ProcessesSnapshotMsg, Record<Pid, Process>>(
-        () => streamCall(link.surface.processesSnapshot.get, {}),
+        () => unenrolledStreamCall(link.surface.processesSnapshot.get, {}),
         { reduce: foldProcessesMessage, initial: {} },
       );
       const processes = (): Record<Pid, Process> => sub() ?? {};

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -80,17 +80,20 @@ function buildAdminSurface() {
   // complete surface (`buildInfo` + the `identity.info` probe). `connectSurfaces`
   // splits the one link into a per-key client bundle and folds them into ONE
   // `health()` fact (`live` AND-reduced across siblings off the one socket).
-  // `heartbeat: false`: the admin socket is owned by `<SurfaceAppProvider>`'s
-  // `createServerLifecycle`, which runs its OWN heartbeat (kolu#1231) — a second
-  // here would double the probe — and retires the socket on a stale-restart
-  // itself, so it opts out of self-retire (`retireOnStaleClose: false`) too.
+  // `connectSurfaces` ALWAYS wires the half-open watchdog (it mints the
+  // watchdog-backed `LiveSignal` the clients require — there is no `heartbeat:
+  // false` that could mint a blind brand). So the admin socket's ONE watchdog
+  // lives here; the `<SurfaceAppProvider>` lifecycle over the SAME socket
+  // (`App.tsx`) opts ITS own watchdog out (`heartbeat={false}` — it mints no
+  // brand) so the socket isn't double-watched. The lifecycle still retires the
+  // socket on a stale-restart, so this opts out of self-retire
+  // (`retireOnStaleClose: false`).
   return connectSurfaces({
     surfaces: adminSurfaces,
     url: () => wsBaseFor(ADMIN_HOST_SENTINEL),
     echo,
     socketOptions: BASE_SOCKET_OPTIONS,
     retireOnStaleClose: false,
-    heartbeat: false,
   });
 }
 

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -17,6 +17,7 @@ import {
   createProcessIdEcho,
   createSurfaceSocket,
 } from "@kolu/surface-app/connect";
+import { createSocketStatus } from "@kolu/surface-app/solid";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
 import { ADMIN_HOST_SENTINEL } from "../common/host";
 import { browserSurface } from "drishti-common/browser";
@@ -66,9 +67,16 @@ type AdminClient = ReturnType<typeof buildAdminSurface>;
 function buildHostSurface(host: string) {
   // Per-host sockets own their stale-close retirement — no provider watches them.
   const ws = makeSocket(host, true);
+  // Thread the socket's reactive liveness into `client.health().live` so the
+  // FACT carries transport death, not a constant `true`. `createSocketStatus`
+  // tracks the socket's own open/close (retiring on a stale-restart close, like
+  // `makeSocket(host, true)` does); `() => status() === "live"` is the boolean
+  // leg `health()` folds in.
+  const status = createSocketStatus(ws, { retireOnStaleClose: true });
   const client = surfaceClient(
     browserSurface,
     websocketLink<typeof browserSurface.contract>(ws as unknown as WebSocket),
+    { live: () => status() === "live" },
   );
   return { ws, client };
 }
@@ -84,7 +92,14 @@ function buildAdminSurface() {
   // the SCOPED slice (`{ surface: link.surface[key] }`), so its primitives
   // resolve at `/surface/<key>/<prim>/<verb>`.
   const link = websocketLink<typeof adminContract>(ws as unknown as WebSocket);
-  const clients = surfaceClients(link, adminSurfaces);
+  // ONE socket carries BOTH siblings, so they share ONE liveness — thread it so
+  // `surfaceClientsHealth({ admin, surfaceApp })` reports `live: false` when the
+  // control-plane socket dies (the AND-reduce over siblings that all read this
+  // same `live`), instead of a structurally-constant `true`.
+  const status = createSocketStatus(ws, { retireOnStaleClose: false });
+  const clients = surfaceClients(link, adminSurfaces, {
+    live: () => status() === "live",
+  });
   return { ws, link, clients };
 }
 

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -19,7 +19,7 @@ import {
 } from "@kolu/surface-app/connect";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
 import { ADMIN_HOST_SENTINEL } from "../common/host";
-import { browserSurface } from "drishti-common";
+import { browserSurface } from "drishti-common/browser";
 
 // ONE shared `pid` echo across every socket (per-host + admin). The parent mints
 // a fresh `processId` per boot; the echo threads the last-known one back as the

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -1,23 +1,27 @@
 /**
  * Client-side surface bundle — one WebSocket per host.
  *
- * Each host gets its own `surfaceClient` over its own `PartySocket`;
- * the admin surface (host set) gets one more at the reserved sentinel.
- * The cache keeps the PartySocket stable across Solid component
- * remounts so a tab switch doesn't tear down the connection — only the
- * subscriptions inside it.
+ * Each host gets its own surface client over its own `PartySocket` via
+ * `connectSurface` (the turnkey seam); the admin surface (host set + the
+ * surface-app sibling) gets one more via `connectSurfaces` at the reserved
+ * sentinel. Both seams wire the half-open liveness heartbeat — probing the
+ * framework-reserved `system.live` round-trip — BY CONSTRUCTION. The hand-built
+ * `surfaceClient + websocketLink` path these used to take could (and silently
+ * did) skip that heartbeat, so it is gone: there is no constructor left that can
+ * forget the watchdog. The admin socket opts the heartbeat OUT (`heartbeat:
+ * false`) only because `<SurfaceAppProvider>`'s `createServerLifecycle` already
+ * runs one for it — a second would double the probe.
  *
- * `disposeHostSurface(host)` closes a host's socket when it's removed
- * from the admin collection so the cache doesn't leak.
+ * The cache keeps the connection stable across Solid component remounts so a tab
+ * switch doesn't tear down the socket — only the subscriptions inside it.
+ * `disposeHostSurface(host)` disposes a host's connection (stopping its heartbeat
+ * and standing subs, then closing the socket) when it leaves the admin collection
+ * so the cache doesn't leak.
  */
 
-import { websocketLink } from "@kolu/surface/links/websocket";
-import { surfaceClient, surfaceClients } from "@kolu/surface/solid";
-import {
-  createProcessIdEcho,
-  createSurfaceSocket,
-} from "@kolu/surface-app/connect";
-import { createSocketStatus } from "@kolu/surface-app/solid";
+import type { ContractRouterClient } from "@orpc/contract";
+import { createProcessIdEcho } from "@kolu/surface-app/connect";
+import { connectSurface, connectSurfaces } from "@kolu/surface-app/solid";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
 import { ADMIN_HOST_SENTINEL } from "../common/host";
 import { browserSurface } from "drishti-common/browser";
@@ -28,12 +32,12 @@ import { browserSurface } from "drishti-common/browser";
 // after a restart and rejects it at the handshake. `App.tsx` feeds this via the
 // provider's `onProcessId` callback (the turnkey `{ ws, probe }` source publishes
 // each observed id); it's null until the first probe, so the first connect omits
-// the param. `createSurfaceSocket` reads it on every reconnect.
+// the param. The connect* seams read it on every reconnect.
 const echo = createProcessIdEcho();
 export const rememberServerProcessId = echo.remember;
 
 // The base WS URL — WITHOUT the `pid` (the echo appends it). A per-host string is
-// built fresh on each reconnect by `createSurfaceSocket`'s URL thunk.
+// built fresh on each reconnect by the seam's URL thunk.
 function wsBaseFor(host: string): string {
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
   return `${proto}//${location.host}/rpc/ws?host=${encodeURIComponent(host)}`;
@@ -42,99 +46,94 @@ function wsBaseFor(host: string): string {
 // Cold start can take 30+ seconds while the parent provisions the agent via
 // `nix copy`, so the connect deadline is bumped well past partysocket's 4s
 // default — without this, the socket flaps repeatedly during the first connect.
-//
-// `retire` controls who tears the socket down on a stale-close: the per-host
-// sockets have no provider lifecycle, so they self-retire on a stale-close
-// (`retire: true`). The admin socket is owned by `<SurfaceAppProvider>`'s turnkey
-// `{ ws, probe }` source, which retires it itself — so it opts out (`retire:
-// false`) to avoid a double-retire.
-function makeSocket(host: string, retire: boolean) {
-  return createSurfaceSocket({
-    url: () => wsBaseFor(host),
-    echo,
-    socketOptions: {
-      connectionTimeout: 60_000,
-      minReconnectionDelay: 2_000,
-      maxReconnectionDelay: 15_000,
-    },
-    retireOnStaleClose: retire,
-  }).ws;
-}
+// Shared by every socket the two connect* seams open.
+const BASE_SOCKET_OPTIONS = {
+  connectionTimeout: 60_000,
+  minReconnectionDelay: 2_000,
+  maxReconnectionDelay: 15_000,
+} as const;
 
-type HostClient = ReturnType<typeof buildHostSurface>;
-type AdminClient = ReturnType<typeof buildAdminSurface>;
+type HostConnection = ReturnType<typeof buildHostSurface>;
+type AdminConnection = ReturnType<typeof buildAdminSurface>;
 
 function buildHostSurface(host: string) {
-  // Per-host sockets own their stale-close retirement — no provider watches them.
-  const ws = makeSocket(host, true);
-  // Thread the socket's reactive liveness into `client.health().live` so the
-  // FACT carries transport death, not a constant `true`. `createSocketStatus`
-  // tracks the socket's own open/close (retiring on a stale-restart close, like
-  // `makeSocket(host, true)` does); `() => status() === "live"` is the boolean
-  // leg `health()` folds in.
-  const status = createSocketStatus(ws, { retireOnStaleClose: true });
-  const client = surfaceClient(
-    browserSurface,
-    websocketLink<typeof browserSurface.contract>(ws as unknown as WebSocket),
-    { live: () => status() === "live" },
-  );
-  return { ws, client };
+  // `connectSurface` builds the reconnecting socket, the reactive client, AND the
+  // default-on half-open heartbeat in one call — so a silently half-open per-host
+  // link is detected and force-reconnected instead of left painting stale metrics
+  // (the gap the hand-built path had: it threaded `{ live }` off open/close but
+  // ran no heartbeat). The socket self-retires on a stale-restart close — no
+  // provider watches per-host sockets — so `retireOnStaleClose: true`. The
+  // transport leg, and (via `browserSurface`'s `connection` cell `liveWhen`) the
+  // mirror leg, both fold into `client.health().live` by construction.
+  return connectSurface({
+    surface: browserSurface,
+    url: () => wsBaseFor(host),
+    echo,
+    socketOptions: BASE_SOCKET_OPTIONS,
+    retireOnStaleClose: true,
+  });
 }
 
 function buildAdminSurface() {
-  // The admin socket is owned by `<SurfaceAppProvider>`'s turnkey source, which
-  // retires it on a stale-restart itself (kolu#1231) — so it opts out here.
-  const ws = makeSocket(ADMIN_HOST_SENTINEL, false);
   // The admin transport multiplexes TWO sibling surfaces (kolu#1197/#1201):
   // drishti's own `admin` surface (the host set + procedures) and surface-app's
-  // complete surface (`buildInfo` + the `identity.info` probe). `surfaceClients`
-  // splits the one link into a per-key client bundle; each client's `.rpc` is
-  // the SCOPED slice (`{ surface: link.surface[key] }`), so its primitives
-  // resolve at `/surface/<key>/<prim>/<verb>`.
-  const link = websocketLink<typeof adminContract>(ws as unknown as WebSocket);
-  // ONE socket carries BOTH siblings, so they share ONE liveness — thread it so
-  // `surfaceClientsHealth({ admin, surfaceApp })` reports `live: false` when the
-  // control-plane socket dies (the AND-reduce over siblings that all read this
-  // same `live`), instead of a structurally-constant `true`.
-  const status = createSocketStatus(ws, { retireOnStaleClose: false });
-  const clients = surfaceClients(link, adminSurfaces, {
-    live: () => status() === "live",
+  // complete surface (`buildInfo` + the `identity.info` probe). `connectSurfaces`
+  // splits the one link into a per-key client bundle and folds them into ONE
+  // `health()` fact (`live` AND-reduced across siblings off the one socket).
+  // `heartbeat: false`: the admin socket is owned by `<SurfaceAppProvider>`'s
+  // `createServerLifecycle`, which runs its OWN heartbeat (kolu#1231) — a second
+  // here would double the probe — and retires the socket on a stale-restart
+  // itself, so it opts out of self-retire (`retireOnStaleClose: false`) too.
+  return connectSurfaces({
+    surfaces: adminSurfaces,
+    url: () => wsBaseFor(ADMIN_HOST_SENTINEL),
+    echo,
+    socketOptions: BASE_SOCKET_OPTIONS,
+    retireOnStaleClose: false,
+    heartbeat: false,
   });
-  return { ws, link, clients };
 }
 
-const hostCache = new Map<string, HostClient>();
+const hostCache = new Map<string, HostConnection>();
 
-/** Get the (cached) surface client for `host`. The first call opens
- *  the PartySocket; subsequent calls return the same instance so a tab
- *  remount preserves the live connection. */
-export function surfaceForHost(host: string) {
+// `connectSurface`/`connectSurfaces` erase the client's `.rpc` to `unknown`/`any`
+// (to dodge TS2590 on their generic seams), so recover the CONCRETE contract for
+// imperative procedures here — the runtime link IS this type. The framework's
+// blessed "cast `.rpc` to your concrete contract once at the wire boundary".
+type HostRpc = ContractRouterClient<typeof browserSurface.contract>;
+type HostClient = HostConnection["client"] & { rpc: HostRpc };
+
+/** Get the (cached) surface client for `host`. The first call opens the
+ *  socket (and starts its heartbeat); subsequent calls return the same instance
+ *  so a tab remount preserves the live connection. */
+export function surfaceForHost(host: string): HostClient {
   let entry = hostCache.get(host);
   if (entry === undefined) {
     entry = buildHostSurface(host);
     hostCache.set(host, entry);
   }
-  return entry.client;
+  return entry.client as HostClient;
 }
 
-/** Close the host's socket and drop the cached client. Call when the
- *  admin collection signals the host was removed — otherwise the
- *  PartySocket keeps trying to reconnect into a server slot that no
- *  longer exists. */
+/** Dispose the host's connection and drop it from the cache. Stops the heartbeat
+ *  and tears down the client's standing subs, then closes the socket — otherwise
+ *  the PartySocket keeps reconnecting into a server slot that no longer exists.
+ *  Call when the admin collection signals the host was removed. */
 export function disposeHostSurface(host: string): void {
   const entry = hostCache.get(host);
   if (entry === undefined) return;
   hostCache.delete(host);
   try {
+    entry.dispose();
     entry.ws.close();
   } catch {
     /* best-effort */
   }
 }
 
-let adminEntry: AdminClient | undefined;
+let adminEntry: AdminConnection | undefined;
 
-function adminEntryLazy(): AdminClient {
+function adminEntryLazy(): AdminConnection {
   if (adminEntry === undefined) adminEntry = buildAdminSurface();
   return adminEntry;
 }
@@ -148,14 +147,19 @@ export function adminClient() {
   return adminEntryLazy().clients.admin;
 }
 
-/** The admin surface's PROCEDURE namespace, typed off the full combined link.
- *  `adminRpc().hosts.add(...)` / `.remove(...)` / `.reconnect(...)` /
- *  `.recheck(...)` resolve at `/surface/admin/hosts/<verb>`. Procedure calls go
- *  through the full typed link (not the per-key scoped client, whose `.rpc` is
- *  `unknown`) — mirroring kolu, where raw/surface procedures resolve off the
- *  full combined link rather than a scoped slice. */
+// The admin scoped client's `.rpc` is the slice `{ surface: link.surface.admin }`,
+// typed `any` by `connectSurfaces`; recover the admin router type so the
+// imperative host-lifecycle procedures stay typed.
+type AdminScopedRpc = {
+  surface: ContractRouterClient<typeof adminContract>["surface"]["admin"];
+};
+
+/** The admin surface's PROCEDURE namespace. `adminRpc().hosts.add(...)` /
+ *  `.remove(...)` / `.reconnect(...)` / `.recheck(...)` resolve at
+ *  `/surface/admin/hosts/<verb>`. Procedure calls go through the scoped rpc
+ *  (recovered to its concrete type above), mirroring kolu. */
 export function adminRpc() {
-  return adminEntryLazy().link.surface.admin;
+  return (adminEntryLazy().clients.admin.rpc as AdminScopedRpc).surface;
 }
 
 /** Get the (cached) surface-app client over the admin transport — the global
@@ -176,4 +180,3 @@ export function surfaceAppClient() {
 export function adminSocket() {
   return adminEntryLazy().ws;
 }
-

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -19,7 +19,7 @@ import {
 } from "@kolu/surface-app/connect";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
 import { ADMIN_HOST_SENTINEL } from "../common/host";
-import { surface } from "drishti-common";
+import { browserSurface } from "drishti-common";
 
 // ONE shared `pid` echo across every socket (per-host + admin). The parent mints
 // a fresh `processId` per boot; the echo threads the last-known one back as the
@@ -67,8 +67,8 @@ function buildHostSurface(host: string) {
   // Per-host sockets own their stale-close retirement — no provider watches them.
   const ws = makeSocket(host, true);
   const client = surfaceClient(
-    surface,
-    websocketLink<typeof surface.contract>(ws as unknown as WebSocket),
+    browserSurface,
+    websocketLink<typeof browserSurface.contract>(ws as unknown as WebSocket),
   );
   return { ws, client };
 }

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -39,14 +39,14 @@ import {
 import { type ProcedureForwarders } from "@kolu/surface/mirror";
 import {
   type HostSession,
-  pipeSessionStateToCell,
   pumpRemoteSurface,
+  seedConnectionCell,
 } from "@kolu/surface-nix-host";
 import {
+  browserSurface,
   type ConnectionInfo,
   type CoreId,
   type CpuCore,
-  DEFAULT_CONNECTION,
   DEFAULT_SYSTEM,
   type IfaceName,
   type MetricHistoryMsg,
@@ -86,9 +86,10 @@ export function buildRouter(opts: BuildRouterOptions) {
   const systemStore: CellStore<SystemInfo> = inMemoryStore({
     ...DEFAULT_SYSTEM,
   });
-  const connectionStore: CellStore<ConnectionInfo> = inMemoryStore({
-    ...DEFAULT_CONNECTION,
-  });
+  // The seeded, gate-closed connection cell — the shared `seedConnectionCell()`,
+  // not a hand-rolled store. Written by `pumpRemoteSurface` off `session.onState`
+  // (the `connection` option below), which owns the subscription + teardown.
+  const connection = seedConnectionCell();
   const processCache = new Map<Pid, Process>();
   const coreCache = new Map<CoreId, CpuCore>();
   const netCache = new Map<IfaceName, NetInterface>();
@@ -119,13 +120,17 @@ export function buildRouter(opts: BuildRouterOptions) {
     current: ProcedureForwarders<typeof surface.spec> | null;
   } = { current: null };
 
-  const fragment = implementSurface(surface, {
+  // Implements the MIRRORED surface (base + the get-only `connection` cell). The
+  // base primitives are forwarded/folded from the agent; `connection` is the
+  // seeded local store the session pump writes — the agent's surface stays
+  // connection-free.
+  const fragment = implementSurface(browserSurface, {
     // Name-keyed in-memory channel factory — publish/subscribe sites
     // land on the same `Channel<T>` instance per name.
     channel: inMemoryChannelByName(),
     cells: {
       system: { store: systemStore },
-      connection: { store: connectionStore },
+      connection,
     },
     collections: {
       processes: {
@@ -220,18 +225,6 @@ export function buildRouter(opts: BuildRouterOptions) {
   // an error on this line.
   const _pumpCtx: FragmentCtx = fragment;
   void _pumpCtx;
-
-  // ── Mirror session connection state → parent's `connection` cell ──
-  // Lives OUTSIDE the pump: the connection cell tracks the *session's*
-  // state (copying / connecting / failed), not any frame the agent sends,
-  // so it's wired straight off `session.onState` and never flows through
-  // the mirror sink. `pipeSessionStateToCell` (kolu #1568) is the shared
-  // pump — it subscribes `session.onState` and writes the projected
-  // `ConnectionInfo` into the cell via the server-internal setter (NOT a
-  // wire verb, so the read-only cell is still parent-writable here).
-  pipeSessionStateToCell(session, (info) =>
-    fragment.ctx.cells.connection.set(info),
-  );
 
   // Sample the metric ring once per agent system tick. CPU% is the mean of
   // the cores currently mirrored into `coreCache` (pumped concurrently);
@@ -329,6 +322,11 @@ export function buildRouter(opts: BuildRouterOptions) {
     // the pump clears them the instant the link dies, so a kill in the gap
     // fails honestly rather than calling into a dead client.
     liveProcedures,
+    // The session's link health (copying / connecting / failed) onto the
+    // browser-facing `connection` cell — the pump OWNS this subscription for the
+    // session's lifetime and tears it down on exit (kolu #1568), so it can't be
+    // forgotten or leak. The cell tracks the SESSION's state, never a mirror frame.
+    connection: { set: (info) => fragment.ctx.cells.connection.set(info) },
     log,
   });
 
@@ -337,7 +335,9 @@ export function buildRouter(opts: BuildRouterOptions) {
   // produces a `surface/surface/...` double-prefix in the matcher tree
   // (no procedure matches what the client sends). Wrap once via
   // `implement(contract).router({...fragment})` to flatten the prefix.
-  const router = implement(surface.contract).router({ ...fragment.router });
+  const router = implement(browserSurface.contract).router({
+    ...fragment.router,
+  });
   return { router, session };
 }
 

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -39,6 +39,7 @@ import {
 import { type ProcedureForwarders } from "@kolu/surface/mirror";
 import {
   type HostSession,
+  pipeSessionStateToCell,
   pumpRemoteSurface,
 } from "@kolu/surface-nix-host";
 import {
@@ -224,15 +225,13 @@ export function buildRouter(opts: BuildRouterOptions) {
   // Lives OUTSIDE the pump: the connection cell tracks the *session's*
   // state (copying / connecting / failed), not any frame the agent sends,
   // so it's wired straight off `session.onState` and never flows through
-  // the mirror sink.
-  session.onState((s) => {
-    fragment.ctx.cells.connection.set({
-      state: s.connection,
-      lastError: s.lastError,
-      failureCause: s.failureCause,
-      progressLines: [...s.progressLines],
-    });
-  });
+  // the mirror sink. `pipeSessionStateToCell` (kolu #1568) is the shared
+  // pump — it subscribes `session.onState` and writes the projected
+  // `ConnectionInfo` into the cell via the server-internal setter (NOT a
+  // wire verb, so the read-only cell is still parent-writable here).
+  pipeSessionStateToCell(session, (info) =>
+    fragment.ctx.cells.connection.set(info),
+  );
 
   // Sample the metric ring once per agent system tick. CPU% is the mean of
   // the cores currently mirrored into `coreCache` (pumped concurrently);

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -42,9 +42,8 @@ import {
   pumpRemoteSurface,
   seedConnectionCell,
 } from "@kolu/surface-nix-host";
+import { browserSurface, type ConnectionInfo } from "drishti-common/browser";
 import {
-  browserSurface,
-  type ConnectionInfo,
   type CoreId,
   type CpuCore,
   DEFAULT_SYSTEM,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "//": "Deps are what the wire contract needs at runtime: surface.ts uses zod and @kolu/surface/define (which pulls @orpc/contract). @kolu/surface is hydrated from the Nix store, not bun.lock, so its support deps must be declared by consumers — here for the contract, and in drishti-agent for the server/peer-server it serves.",
+  "//": "Deps are what the wire contract needs at runtime: surface.ts uses zod and @kolu/surface/define (which pulls @orpc/contract). @kolu/surface is hydrated from the Nix store, not bun.lock, so its support deps must be declared by consumers \u2014 here for the contract, and in drishti-agent for the server/peer-server it serves.",
   "main": "./src/surface.ts",
   "types": "./src/surface.ts",
   "exports": {
-    ".": "./src/surface.ts"
+    ".": "./src/surface.ts",
+    "./browser": "./src/browser.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/common/src/browser.ts
+++ b/packages/common/src/browser.ts
@@ -1,0 +1,28 @@
+/**
+ * App-only (browser + parent re-serve) surface bits. This is the ONLY
+ * drishti-common module that imports `@kolu/surface-nix-host` — kept off the
+ * agent-shared `./surface.ts` so the agent (whose scoped build hydrates only
+ * `@kolu/surface`) never loads the parent-only provisioning lib at runtime.
+ * Exposed as the `drishti-common/browser` subpath; the agent imports
+ * `drishti-common` (`./surface.ts`) and never reaches this file.
+ */
+
+import { mirroredSurface } from "@kolu/surface-nix-host/connection";
+import { surface } from "./surface";
+
+/** The surface the BROWSER consumes and the PARENT re-serves: the agent's base
+ *  `surface` augmented at the mirror seam with the gate-closed get-only
+ *  `connection` cell. The agent serves the base; the parent mirrors it and writes
+ *  `connection` from `session.onState` — kolu's `mirroredSurface` combinator, the
+ *  single source of truth, instead of a hand-composed cell. */
+export const browserSurface = mirroredSurface(surface);
+
+// The connection-cell types + gate-closed default, re-exported here (not from the
+// agent-shared `./surface.ts`) so app modules import them without pulling
+// `@kolu/surface-nix-host` into the agent's runtime.
+export {
+  type ConnectionInfo,
+  type ConnectionState,
+  DEFAULT_CONNECTION,
+  type FailureCause,
+} from "@kolu/surface-nix-host/connection";

--- a/packages/common/src/surface.test.ts
+++ b/packages/common/src/surface.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, it } from "bun:test";
 import { surface } from "./surface";
 
-// drishti is a read-only monitor: the per-host surface must expose
-// cells, collections, and streams but **no procedures**. A procedure is
-// the only way to push a mutation (e.g. a signal/kill) down to the
-// monitored host, so the absence of any procedure is the structural
-// guarantee that the app can't act on a host — only observe it. If a
-// future change re-introduces a procedure here, this test fails on
-// purpose: removing the kill capability was a deliberate decision, not
-// an oversight to be quietly undone.
-describe("surface is read-only", () => {
-  it("declares no procedures", () => {
-    // The spec type literally has no `procedures` key (read-only by
-    // construction). Widen to read the optional slot at runtime: this
-    // still fails the moment a procedure is re-added, even though the
-    // type would also light up at the call sites that consume it.
-    const spec = surface.spec as Record<string, unknown>;
-    expect(spec.procedures).toBeUndefined();
+// drishti is an observe-mostly monitor: the per-host surface is cells,
+// collections, and streams plus EXACTLY ONE deliberate mutating escape hatch —
+// the `process.kill` procedure (the R7 keystone, kolu #1505). A procedure is the
+// only way to push a mutation down to a monitored host, so this test pins the
+// blast radius: `process.kill` is the sole procedure, and ANY other procedure
+// (or a second verb under `process`) fails on purpose — a new way to act on a
+// host must be a deliberate decision, not an oversight quietly slipped in.
+describe("surface mutation surface is exactly process.kill", () => {
+  it("declares exactly the `process.kill` escape hatch and no other procedure", () => {
+    const procedures = (surface.spec.procedures ?? {}) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    // Exactly one namespace (`process`), exactly one verb under it (`kill`).
+    expect(Object.keys(procedures)).toEqual(["process"]);
+    expect(Object.keys(procedures.process ?? {})).toEqual(["kill"]);
   });
 
   it("still exposes the read-only primitives", () => {

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -21,9 +21,9 @@ import { defineSurface, type SurfaceTypes } from "@kolu/surface/define";
 import {
   type ConnectionInfo,
   type ConnectionState,
-  connectionCell,
   DEFAULT_CONNECTION,
   type FailureCause,
+  mirroredSurface,
 } from "@kolu/surface-nix-host/connection";
 import { z } from "zod";
 
@@ -31,7 +31,8 @@ import { z } from "zod";
 // from `drishti-common` (the canonical surface module) rather than reaching
 // into `@kolu/surface-nix-host/connection` directly. The cell itself — schema,
 // default, and the parent-only-write authority — is now owned upstream
-// (kolu #1568); drishti composes the shared `connectionCell` into its surface.
+// (kolu #1568); drishti adds it ONLY at the re-serve seam via `mirroredSurface`
+// (`browserSurface` below), never on the base surface the agent serves.
 export {
   type ConnectionInfo,
   type ConnectionState,
@@ -141,12 +142,12 @@ const SystemSchema = z.object({
 // ⚠ **Parent-to-agent link lifecycle — owned upstream (kolu #1568).**
 // The connection-health cell (schema, gate-closed `DEFAULT_CONNECTION`, and
 // the parent-only-write / read-only-over-the-wire authority) now lives in
-// `@kolu/surface-nix-host/connection` as the composable `connectionCell`. It
-// is byte-identical in shape to drishti's former local `ConnectionSchema`
-// (the five link phases, nullable `lastError`, nullable `network|remote`
-// `failureCause`, `progressLines` string tail). drishti spreads the shared
-// descriptor into its surface below and re-exports the types at the top of
-// this module, so a re-served mirror's browser still sees honest link health.
+// `@kolu/surface-nix-host/connection`. It is byte-identical in shape to
+// drishti's former local `ConnectionSchema` (the five link phases, nullable
+// `lastError`, nullable `network|remote` `failureCause`, `progressLines` tail).
+// drishti adds it ONLY at the re-serve seam via `mirroredSurface` (`browserSurface`)
+// and re-exports the types at the top of this module, so a re-served mirror's
+// browser sees honest link health while the base surface stays connection-free.
 
 export const DEFAULT_SYSTEM: z.infer<typeof SystemSchema> = {
   loadAvg: [0, 0, 0],
@@ -222,12 +223,10 @@ export const surface = defineSurface({
       schema: SystemSchema,
       default: DEFAULT_SYSTEM,
     },
-    // Read-only over the wire (`verbs: ["get"]`) — the parent owns this
-    // cell and writes it server-side off `session.onState` via
-    // `pipeSessionStateToCell`; a remote RPC client can no longer forge
-    // the host's health. The shared descriptor carries its own schema and
-    // gate-closed default (kolu #1568).
-    connection: connectionCell,
+    // NOTE: no `connection` cell here. Link health is composed ONLY at the
+    // nix-host re-serve seam via `mirroredSurface(surface)` (`browserSurface`
+    // below) — the agent serves this connection-free base; the parent mirrors
+    // it and adds the cell, writing it off `session.onState` (kolu #1568).
   },
   collections: {
     processes: {
@@ -281,6 +280,13 @@ export const surface = defineSurface({
     },
   },
 });
+
+/** The surface the BROWSER consumes and the PARENT re-serves: the agent's base
+ *  `surface` augmented at the mirror seam with the gate-closed get-only
+ *  `connection` cell. The agent serves the base; the parent mirrors it and writes
+ *  `connection` from `session.onState` — kolu's `mirroredSurface` combinator, the
+ *  single source of truth, instead of a hand-composed cell. */
+export const browserSurface = mirroredSurface(surface);
 
 type SF = SurfaceTypes<typeof surface.spec>;
 

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -18,27 +18,15 @@
  */
 
 import { defineSurface, type SurfaceTypes } from "@kolu/surface/define";
-import {
-  type ConnectionInfo,
-  type ConnectionState,
-  DEFAULT_CONNECTION,
-  type FailureCause,
-  mirroredSurface,
-} from "@kolu/surface-nix-host/connection";
 import { z } from "zod";
 
-// Re-export the connection-cell types so drishti modules keep importing them
-// from `drishti-common` (the canonical surface module) rather than reaching
-// into `@kolu/surface-nix-host/connection` directly. The cell itself — schema,
-// default, and the parent-only-write authority — is now owned upstream
-// (kolu #1568); drishti adds it ONLY at the re-serve seam via `mirroredSurface`
-// (`browserSurface` below), never on the base surface the agent serves.
-export {
-  type ConnectionInfo,
-  type ConnectionState,
-  DEFAULT_CONNECTION,
-  type FailureCause,
-};
+// IMPORTANT: this module is AGENT-shared (drishti-common's `.` export — the
+// agent serves the base surface from it). It must NOT import
+// `@kolu/surface-nix-host`: the agent's scoped build hydrates only `@kolu/surface`,
+// so a runtime import of the parent-only provisioning lib crashes the agent at
+// load. The connection-cell types, `DEFAULT_CONNECTION`, and the `browserSurface`
+// mirror-seam composition therefore live in the APP-only `drishti-common/browser`
+// subpath (./browser.ts), imported only by the parent re-serve + the client.
 
 const PidSchema = z.number().int().nonnegative();
 const ProcessSchema = z.object({
@@ -281,13 +269,6 @@ export const surface = defineSurface({
   },
 });
 
-/** The surface the BROWSER consumes and the PARENT re-serves: the agent's base
- *  `surface` augmented at the mirror seam with the gate-closed get-only
- *  `connection` cell. The agent serves the base; the parent mirrors it and writes
- *  `connection` from `session.onState` — kolu's `mirroredSurface` combinator, the
- *  single source of truth, instead of a hand-composed cell. */
-export const browserSurface = mirroredSurface(surface);
-
 type SF = SurfaceTypes<typeof surface.spec>;
 
 export type Pid = SF["collections"]["processes"]["Key"];
@@ -297,10 +278,9 @@ export type CpuCore = SF["collections"]["cpuCores"]["Value"];
 export type IfaceName = SF["collections"]["networkInterfaces"]["Key"];
 export type NetInterface = SF["collections"]["networkInterfaces"]["Value"];
 export type SystemInfo = SF["cells"]["system"]["Value"];
-// `ConnectionInfo` / `ConnectionState` / `FailureCause` are re-exported at the
-// top of this module from `@kolu/surface-nix-host/connection` (kolu #1568) —
-// the shared cell is the single source of truth, so they are no longer derived
-// from the local surface spec here.
+// `ConnectionInfo` / `ConnectionState` / `FailureCause` are re-exported from the
+// app-only `drishti-common/browser` subpath (./browser.ts), NOT here — see the
+// agent-safety note near the top of this file.
 export type ProcessesSnapshotMsg = SF["streams"]["processesSnapshot"]["Output"];
 export type MetricSample = z.infer<typeof MetricSampleSchema>;
 export type MetricHistoryMsg = SF["streams"]["metricHistory"]["Output"];

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -18,7 +18,26 @@
  */
 
 import { defineSurface, type SurfaceTypes } from "@kolu/surface/define";
+import {
+  type ConnectionInfo,
+  type ConnectionState,
+  connectionCell,
+  DEFAULT_CONNECTION,
+  type FailureCause,
+} from "@kolu/surface-nix-host/connection";
 import { z } from "zod";
+
+// Re-export the connection-cell types so drishti modules keep importing them
+// from `drishti-common` (the canonical surface module) rather than reaching
+// into `@kolu/surface-nix-host/connection` directly. The cell itself — schema,
+// default, and the parent-only-write authority — is now owned upstream
+// (kolu #1568); drishti composes the shared `connectionCell` into its surface.
+export {
+  type ConnectionInfo,
+  type ConnectionState,
+  DEFAULT_CONNECTION,
+  type FailureCause,
+};
 
 const PidSchema = z.number().int().nonnegative();
 const ProcessSchema = z.object({
@@ -119,58 +138,15 @@ const SystemSchema = z.object({
   pollIntervalMs: z.number(),
 });
 
-/** Parent-to-agent link lifecycle.
- *
- *  ⚠ **Parent-only write authority.** The cell lives on the shared
- *  surface so the browser can subscribe to it via snapshot-then-delta,
- *  but the *value* is owned by the parent's `HostSession`. The agent
- *  has no visibility into the link from the inside (a process can't
- *  observe its own SSH transport state) and must NOT publish updates
- *  here — see the inert stub in `agent/main.ts`. Any direct-to-agent
- *  client would see `DEFAULT_CONNECTION` forever; that's by design,
- *  since direct-to-agent connections imply the link is local and
- *  always-up.
- *
- *  The browser subscribes via `useCell(connection)`, which yields the
- *  current value synchronously to a new subscriber — the overlay
- *  attaches before `connect()` returns and still sees the initial
- *  `connecting` state. */
-const ConnectionSchema = z.object({
-  /** Link phase. Mirrors `HostSession`'s `ConnectionState` 1:1 (the
-   *  parent owns this — see above). `disconnected` is the transient gap
-   *  between retry attempts; `failed` is terminal — the parent's
-   *  reconnect loop gave up and won't retry without a manual
-   *  `hosts.reconnect`. Splitting the two is the whole point: the UI can
-   *  finally tell "reconnecting…" from "gave up, here's why". */
-  state: z.enum([
-    "copying",
-    "connecting",
-    "connected",
-    "disconnected",
-    "failed",
-  ]),
-  /** The error behind a `disconnected`/`failed` state, verbatim from the
-   *  parent (`HostSession.lastError`). `null` while healthy. Free-form —
-   *  the parent owns the vocabulary; the browser only renders it. */
-  lastError: z.string().nullable(),
-  /** Why the link is down, mirroring `HostSession.failureCause` — a stable
-   *  discriminant the browser keys messaging off of (vs parsing the
-   *  free-form `lastError`). `"network"` = host unreachable, so the parent
-   *  retries forever; `"remote"` = the host rejected the closure, which
-   *  goes terminal (`failed`). `null` while `copying`/`connecting`/
-   *  `connected`. */
-  failureCause: z.enum(["network", "remote"]).nullable(),
-  /** Tail of the parent's link-lifecycle progress log (nix-copy output,
-   *  ssh spawn, "reconnecting… (attempt N/5)"). Lets the overlay show
-   *  live retry progress without the browser parsing it for control
-   *  flow — it's display text, never a branch condition. Deliberately
-   *  uncapped: the parent already trims the ring to a kolu-private bound,
-   *  and re-asserting that constant here would couple this contract to a
-   *  value drishti doesn't own — and reject valid frames if kolu ever
-   *  raised it. The UI reads only a bounded tail (the overlay's last line;
-   *  the failed-host card's last few), so the length is moot. */
-  progressLines: z.array(z.string()),
-});
+// ⚠ **Parent-to-agent link lifecycle — owned upstream (kolu #1568).**
+// The connection-health cell (schema, gate-closed `DEFAULT_CONNECTION`, and
+// the parent-only-write / read-only-over-the-wire authority) now lives in
+// `@kolu/surface-nix-host/connection` as the composable `connectionCell`. It
+// is byte-identical in shape to drishti's former local `ConnectionSchema`
+// (the five link phases, nullable `lastError`, nullable `network|remote`
+// `failureCause`, `progressLines` string tail). drishti spreads the shared
+// descriptor into its surface below and re-exports the types at the top of
+// this module, so a re-served mirror's browser still sees honest link health.
 
 export const DEFAULT_SYSTEM: z.infer<typeof SystemSchema> = {
   loadAvg: [0, 0, 0],
@@ -182,13 +158,6 @@ export const DEFAULT_SYSTEM: z.infer<typeof SystemSchema> = {
   os: "unknown",
   hostname: "",
   pollIntervalMs: 0,
-};
-
-export const DEFAULT_CONNECTION: z.infer<typeof ConnectionSchema> = {
-  state: "connecting",
-  lastError: null,
-  failureCause: null,
-  progressLines: [],
 };
 
 /** Snapshot-then-delta `Stream<>` shape — the bulk-friendly counterpart
@@ -253,10 +222,12 @@ export const surface = defineSurface({
       schema: SystemSchema,
       default: DEFAULT_SYSTEM,
     },
-    connection: {
-      schema: ConnectionSchema,
-      default: DEFAULT_CONNECTION,
-    },
+    // Read-only over the wire (`verbs: ["get"]`) — the parent owns this
+    // cell and writes it server-side off `session.onState` via
+    // `pipeSessionStateToCell`; a remote RPC client can no longer forge
+    // the host's health. The shared descriptor carries its own schema and
+    // gate-closed default (kolu #1568).
+    connection: connectionCell,
   },
   collections: {
     processes: {
@@ -320,9 +291,10 @@ export type CpuCore = SF["collections"]["cpuCores"]["Value"];
 export type IfaceName = SF["collections"]["networkInterfaces"]["Key"];
 export type NetInterface = SF["collections"]["networkInterfaces"]["Value"];
 export type SystemInfo = SF["cells"]["system"]["Value"];
-export type ConnectionInfo = SF["cells"]["connection"]["Value"];
-export type ConnectionState = ConnectionInfo["state"];
-export type FailureCause = NonNullable<ConnectionInfo["failureCause"]>;
+// `ConnectionInfo` / `ConnectionState` / `FailureCause` are re-exported at the
+// top of this module from `@kolu/surface-nix-host/connection` (kolu #1568) —
+// the shared cell is the single source of truth, so they are no longer derived
+// from the local surface spec here.
 export type ProcessesSnapshotMsg = SF["streams"]["processesSnapshot"]["Output"];
 export type MetricSample = z.infer<typeof MetricSampleSchema>;
 export type MetricHistoryMsg = SF["streams"]["metricHistory"]["Output"];


### PR DESCRIPTION
## What & why

Two adoptions of kolu's shared surface framework, both required by [kolu #1568](https://github.com/juspay/kolu/pull/1568)'s `.claude/rules/surface.md` gate: the **connection cell + mirror seam**, and the re-reviewed **`client.health()` fact** — where drishti becomes the *real second policy consumer* the fact/policy split exists for.

drishti hand-rolled a connection-health cell that was **byte-identical** to the cell kolu now ships from `@kolu/surface-nix-host`: the same five link phases (`copying → connecting → connected → disconnected → failed`), nullable `lastError`, nullable `network|remote` `failureCause`, and a `progressLines` string tail — plus the inline `session.onState → connection.set({...})` mapping in the parent router.

kolu #1568 extracts that cell as a **composable, browser-safe export** (`connectionCell` from `@kolu/surface-nix-host/connection`) and ships the node-side pump (`pipeSessionStateToCell` / `projectConnection`) from the package root. This PR **adopts the shared exports and deletes drishti's verbatim copy** — one source of truth for the schema, the gate-closed default, and the `onState → cell` pump.

It also adopts kolu's **mirror-seam** shape. drishti used to declare `connection` on the shared base surface and serve an **inert stub** for it from the agent; now the agent serves a **connection-free base**, and the cell is composed **only at the parent's re-serve** via `mirroredSurface(surface)` — a new `drishti-common/browser` subpath. The agent can't observe its own SSH transport from the inside, so link health is the *parent's* observation and the seam is where it belongs. That subpath is also the **only** module importing `@kolu/surface-nix-host`, which keeps the parent-only provisioning lib off the agent's scoped runtime path (the agent imports `drishti-common` and never reaches it).

This is the **surface-gate companion** required by kolu's `.claude/rules/surface.md`: any API change to `@kolu/surface*` needs a linked drishti PR that adopts it with green CI. Pinned and CI-verified against the **final** kolu HEAD (`ba51c99772` — the round-5.2 adversarial hardening: the fail-fast half-open-link guard + `gateStatus` in the `@kolu/surface/solid` barrel, on top of the `client.health()`/`<SurfaceGate>` framework — so the gate is green against the *latest* surface API, not a pre-re-review SHA).

## Adopts the re-reviewed `client.health()` — drishti is the second policy

kolu's [re-review](https://github.com/juspay/kolu/pull/1568#issuecomment-4802069408) demanded the "two divergent consumers" premise be *real*, not asserted: pulam-web hard-gates the host; **drishti renders stale-while-degraded**. This PR makes drishti that second consumer of the same `client.health()` fact, with the opposite policy:

- **R3 — stale-while-degraded, via its own `<SurfaceGate>`.** drishti now **mounts the framework `<SurfaceGate>`** — the second re-review's ask that drishti be a *real component-level adopter*, not just a fact reader. Its `degraded` slot renders a **non-blocking** "some data is stale" strip while the body **stays visible**, and its default render-while-reconnecting keeps the last-good view on a transport blip. pulam-web's `<SurfaceGate ready>` hard-gates the whole host on the same fact — the divergence over one shared fact is the whole point of exposing a fact and leaving the verdict to each consumer.
- **Leak A / 🔴2 — both raw streams join the fact, structurally.** `metricHistory` moves onto **`app.rawStream`** — the structural path that enrols it and throws outside a reactive owner (the second re-review's 🔴2: the real adopter must *use* the structural path, not hand-`enroll`). `processesSnapshot` keeps its `createSubscription` (its reduce/reconcile can't collapse onto rawStream's value-less source) + `app.enroll`, now driving the renamed **`unenrolledStreamCall`** so the hand-enrol *self-flags* as deliberate. A dead feed surfaces in the one fact instead of a private `console.error`.
- **Leak D — the control plane folds its siblings.** `surfaceClientsHealth({ admin, surfaceApp })` folds the admin transport's two sibling surfaces into one read — a non-blocking "control plane degraded" strip. drishti's always-open control plane is the natural consumer of the fold kolu's per-cell-toast UI deliberately doesn't use.

## Third re-review (kolu #1568, [round 5](https://github.com/juspay/kolu/pull/1568#issuecomment-4804563780)) — the dot can no longer lie

kolu's third re-review **completed the fact** and **single-sourced the dot**; drishti adopts both so it stops re-expressing the #1564 lie one viewer over:

- **The half-open watchdog, by construction.** drishti's per-host sockets hand-built `surfaceClient + websocketLink` — they threaded `{ live }` off open/close but ran **no heartbeat**, so a *silently* half-open per-host link kept painting stale metrics. They move onto **`connectSurface`** (the heartbeat is wired by construction) and the admin bundle onto **`connectSurfaces({ heartbeat: false })`** (the control plane's heartbeat is already owned by `<SurfaceAppProvider>`). The hand-built no-heartbeat path is **deleted** — no constructor can forget the watchdog. `.rpc` is recovered to its concrete contract once at the wire boundary (the framework-blessed cast) for the imperative procedures.
- **One dot, green only from the fact.** drishti's three per-host dots (fleet card, tab chip, open-host header) read the **raw `connection.state`** cell to color themselves — a green dot over a dead mirror. They're now ONE shared **`<HostDot>`**, a thin skin over the framework **`<HostStatusPip health={app.health}>`**: green is emitted ONLY from the fact's readiness verdict (transport ∧ mirror ∧ sub-errors), so a stale `connected` cell can't paint it. The rich state still drives the *not-ready* tone (failed → red, else amber), the pulse, and the label — never the green.
- **The mirror leg rides the fact now.** Because kolu's `connection` cell gained a `liveWhen` predicate, `app.health().live` folds the mirror state **by construction** — no consumer hand-ANDs `connection.state === "connected"` anymore. drishti's fleet-card body gates its metrics on `app.health().live` (stale-while-degraded: last-good metrics stay visible under the now-honest amber dot+word), while the open-host `<SurfaceGate>` stays stale-while-degraded for *sub* health.

### Round 5.2 — the status *word* now tracks the dot

An adversarial sweep (independent skeptics each trying to *express* the #1564 lie; an independent verifier confirming each) found one drishti relocation and chased it to **`CLASS-UNEXPRESSIBLE`**: the green **dot** was fact-gated, but the adjacent status **word** was still colored from the bare `live` boolean — a signal *narrower* than the dot's verdict. On a live-but-degraded host (a sub silently erroring while transport+mirror are up) the dot went amber while the word stayed green. `statusTextClass` now folds the **whole `health()` through the same `gateStatus` the dot uses**, so word and dot are one decision (it consumes `gateStatus` from kolu's now-barrel-exported verdict). The companion kolu HEAD also makes kolu's *own* app thread its transport-live leg the same way — a real gap the new half-open-link guard caught.

## Changes

| Area | File(s) | Change |
|------|---------|--------|
| **Re-pin** | `npins/sources.json` | Pin kolu → `ba51c99772` on `pulam-conn-bug` (final HEAD of kolu #1568 — post-round-5.2 + master merge). |
| **Status word folds the verdict** | `packages/app/src/client/{connectionColors.ts,App.tsx}` · `connectionColors.test.ts` | `statusTextClass(state, health)` greens only when `gateStatus(health) === "ready"` (matching the dot); the two callers pass the whole `health()` fact. Tests cover the degraded-while-live case the bare-`live` word missed. |
| **Adopt the shared cell** | `packages/common/src/surface.ts` | Delete the byte-identical `ConnectionSchema` + `DEFAULT_CONNECTION`; the agent's base surface is now **connection-free** (the cell moves to the seam). |
| **Mirror seam** | `packages/common/src/browser.ts` *(new)* · `package.json` | New `drishti-common/browser` subpath: `browserSurface = mirroredSurface(surface)` plus a re-export of `DEFAULT_CONNECTION` and the `ConnectionInfo`/`ConnectionState`/`FailureCause` types. The **only** module importing `@kolu/surface-nix-host`. |
| **Agent stays bare** | `packages/agent/src/main.ts` | Drop the inert `connection` stub cell — the agent serves the connection-free base. |
| **Parent re-serve** | `packages/app/src/server/router.ts` | Re-serve `browserSurface`; replace the inline `session.onState(...) → connection.set({...})` block with `pipeSessionStateToCell` (behaviour-preserving). |
| **Adopt `client.health()`** | `packages/app/src/client/{App.tsx,wire.ts}` | drishti's own `<SurfaceGate>` (R3, stale-while-degraded); `metricHistory` → `app.rawStream`, `processesSnapshot` → `unenrolledStreamCall` + `app.enroll` (Leak A / 🔴2); `wire.ts` threads each socket's real `{ live }`; `surfaceClientsHealth` control-plane strip reading `.live` (Leak D). |
| **Client consumes the seam** | `packages/app/src/client/{wire,App,TabStrip,connectionColors}.ts(x)` | `surfaceClient` binds `browserSurface`; the connection types + `DEFAULT_CONNECTION` now import from `drishti-common/browser`. |
| **Test** | `packages/common/src/surface.test.ts` | Updated for the connection-free base / mirror-seam shape. |

No tsconfig change: kolu's `surface-nix-host` modules use extension-less imports, so drishti's existing `moduleResolution: bundler` type-checks them as-is.

## Security improvement: the connection cell is now read-only over the wire

The shared `connectionCell` pins `verbs: ["get"]`. Previously drishti's cell defaulted to `["get", "set"]`, so a remote RPC client could `connection.set` the host's health to `connected` and **forge the very signal a stale-health gate trusts**. The parent still writes the cell server-side off `session.onState` (via `pipeSessionStateToCell` → the server-internal setter, not a wire verb), so behaviour is unchanged; only the wire authority is tightened. kolu's final HEAD additionally type-enforces this read-only contract (`CellIsMutable` / `ReadOnlyBoundCell`), and drishti's `surfaceClient` consumer type-checks clean against the new types.

## Verification (local, against the final pin)

- `just typecheck` — green across all three workspace members (common, agent, app), including the client's `surfaceClient` consumption of the read-only connection cell **and** the `client.health()` / `app.rawStream` / `unenrolledStreamCall` / `surfaceClientsHealth` API.
- `just test` — the full suite passes (**137/137**), including `processesStream.test.ts` (now driving the renamed `unenrolledStreamCall`) and `connectionColors.test.ts` (13/13, with the round-5.2 degraded-while-live word cases).

## CI

Green on **both** platforms against the PR head at the final pin (drishti `268ab95`, kolu `ba51c99772`): the full odu pipeline — **20/20 nodes ok, 0 failed** — `aarch64-darwin` (on `rasam`) + `x86_64-linux` (on `kolu-ci-2`), including the launchd eval-build and the `home-manager` nixosTest VM boot, with `typecheck` clean on both against the round-5.2 surface API (the half-open-link guard, `gateStatus` in the `@kolu/surface/solid` barrel, `connectSurface` / `connectSurfaces`, the `<HostStatusPip>` dot, the `liveWhen` mirror-fold).

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._



