### PR TITLE
chore(npins): bump kolu to W2.2 HEAD (juspay/kolu W2.2 cutover)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "W2.2",
       "submodules": false,
-      "revision": "7e7a5b4f14f47e04eb8cae6973e70337894111a0",
-      "url": "https://github.com/juspay/kolu/archive/7e7a5b4f14f47e04eb8cae6973e70337894111a0.tar.gz",
-      "hash": "sha256-FimOPd+NhtXP6XOUdqSpeXYn620/a4WPqz1PYX2W9n8="
+      "revision": "ab1619237323497d72415f7a9bd15a821d02bfb1",
+      "url": "https://github.com/juspay/kolu/archive/ab1619237323497d72415f7a9bd15a821d02bfb1.tar.gz",
+      "hash": "sha256-/SwCQB89gtlNeM7BU/BC/znJEwL3gggBptiJ7980HPA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "W2.2",
       "submodules": false,
-      "revision": "316863b5c7b9b311ecd0f24fa2009037439d7cb2",
-      "url": "https://github.com/juspay/kolu/archive/316863b5c7b9b311ecd0f24fa2009037439d7cb2.tar.gz",
-      "hash": "sha256-njLcmrVwkI29D7H22m/CRE3dohTitKDUmGHbFn2CQGg="
+      "revision": "0e51baeb7eb650d80308e4a63b1046ce1a742d7b",
+      "url": "https://github.com/juspay/kolu/archive/0e51baeb7eb650d80308e4a63b1046ce1a742d7b.tar.gz",
+      "hash": "sha256-zqQohs5NLWJBoPmIjMcz+hBaF8vIqdkkfIAMsRGzzZU="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "W2.2",
+      "branch": "master",
       "submodules": false,
-      "revision": "0e51baeb7eb650d80308e4a63b1046ce1a742d7b",
-      "url": "https://github.com/juspay/kolu/archive/0e51baeb7eb650d80308e4a63b1046ce1a742d7b.tar.gz",
-      "hash": "sha256-zqQohs5NLWJBoPmIjMcz+hBaF8vIqdkkfIAMsRGzzZU="
+      "revision": "590f49e48b6e784bdb077987074fc4de0367732e",
+      "url": "https://github.com/juspay/kolu/archive/590f49e48b6e784bdb077987074fc4de0367732e.tar.gz",
+      "hash": "sha256-u6w7Li4h7PZtKUiq3EC5V+VIo3mq7wc0IXmbtJ5Gsio="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "W2.2",
       "submodules": false,
-      "revision": "ab1619237323497d72415f7a9bd15a821d02bfb1",
-      "url": "https://github.com/juspay/kolu/archive/ab1619237323497d72415f7a9bd15a821d02bfb1.tar.gz",
-      "hash": "sha256-/SwCQB89gtlNeM7BU/BC/znJEwL3gggBptiJ7980HPA="
+      "revision": "316863b5c7b9b311ecd0f24fa2009037439d7cb2",
+      "url": "https://github.com/juspay/kolu/archive/316863b5c7b9b311ecd0f24fa2009037439d7cb2.tar.gz",
+      "hash": "sha256-njLcmrVwkI29D7H22m/CRE3dohTitKDUmGHbFn2CQGg="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Bumps drishti's npins kolu pin from master (`7e7a5b4`) to the **W2.2 branch HEAD** (`ab1619237`, juspay/kolu), validating W2.2's `@kolu/surface*` changes against drishti's consumers.

This is the paired drishti PR required by kolu's `.claude/rules/surface.md` gate: any API-facing change to `@kolu/surface` / `@kolu/surface-app` / `@kolu/surface-nix-host` needs a drishti PR that bumps the pin and passes full CI on both platforms.

## What changed in kolu W2.2

The surface-library deltas this cycle are **additive / non-breaking**:

- **`packages/surface/src/server.ts`** — a new *optional* `CellForward<T, P>` type plus `CellHandlerDeps.forward` / `CellImplDeps.forward` fields (existing dep objects unaffected); and `InMemoryChannelOptions` + `ChannelOverflowError`, with `inMemoryChannel` / `inMemoryPublisher` / `inMemoryChannelByName` gaining an *optional* trailing options arg. **Default behavior is unchanged / unbounded** — drishti calls these with no options, so it observes no behavior change.
- **`packages/surface-nix-host`** — internal changes to `reServeSurface.ts` + `relayStream.ts` (the padi "cutover": bind padi, re-serve, delete in-process serving). drishti does **not** consume `reServeSurface` / `relayStream`; its surface-nix-host consumers are `pumpRemoteSurface`, `mirroredSurface`, `mirrorCollection.initialKeys`, `destroyAllSessions`, `resolveSystem`, `getHostSession`, `buildHostRegistry`, `seedConnectionCell`, and the connection types.

## Consumer impact

**None.** Local `just typecheck` is green across `common` / `agent` / `app`, and no drishti source change was needed — the new kolu APIs are purely additive and drishti's call sites are unaffected.

## Pairing

Pairs kolu's **W2.2** branch work (juspay/kolu branch `W2.2`). The kolu PR number is not final yet — it will be linked here once opened.

> [!IMPORTANT]
> The pin here is `ab1619237` — the **pre-gauntlet** W2.2 HEAD. kolu's review gauntlet (lens / codex / police) and CI fix-commits routinely reshape the shared surface API *after* the gate first passes. This pin must be **re-bumped to kolu's final W2.2 HEAD** and CI re-confirmed green there before the gate is satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
