### PR TITLE
Bump kolu pin to master: @kolu/surface safety-invariant sweep (juspay/kolu#1599)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "85ca242b37105ea34ccdc7f826aef19b809af41c",
-      "url": "https://github.com/juspay/kolu/archive/85ca242b37105ea34ccdc7f826aef19b809af41c.tar.gz",
-      "hash": "sha256-EDGKHclK0+g/MHIF/p/iHxgX0YBWgMpLIytNg/NTHCk="
+      "revision": "d9e4b77ccf4ccdebe2bce1f288ac9a62eb9bfd13",
+      "url": "https://github.com/juspay/kolu/archive/d9e4b77ccf4ccdebe2bce1f288ac9a62eb9bfd13.tar.gz",
+      "hash": "sha256-UbBS4ikqRspKsjkQVgrDjLkrMt2DsN3P9jLM2FY1/Gs="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Advances the kolu pin (`@kolu/surface` + `@kolu/surface-nix-host`) to kolu **master `d9e4b77c`** — the merged [#1599](https://github.com/juspay/kolu/pull/1599) perfection sweep (#1580) that makes the surface stack's connection-health invariants **unspellable**:

- the half-open brand moved to the `wireClient` chokepoint, so **every** wire link is refused bare unless watchdog-backed;
- `<HostStatusPip>`'s green is floored on `health().live`;
- `createSurfaceHealthRegistry` (the raw-`live` minter) is un-exported from the `/solid` barrel.

**Pin-only — no drishti code change.** drishti already wires surface through the blessed `connectSurface` / `createLiveSignal` factories (since #76) and imports none of the removed/relocated symbols, so the tightening is transparent. Satisfies kolu's [`surface.md`](https://github.com/juspay/kolu/blob/master/.claude/rules/surface.md) gate against the merged kolu HEAD.

> Supersedes #78, which was branched off a stale master (it replayed the already-merged #76 lineage). This is the clean equivalent: a single pin-advance commit off latest `origin/master`.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._