### PR TITLE
Bump kolu pin to R9a (additive mirrorOnce export)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "R9a",
       "submodules": false,
-      "revision": "f5b1070cf540c30280326c444e4eeb5c27bae469",
-      "url": "https://github.com/juspay/kolu/archive/f5b1070cf540c30280326c444e4eeb5c27bae469.tar.gz",
-      "hash": "sha256-KsGOsqiXJ0KnOO7mttODWtQXcD0DP4gtRYxSm1NOi4o="
+      "revision": "d7dd18efa6ca6136c2fb19eef09828930b2325cb",
+      "url": "https://github.com/juspay/kolu/archive/d7dd18efa6ca6136c2fb19eef09828930b2325cb.tar.gz",
+      "hash": "sha256-rr6aKKMP6WTgCw8RqS3bKrLmazuMKZMi5bwbhOtjTDQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "R9a",
       "submodules": false,
-      "revision": "20df9f5a9c2db602ea84dd7dcd299f833238b8b5",
-      "url": "https://github.com/juspay/kolu/archive/20df9f5a9c2db602ea84dd7dcd299f833238b8b5.tar.gz",
-      "hash": "sha256-hzdlqtZfM196EUmtemYZSw6oh9Zps2MxcoXWZemgqhg="
+      "revision": "f5b1070cf540c30280326c444e4eeb5c27bae469",
+      "url": "https://github.com/juspay/kolu/archive/f5b1070cf540c30280326c444e4eeb5c27bae469.tar.gz",
+      "hash": "sha256-KsGOsqiXJ0KnOO7mttODWtQXcD0DP4gtRYxSm1NOi4o="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
This is the paired drishti PR for **kolu #1604** required by kolu's `.claude/rules/surface.md` gate: any API-facing change to `packages/surface*` must ship with a drishti PR that updates drishti for the change and passes full CI against the final kolu HEAD.

## What kolu #1604 changes

kolu #1604 adds an **additive** public export — `mirrorOnce` / `MirrorOnceOptions` — to `@kolu/surface-nix-host` (`packages/surface-nix-host/src/index.ts` + `hostFanout.ts`). The change is purely additive:

- `pumpRemoteSurface`'s signature is unchanged.
- drishti never imports `mirrorOnce`.

So drishti's own source needs **no code change** — this PR is a kolu-pin bump plus a CI-green confirmation against the new `surface-nix-host`.

## What this PR does

- Bumps the npins kolu pin (`npins/sources.json`) to the final kolu R9a HEAD `f5b1070cf540c30280326c444e4eeb5c27bae469` (hash recomputed by `npins`, not hand-edited).

Local `just typecheck` is green against the new pin; full odu CI (x86_64-linux + aarch64-darwin) confirmed green on the PR.

Pairs with: https://github.com/juspay/kolu/pull/1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
