### PR TITLE
chore: consume kolu's surface-rebind fix (kolu #1683)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "fix/surface-rebind-frame-drop",
       "submodules": false,
-      "revision": "590f49e48b6e784bdb077987074fc4de0367732e",
-      "url": "https://github.com/juspay/kolu/archive/590f49e48b6e784bdb077987074fc4de0367732e.tar.gz",
-      "hash": "sha256-u6w7Li4h7PZtKUiq3EC5V+VIo3mq7wc0IXmbtJ5Gsio="
+      "revision": "5d2ac5683d7775f62e7b06bd32ffbcb3a86bd6a9",
+      "url": "https://github.com/juspay/kolu/archive/5d2ac5683d7775f62e7b06bd32ffbcb3a86bd6a9.tar.gz",
+      "hash": "sha256-njuja8mZPqcV4/DFytEg7/x6QXATMv28PH5ZTG3AyJ4="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Paired with **[juspay/kolu#1683](https://github.com/juspay/kolu/pull/1683)** per kolu's `.claude/rules/surface.md` gate — any `@kolu/surface*` change needs a drishti PR that consumes it and passes full CI.

kolu #1683 fixes two `@kolu/surface`-stack framework gaps a padi drain→respawn rebind exposes:

1. **A standing client subscription now re-subscribes on a clean server-side stream completion**, not only on a transport drop — so a re-served surface that the server completes and re-opens across a rebind keeps delivering (the gray Kaval chip, [kolu#1681](https://github.com/juspay/kolu/issues/1681)). `createSubscription` / `createReactiveSubscription` keep their signatures.
2. **The re-serve's cell fold forces one republish past the `equals` de-dup gate on a rebind** — the server-internal cell setter gains an optional `set(v, { force })`; the change is additive.

Both are **backward-compatible**, so drishti consumes them **unchanged** — this is a pin bump that validates drishti's `pumpRemoteSurface`/`implementSurface` server and its `createSubscription` client against the new surface source via typecheck + the nix build lane.

The pin will be bumped to kolu #1683's **final** HEAD (post review-gauntlet) before either side merges, per the surface.md re-validation clause.