### PR TITLE
refactor: consume kolu's surface-hosting simplification (makeSession + system.identity)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "refactor/surface-hosting-simplify",
       "submodules": false,
-      "revision": "08c2c29c48c5427e28a2363529204b69bc9c6db3",
-      "url": "https://github.com/juspay/kolu/archive/08c2c29c48c5427e28a2363529204b69bc9c6db3.tar.gz",
-      "hash": "sha256-FZK4mqxY484WY6I8n+nrrhL3KNf9Px78YFImjAnWqNk="
+      "revision": "c0c899a804a00c964b19255c90a4595874398284",
+      "url": "https://github.com/juspay/kolu/archive/c0c899a804a00c964b19255c90a4595874398284.tar.gz",
+      "hash": "sha256-5ae4egg9iBQseuRQ4NttNrM4sJbxR7g30VtbrWtfEL0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "refactor/surface-hosting-simplify",
       "submodules": false,
-      "revision": "1ae5a885f7ed5cba4d7b902183bf37df33c464c5",
-      "url": "https://github.com/juspay/kolu/archive/1ae5a885f7ed5cba4d7b902183bf37df33c464c5.tar.gz",
-      "hash": "sha256-9CFwwo0B8dK5r1yDmmpYIoFPm5NGo/oLFw9iYmbRRmU="
+      "revision": "8c6873fb77d56c4ae662ef6df9a5f5db0a669ed6",
+      "url": "https://github.com/juspay/kolu/archive/8c6873fb77d56c4ae662ef6df9a5f5db0a669ed6.tar.gz",
+      "hash": "sha256-/jrxzB3f1ALDnYS0IIspd1RIu0LkpAgqrDTdQ7+NfIs="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "refactor/surface-hosting-simplify",
       "submodules": false,
-      "revision": "c97aac812e753c8c3c4561cf9043856247d044da",
-      "url": "https://github.com/juspay/kolu/archive/c97aac812e753c8c3c4561cf9043856247d044da.tar.gz",
-      "hash": "sha256-yPX8IqNFw/UGIflaDJrT+cPxa3SPnNOxpYoyX0u2vLU="
+      "revision": "1ae5a885f7ed5cba4d7b902183bf37df33c464c5",
+      "url": "https://github.com/juspay/kolu/archive/1ae5a885f7ed5cba4d7b902183bf37df33c464c5.tar.gz",
+      "hash": "sha256-9CFwwo0B8dK5r1yDmmpYIoFPm5NGo/oLFw9iYmbRRmU="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "refactor/surface-hosting-simplify",
+      "branch": "master",
       "submodules": false,
-      "revision": "c0c899a804a00c964b19255c90a4595874398284",
-      "url": "https://github.com/juspay/kolu/archive/c0c899a804a00c964b19255c90a4595874398284.tar.gz",
-      "hash": "sha256-5ae4egg9iBQseuRQ4NttNrM4sJbxR7g30VtbrWtfEL0="
+      "revision": "59ab99b358bf4c55205f2ab8d4ce8ca1462311df",
+      "url": "https://github.com/juspay/kolu/archive/59ab99b358bf4c55205f2ab8d4ce8ca1462311df.tar.gz",
+      "hash": "sha256-RL9vmDzauV0Nd8dTowehj4RoXau0IPhAbdybnYKIspY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "refactor/surface-hosting-simplify",
       "submodules": false,
-      "revision": "8c6873fb77d56c4ae662ef6df9a5f5db0a669ed6",
-      "url": "https://github.com/juspay/kolu/archive/8c6873fb77d56c4ae662ef6df9a5f5db0a669ed6.tar.gz",
-      "hash": "sha256-/jrxzB3f1ALDnYS0IIspd1RIu0LkpAgqrDTdQ7+NfIs="
+      "revision": "dc298b997ed47a61e4da801b516f754689ba7346",
+      "url": "https://github.com/juspay/kolu/archive/dc298b997ed47a61e4da801b516f754689ba7346.tar.gz",
+      "hash": "sha256-5r+rfpWVIFGIpuGD0jcmzsnOFgMRvUaxoln36maasi4="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "refactor/surface-hosting-simplify",
       "submodules": false,
-      "revision": "dc298b997ed47a61e4da801b516f754689ba7346",
-      "url": "https://github.com/juspay/kolu/archive/dc298b997ed47a61e4da801b516f754689ba7346.tar.gz",
-      "hash": "sha256-5r+rfpWVIFGIpuGD0jcmzsnOFgMRvUaxoln36maasi4="
+      "revision": "08c2c29c48c5427e28a2363529204b69bc9c6db3",
+      "url": "https://github.com/juspay/kolu/archive/08c2c29c48c5427e28a2363529204b69bc9c6db3.tar.gz",
+      "hash": "sha256-FZK4mqxY484WY6I8n+nrrhL3KNf9Px78YFImjAnWqNk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/hostRegistry.ts
+++ b/packages/app/src/server/hostRegistry.ts
@@ -2,8 +2,8 @@
  * Per-host session + handler registry — single source of truth for
  * "which hosts this parent server knows about". Owns:
  *
