### PR TITLE
chore(npins): bump kolu to W2.1 HEAD + adopt mirrorCollection.initialKeys (juspay/kolu#1661)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "W2.1",
+      "branch": "master",
       "submodules": false,
-      "revision": "46dc0fb34aca550fe957b985035e7b357f242d9f",
-      "url": "https://github.com/juspay/kolu/archive/46dc0fb34aca550fe957b985035e7b357f242d9f.tar.gz",
+      "revision": "7e7a5b4f14f47e04eb8cae6973e70337894111a0",
+      "url": "https://github.com/juspay/kolu/archive/7e7a5b4f14f47e04eb8cae6973e70337894111a0.tar.gz",
       "hash": "sha256-FimOPd+NhtXP6XOUdqSpeXYn620/a4WPqz1PYX2W9n8="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "W2.1",
       "submodules": false,
-      "revision": "4703fa4b75ecb63cab80d96c135002746d867b33",
-      "url": "https://github.com/juspay/kolu/archive/4703fa4b75ecb63cab80d96c135002746d867b33.tar.gz",
-      "hash": "sha256-lKRwH0ChL2PH/GiG+K0TB9+vv3IK8m3ef/91+zOukpg="
+      "revision": "46dc0fb34aca550fe957b985035e7b357f242d9f",
+      "url": "https://github.com/juspay/kolu/archive/46dc0fb34aca550fe957b985035e7b357f242d9f.tar.gz",
+      "hash": "sha256-FimOPd+NhtXP6XOUdqSpeXYn620/a4WPqz1PYX2W9n8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -283,17 +283,25 @@ export function buildRouter(opts: BuildRouterOptions) {
         },
         collections: {
           // Small-N per-key collections — the path the private collection
-          // engine drives (keys stream + per-key value streams).
+          // engine drives (keys stream + per-key value streams). `coreCache` /
+          // `netCache` outlive the per-spawn sink (they're minted once above),
+          // so a core/iface that vanished while the ssh link was down would
+          // survive as a ghost row across the reconnect. `initialKeys` hands the
+          // fresh mirror this spawn's carry-over keys; its first `keys` frame
+          // prunes any the snapshot omits — no stale row, no empty flash
+          // (kolu #1661; mirrors surface-nix-host's reServeSurface).
           cpuCores: {
             upsert: (key, value) =>
               fragment.ctx.collections.cpuCores.upsert(key, value),
             remove: (key) => fragment.ctx.collections.cpuCores.remove(key),
+            initialKeys: () => new Set(coreCache.keys()),
           },
           networkInterfaces: {
             upsert: (key, value) =>
               fragment.ctx.collections.networkInterfaces.upsert(key, value),
             remove: (key) =>
               fragment.ctx.collections.networkInterfaces.remove(key),
+            initialKeys: () => new Set(netCache.keys()),
           },
         },
         streams: {


### PR DESCRIPTION
Pins the kolu npins source to PR [juspay/kolu#1661](https://github.com/juspay/kolu/pull/1661)'s final HEAD `46dc0fb34aca550fe957b985035e7b357f242d9f` (branch `W2.1`), the paired-drishti gate for that PR's `@kolu/surface` change.

## The kolu change being gated

`SurfaceSink.collections.<k>` gained an additive, optional `initialKeys?: () => Iterable<K>` hook. On the **first** fresh `keys` frame of a mirror, any carry-over key the snapshot omits is pruned via `onRemove` — reconciling a collection key that departed while the link was down. It's purely additive: a sink that doesn't pass `initialKeys` is byte-identical to before, so the re-pin alone keeps CI green.

## What drishti does with it (a real second-consumer proof, not just a re-pin)

drishti's parent re-serves its agent's collections through `pumpRemoteSurface`'s per-spawn `makeSink` (`packages/app/src/server/router.ts`). Two of its collections ride a **collection sink** backed by a cache that outlives the per-spawn sink (`cpuCores` → `coreCache`, `networkInterfaces` → `netCache`, both minted once per `buildRouter`). Without reconcile, a CPU core or network interface that vanished while the ssh link was down survived as a **ghost row** across the reconnect.

This PR adopts `initialKeys: () => new Set(<cache>.keys())` on both of those sinks, mirroring exactly what kolu's own `surface-nix-host/src/reServeSurface.ts` does — so the fresh snapshot prunes the departed key with no stale row and no empty flash.

`processes` is intentionally **not** touched: it rides the bulk `processesSnapshot` stream (not a keyed collection sink) and already reconciles on each snapshot frame via `applySnapshotMessage`. There is nothing to adopt there.

## Verification

- `just typecheck` — green (common, agent, app).
- `just test` — 142 pass / 0 fail.
- drishti CI on both platforms (x86_64-linux + aarch64-darwin) — see checks.

Refs juspay/kolu#1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
