### PR TITLE
chore(deps): bump kolu pin to heartbeat suspension/void surface API (kolu#1598)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "fix/heartbeat-suspension-void",
       "submodules": false,
-      "revision": "85ca242b37105ea34ccdc7f826aef19b809af41c",
-      "url": "https://github.com/juspay/kolu/archive/85ca242b37105ea34ccdc7f826aef19b809af41c.tar.gz",
-      "hash": "sha256-EDGKHclK0+g/MHIF/p/iHxgX0YBWgMpLIytNg/NTHCk="
+      "revision": "cd6235c03ab99ee68ad851d3b1f22f054ef0ab5a",
+      "url": "https://github.com/juspay/kolu/archive/cd6235c03ab99ee68ad851d3b1f22f054ef0ab5a.tar.gz",
+      "hash": "sha256-jllZG8pGEzkgOLkv5eh/imFwiv0SeYXxbqd4YR2GNrs="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Paired drishti PR for **[juspay/kolu#1598](https://github.com/juspay/kolu/pull/1598)** — *"fix(surface): stop the half-open watchdog flashing \"Disconnected\" on resume"* — required by kolu's `.claude/rules/surface.md` (any API-facing change to the shared `@kolu/surface*` libraries must ship a paired, CI-green drishti PR pinned to the **final** kolu HEAD).

## What changed here

A single **npins pin bump**: `npins/sources.json` → `juspay/kolu` `fix/heartbeat-suspension-void` @ **`cd6235c03ab99ee68ad851d3b1f22f054ef0ab5a`** (kolu#1598's final, post-review-gauntlet HEAD). drishti vendors all five `@kolu/*` packages (surface, surface-nix-host, surface-app, solid-pwa-install, shell-quote) from this one pin via `nix/overlay.nix`, so the bump moves the whole surface stack at once. No `bun.lock` / `bun.nix` churn — the `@kolu/*` sources are hydrated from the Nix store as raw `.ts`, not npm deps.

**No drishti code change was required.** The kolu API delta is additive / backward-compatible. As it settled after the review gauntlet:

- `@kolu/surface/solid`: new `gracedDown(source, ms)` overlay-debounce primitive; new `onWake`.
- `@kolu/surface/heartbeat`: `createHeartbeat` return gains `wake`; the `now`/`mono` test seams are gathered into one optional both-or-neither `deps?: { now, mono }` container (default `Date.now` / `performance.now`); new `SUSPENSION_SLACK_MS` / `VOID_BUDGET_FACTOR` exports + an internal wake-storm budget.
- `@kolu/surface-app/solid`: `presentingDown` is now derived **once** inside `SurfaceAppProvider` via `gracedDown` (no longer on `createServerLifecycle`'s return or on `ConnectionSource`); `SurfaceAppModel.presentingDown` stays on the model, provider-filled; new `DISCONNECT_OVERLAY_GRACE_MS`.

drishti consumes surface-app exclusively through `<SurfaceAppProvider>` / `useSurfaceApp()` (`packages/app/src/client/App.tsx`) and never hand-builds a `SurfaceAppModel`, so every model field (including `presentingDown`) is provider-filled. `bun run typecheck` is green across all three workspaces (common, agent, app) against the final types.

## CI

Full drishti odu pipeline green at HEAD `47d2be6`, both lanes — **`20 ok · 0 failed · 0 errored · 0 skipped`**:
- **aarch64-darwin** → `srid@sincereintent`
- **x86_64-linux** → `kolu-ci-2`

Pinned to the final kolu HEAD `cd6235c0` and ready.