- *   - One `HostSession` per host (via the kolu pool, keyed by
- *     `(host, binary)`).
+ *   - One `Session` per host (`makeSession` over an `sshConnector`
+ *     transport plug, keyed by host).
  *   - One `RPCHandler` per host (built from `buildRouter({session})`).
  *   - The set of open browser WebSockets per host (for eviction on
  *     remove — partysocket auto-reconnects, so we close on the server
@@ -25,8 +25,8 @@
  * pulam-web's terminal-awareness server can share it. drishti keeps a
  * THIN wrapper here: it owns only the app-specific knowledge the shared
  * registry deliberately doesn't hold — how a host becomes a `{ session,
- * handler }` (`buildEntry`: `getHostSession` + `buildRouter` + `new
- * RPCHandler`), where the host set persists (`saveHosts`), and the
+ * handler }` (`buildEntry`: `makeSession`/`sshConnector` + `buildRouter` +
+ * `new RPCHandler`), where the host set persists (`saveHosts`), and the
  * admin-surface wire-shape projection (`snapshot()`). The wrapper's async
  * signature and `resolveDrvPath`/`hostsFile` options are preserved so
  * `main.ts` and `admin-router.ts` call it exactly as before.
@@ -34,9 +34,13 @@
 
 import { RPCHandler } from "@orpc/server/ws";
 import {
+  type AgentClient,
   buildHostRegistry as buildSharedHostRegistry,
-  getHostSession,
+  type FleetControls,
   type HostRegistry as SharedHostRegistry,
+  makeSession,
+  type Session,
+  sshConnector,
 } from "@kolu/surface-nix-host";
 import type { WebSocket as WsConn } from "ws";
 import type { HostEntry } from "../common/admin-surface";
