### PR TITLE
chore(npins): bump kolu — validate surface-app precompressed static (juspay/kolu#1643)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "bundle-compression",
+      "branch": "master",
       "submodules": false,
-      "revision": "fc011346fd7e9c7d2bc237cb0c410ddd4d0e6cad",
-      "url": "https://github.com/juspay/kolu/archive/fc011346fd7e9c7d2bc237cb0c410ddd4d0e6cad.tar.gz",
+      "revision": "4703fa4b75ecb63cab80d96c135002746d867b33",
+      "url": "https://github.com/juspay/kolu/archive/4703fa4b75ecb63cab80d96c135002746d867b33.tar.gz",
       "hash": "sha256-lKRwH0ChL2PH/GiG+K0TB9+vv3IK8m3ef/91+zOukpg="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "bundle-compression",
       "submodules": false,
-      "revision": "8eb6a69e117cfaf49f203bc76e8696fc82a667b3",
-      "url": "https://github.com/juspay/kolu/archive/8eb6a69e117cfaf49f203bc76e8696fc82a667b3.tar.gz",
-      "hash": "sha256-sQwrNZpSrIaeq3lL8ooSFE3wV2qOoZrkoNANSYZJD20="
+      "revision": "fc011346fd7e9c7d2bc237cb0c410ddd4d0e6cad",
+      "url": "https://github.com/juspay/kolu/archive/fc011346fd7e9c7d2bc237cb0c410ddd4d0e6cad.tar.gz",
+      "hash": "sha256-lKRwH0ChL2PH/GiG+K0TB9+vv3IK8m3ef/91+zOukpg="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Companion PR for **juspay/kolu#1643** (*serve the client bundle compressed*), per `.claude/rules/surface.md` — any API-facing change to `@kolu/surface-app` must be re-validated against a drishti PR that passes CI at the **final** kolu HEAD.

Bumps the npins `kolu` pin to `fc011346f` (the kolu PR's post-gauntlet HEAD). The surface-app change:
- adds serve-static `precompressed` negotiation to `installFreshStatic`, **scoped to the immutable asset prefix** (`${assetPrefix}*`) so the `no-store` shell can never be served compressed;
- adds two **additive** exports (`DEFAULT_ASSET_PREFIX`, `DEFAULT_SHELL_PATHS`);
- fails fast if a caller's `assetPrefix` would capture the shell.

It is **backward-compatible**: drishti emits no `.br`/`.gz` siblings, so responses are byte-identical identity, and drishti uses the default `assetPrefix` (no throw). No drishti wiring change is needed — this pin bump exists only to prove the shared surface API still builds drishti green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)