### PR TITLE
chore: consume kolu's gray-chip fix (kolu #1687)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "fix/surface-boot-window-subscription",
       "submodules": false,
-      "revision": "d8d26e67624c245a986a912fb2447d1ad926d9d8",
-      "url": "https://github.com/juspay/kolu/archive/d8d26e67624c245a986a912fb2447d1ad926d9d8.tar.gz",
-      "hash": "sha256-6ta/8JhCdiDE9FZJpPW1cC/2ICYvJIjhyV/jGsv8gDc="
+      "revision": "e01cc8ea8f8e7e841d147d9af04047eb8dccf7b1",
+      "url": "https://github.com/juspay/kolu/archive/e01cc8ea8f8e7e841d147d9af04047eb8dccf7b1.tar.gz",
+      "hash": "sha256-yPX8IqNFw/UGIflaDJrT+cPxa3SPnNOxpYoyX0u2vLU="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "fix/surface-boot-window-subscription",
+      "branch": "master",
       "submodules": false,
-      "revision": "e01cc8ea8f8e7e841d147d9af04047eb8dccf7b1",
-      "url": "https://github.com/juspay/kolu/archive/e01cc8ea8f8e7e841d147d9af04047eb8dccf7b1.tar.gz",
+      "revision": "c97aac812e753c8c3c4561cf9043856247d044da",
+      "url": "https://github.com/juspay/kolu/archive/c97aac812e753c8c3c4561cf9043856247d044da.tar.gz",
       "hash": "sha256-yPX8IqNFw/UGIflaDJrT+cPxa3SPnNOxpYoyX0u2vLU="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "fix/surface-boot-window-subscription",
       "submodules": false,
-      "revision": "590f49e48b6e784bdb077987074fc4de0367732e",
-      "url": "https://github.com/juspay/kolu/archive/590f49e48b6e784bdb077987074fc4de0367732e.tar.gz",
-      "hash": "sha256-u6w7Li4h7PZtKUiq3EC5V+VIo3mq7wc0IXmbtJ5Gsio="
+      "revision": "ac9ed53603c7deb06193bd138f6265b7e69deeea",
+      "url": "https://github.com/juspay/kolu/archive/ac9ed53603c7deb06193bd138f6265b7e69deeea.tar.gz",
+      "hash": "sha256-pFB/idAotoqg9OPWd2EKirRcL7+rKdxQL4GhQSJc2ZQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "fix/surface-boot-window-subscription",
       "submodules": false,
-      "revision": "ac9ed53603c7deb06193bd138f6265b7e69deeea",
-      "url": "https://github.com/juspay/kolu/archive/ac9ed53603c7deb06193bd138f6265b7e69deeea.tar.gz",
-      "hash": "sha256-pFB/idAotoqg9OPWd2EKirRcL7+rKdxQL4GhQSJc2ZQ="
+      "revision": "d8d26e67624c245a986a912fb2447d1ad926d9d8",
+      "url": "https://github.com/juspay/kolu/archive/d8d26e67624c245a986a912fb2447d1ad926d9d8.tar.gz",
+      "hash": "sha256-6ta/8JhCdiDE9FZJpPW1cC/2ICYvJIjhyV/jGsv8gDc="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Paired with **[juspay/kolu#1687](https://github.com/juspay/kolu/pull/1687)** per kolu's `.claude/rules/surface.md` gate.

kolu #1687 fixes the gray Kaval chip after a fresh server start (reproduced on a pu box against a real browser):

1. **A per-key collection `get` for a not-yet-existing key now HOLDS OPEN** (subscribe-before-snapshot, yields the moment the key appears) instead of throwing `"key not found at first snapshot"` — a throw that reached the browser as a non-retriable `ORPCError` and killed the standing subscription, so a key born after boot never reached the consumer until a page reload.
2. **The re-serve's cell fold can `{ force }` past the `equals` dedup** on a rebind epoch — the ctx cell setter gains an *optional* `{ force }`.

Both are **backward-compatible** (no consumer API removed; `get`'s change is a runtime held-open semantic; the ctx setter's new param is optional), so drishti consumes them **unchanged** — this is a pin bump that validates drishti's `pumpRemoteSurface`/`implementSurface` server (its `processes`/`cpuCores`/`networkInterfaces` collections now inherit the held-open `get`) and its `createSubscription` client against the new surface source via typecheck + the nix build lane.

The pin will be bumped to kolu #1687's **final** HEAD (post review-gauntlet) before either side merges, per the surface.md re-validation clause.