@@ -97,6 +101,10 @@ export interface HostRegistry {
   recheckAll(): void;
   registerConnection(host: string, ws: WsConn): void;
   unregisterConnection(host: string, ws: WsConn): void;
+  /** Destroy every host's session — called from the server's `shutdown()`.
+   *  Replaces the deleted free-standing `destroyAllSessions()`: sessions are
+   *  no longer pooled, so teardown runs through the registry that owns them. */
+  destroyAll(): void;
 }
 
 export interface HostRegistryOptions {
@@ -115,40 +123,59 @@ export async function buildHostRegistry(
   // The shared registry owns the keyed map + its full lifecycle. drishti
   // supplies only `buildEntry` (how a host becomes a session + handler)
   // and `persist` (where the host set lands on disk). Both stay SYNC for
-  // `buildEntry`: `getHostSession` defers the spawn into the session's own
+  // `buildEntry`: `makeSession` defers the spawn into the session's own
   // reconnect machinery, so a host unreachable at boot surfaces as a
   // per-host `failed` connection state — never a throw that takes the
   // whole registry (and with it the parent's HTTP port, never bound until
   // this resolves) down.
-  const shared: SharedHostRegistry<typeof surface.contract, DrishtiHandler> =
-    buildSharedHostRegistry({
-      initialHosts: opts.initialHosts,
-      buildEntry: (host) => {
-        const session = getHostSession<typeof surface.contract>({
+  const shared: SharedHostRegistry<
+    Session<AgentClient<typeof surface.contract>>,
+    DrishtiHandler
+  > &
+    FleetControls = buildSharedHostRegistry({
+    initialHosts: opts.initialHosts,
+    buildEntry: (host) => {
+      // `makeSession` over an `sshConnector` transport plug (kolu S9/S10 —
+      // the deleted `getHostSession` is now this composition). The connector
+      // owns everything transport-specific (resolve .drv per dial, nix copy,
+      // spawn ssh, wire stdio to a typed client); `makeSession` owns the
+      // durable lifecycle (pin/ref-count, backoff, give-up, watchdogs,
+      // reconnect/recheck, the connection-state cell). The agent .drv is
+      // resolved LAZILY inside the connector's dial (not awaited here): a host
+      // unreachable at probe time makes the resolver reject, which the loop
+      // treats as an ordinary connection failure (disconnected → backoff →
+      // failed, re-armable via Reconnect) — so it can't throw out of here
+      // before the session exists, and one unreachable initial host can't
+      // crash the whole server at boot.
+      const session = makeSession<AgentClient<typeof surface.contract>>({
+        connectOnce: sshConnector<typeof surface.contract>({
           host,
-          // Resolve the agent .drv lazily, inside the session's spawn
-          // cycle, rather than awaiting the arch probe here. A host that's
-          // unreachable at probe time makes the resolver reject, which the
-          // session treats as an ordinary connection failure (disconnected
-          // → backoff → failed, re-armable via Reconnect) — so it can't
-          // throw out of here before the session exists. That's what keeps
-          // one unreachable initial host from crashing the whole server at
-          // boot.
-          resolveDrvPath: () => opts.resolveDrvPath(host),
           binary: "drishti-agent",
-          connectTimeoutMs: CONNECT_TIMEOUT_MS,
-        });
-        const { router } = buildRouter({ host, session });
-        // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
-        const handler = new RPCHandler(router as any);
-        return { session, handler };
-      },
-      // Persist after every add/remove, awaited before the call resolves
-      // (the shared registry guarantees the ordering) — so the admin
-      // router's announce never races ahead of the on-disk store.
-      persist: (hosts) => saveHosts(opts.hostsFile, hosts),
-      log: (line) => log(line),
-    });
+          resolveDrvPath: () => opts.resolveDrvPath(host),
+        }),
+        connectTimeoutMs: CONNECT_TIMEOUT_MS,
+        label: `host:${host}`,
+      });
+      const { router } = buildRouter({ host, session });
+      // biome-ignore lint/suspicious/noExplicitAny: implementSurface's Lazy<Router> spread isn't accepted by oRPC's Router<any, T> input type; runtime shape is valid.
+      const handler = new RPCHandler(router as any);
+      return { session, handler };
+    },
+    // Fleet verbs (`reconnect(host)` / `recheckAll()`) exist on the returned
+    // registry ONLY when `controls` is supplied (kolu S2) — they're how the
+    // registry enacts a re-arm / link-recheck on each session. The `Session`
+    // that `makeSession` returns carries universal `reconnect()` / `recheck()`
+    // methods, so these thunks typecheck directly.
+    controls: {
+      reconnect: (s) => s.reconnect(),
+      recheck: (s) => s.recheck(),
+    },
+    // Persist after every add/remove, awaited before the call resolves
+    // (the shared registry guarantees the ordering) — so the admin
+    // router's announce never races ahead of the on-disk store.
+    persist: (hosts) => saveHosts(opts.hostsFile, hosts),
+    log: (line) => log(line),
+  });
 
   return {
     has: (host) => shared.has(host),
@@ -172,5 +199,6 @@ export async function buildHostRegistry(
     // through without a cast.
     registerConnection: (host, ws) => shared.registerConnection(host, ws),
     unregisterConnection: (host, ws) => shared.unregisterConnection(host, ws),
+    destroyAll: () => shared.destroyAll(),
   };
 }

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -27,7 +27,6 @@ import { cli } from "cleye";
 import { Hono } from "hono";
 import { WebSocketServer } from "ws";
 import { z } from "zod";
-import { destroyAllSessions } from "@kolu/surface-nix-host";
 import { gateWsOrigin, parseAllowedOrigins } from "@kolu/surface/ws-origin";
 import {
   gateStaleSocket,
@@ -362,7 +361,7 @@ async function main(): Promise<void> {
   const shutdown = (sig: string) => {
     log(`${sig}: destroying host sessions`);
     stopWakeMonitor();
-    destroyAllSessions();
+    registry.destroyAll();
     heartbeat.stop();
     wss.close();
     for (const ws of wss.clients) {

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -38,9 +38,10 @@ import {
 } from "@kolu/surface/server";
 import { type ProcedureForwarders } from "@kolu/surface/mirror";
 import {
-  type HostSession,
+  type AgentClient,
   pumpRemoteSurface,
   seedConnectionCell,
+  type Session,
 } from "@kolu/surface-nix-host";
 import { browserSurface, type ConnectionInfo } from "drishti-common/browser";
 import {
@@ -66,10 +67,10 @@ import { type Logger, makeLogger } from "./log";
 
 export interface BuildRouterOptions {
   /** The host this router bridges — used only to tag the bridge's log
-   *  lines (`bridge:${host}`). `HostSession` keeps its `host` private,
+   *  lines (`bridge:${host}`). The `Session` keeps its `host` private,
    *  so the registry (which has it) passes it in explicitly. */
   host: string;
-  session: HostSession<typeof surface.contract>;
+  session: Session<AgentClient<typeof surface.contract>>;
 }
 
 /** Build the parent's oRPC router. The session's connection state


### PR DESCRIPTION
Paired consumer PR for **juspay/kolu#1705** (the `@kolu/surface` hosting-side simplification, S1–S10 + the reserved `system.identity` member). Both must be two-platform CI-green at pinned heads before either merges — the paired-PR gate, extended to three (kolu · drishti · odu).

## The migration
- `getHostSession`/`HostSession` are deleted → `makeSession({ connectOnce: sshConnector({ host, binary, resolveDrvPath }), connectTimeoutMs })`. `HostSession<C>` → `Session<AgentClient<C>>` (client-parameterized; the dead contract generic dropped at the role boundary).
- `buildHostRegistry` is now session-type-first (`<S extends DestroyableSession, H>`) and gates its fleet verbs behind `controls`. The shared registry is built with `controls: { reconnect: (s) => s.reconnect(), recheck: (s) => s.recheck() }` and typed `& FleetControls`; the wrapper's `reconnect(host)`/`recheckAll()` delegations are otherwise unchanged.
- `destroyAllSessions` (deleted, S10) → the registry's own `destroyAll()`, called from `shutdown()`.
- npins re-pinned to the paired refactor HEAD.

No surface member-set test churn: drishti asserts on `surface.spec.procedures`, and `system.identity` (like `system.live`) is claimed into the contract only, never the spec.

Draft; do not merge until all three PRs are green at the final pinned heads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)