### PR TITLE
refactor: consume kolu's W4 SurfaceAppProvider accessor (juspay/kolu#1708)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "c5f3f3014c6eae114b5524f62b603704501141fc",
-      "url": "https://github.com/juspay/kolu/archive/c5f3f3014c6eae114b5524f62b603704501141fc.tar.gz",
-      "hash": "sha256-CIFHTDbyefV+IGo0kF9LbCqaVuJKV/aYjmf/c/lDhYE="
+      "revision": "e9900fa467a92efe83f3f3384fcd32824c1eed25",
+      "url": "https://github.com/juspay/kolu/archive/e9900fa467a92efe83f3f3384fcd32824c1eed25.tar.gz",
+      "hash": "sha256-BAreFRjvorYf5AUWtB+c31OsLZlwaA5aZAYa84RRBu0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "59ab99b358bf4c55205f2ab8d4ce8ca1462311df",
-      "url": "https://github.com/juspay/kolu/archive/59ab99b358bf4c55205f2ab8d4ce8ca1462311df.tar.gz",
-      "hash": "sha256-RL9vmDzauV0Nd8dTowehj4RoXau0IPhAbdybnYKIspY="
+      "revision": "d7ba2e9a62e5fb5a69184fde3e9c22544662cbf7",
+      "url": "https://github.com/juspay/kolu/archive/d7ba2e9a62e5fb5a69184fde3e9c22544662cbf7.tar.gz",
+      "hash": "sha256-+13qwzG++1A4KQxxL7bqxSyZrsP7qLBJXZHV8j+YKG0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "d7ba2e9a62e5fb5a69184fde3e9c22544662cbf7",
-      "url": "https://github.com/juspay/kolu/archive/d7ba2e9a62e5fb5a69184fde3e9c22544662cbf7.tar.gz",
-      "hash": "sha256-+13qwzG++1A4KQxxL7bqxSyZrsP7qLBJXZHV8j+YKG0="
+      "revision": "5f253e520118252620e8131e03ceb0cc4b263013",
+      "url": "https://github.com/juspay/kolu/archive/5f253e520118252620e8131e03ceb0cc4b263013.tar.gz",
+      "hash": "sha256-Gmy0yzfY+F0mnLXYgLxAeRoYLF3ictRiqK+qL/MKGLo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "e889b8764affb896af77e153b5397c25b3ad615d",
-      "url": "https://github.com/juspay/kolu/archive/e889b8764affb896af77e153b5397c25b3ad615d.tar.gz",
-      "hash": "sha256-PUtrI7cgMJFonMUM8dNCZ5UnWXI/NDF5WOYtr5g3Ogc="
+      "revision": "06640a4918b2e82e19c52a765b94fc95e6e74f9f",
+      "url": "https://github.com/juspay/kolu/archive/06640a4918b2e82e19c52a765b94fc95e6e74f9f.tar.gz",
+      "hash": "sha256-uVSS21Fg3LWI9xFXTxcR/1orrrMosC5t3Nzdx0v/7+A="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "5f253e520118252620e8131e03ceb0cc4b263013",
-      "url": "https://github.com/juspay/kolu/archive/5f253e520118252620e8131e03ceb0cc4b263013.tar.gz",
-      "hash": "sha256-Gmy0yzfY+F0mnLXYgLxAeRoYLF3ictRiqK+qL/MKGLo="
+      "revision": "e889b8764affb896af77e153b5397c25b3ad615d",
+      "url": "https://github.com/juspay/kolu/archive/e889b8764affb896af77e153b5397c25b3ad615d.tar.gz",
+      "hash": "sha256-PUtrI7cgMJFonMUM8dNCZ5UnWXI/NDF5WOYtr5g3Ogc="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "9b6d28943252be6b62fcd9a1dea740f6153d6c19",
-      "url": "https://github.com/juspay/kolu/archive/9b6d28943252be6b62fcd9a1dea740f6153d6c19.tar.gz",
-      "hash": "sha256-xg8J+Sw0mHf/asqQ2Js0SZyNEan8sfiRqCaG/Q/8sIo="
+      "revision": "c5f3f3014c6eae114b5524f62b603704501141fc",
+      "url": "https://github.com/juspay/kolu/archive/c5f3f3014c6eae114b5524f62b603704501141fc.tar.gz",
+      "hash": "sha256-CIFHTDbyefV+IGo0kF9LbCqaVuJKV/aYjmf/c/lDhYE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "06640a4918b2e82e19c52a765b94fc95e6e74f9f",
-      "url": "https://github.com/juspay/kolu/archive/06640a4918b2e82e19c52a765b94fc95e6e74f9f.tar.gz",
-      "hash": "sha256-uVSS21Fg3LWI9xFXTxcR/1orrrMosC5t3Nzdx0v/7+A="
+      "revision": "9b6d28943252be6b62fcd9a1dea740f6153d6c19",
+      "url": "https://github.com/juspay/kolu/archive/9b6d28943252be6b62fcd9a1dea740f6153d6c19.tar.gz",
+      "hash": "sha256-xg8J+Sw0mHf/asqQ2Js0SZyNEan8sfiRqCaG/Q/8sIo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w4-the-switch",
       "submodules": false,
-      "revision": "e9900fa467a92efe83f3f3384fcd32824c1eed25",
-      "url": "https://github.com/juspay/kolu/archive/e9900fa467a92efe83f3f3384fcd32824c1eed25.tar.gz",
-      "hash": "sha256-BAreFRjvorYf5AUWtB+c31OsLZlwaA5aZAYa84RRBu0="
+      "revision": "1ad329ad7b13fd09864e47e01dd24260d2bd60e1",
+      "url": "https://github.com/juspay/kolu/archive/1ad329ad7b13fd09864e47e01dd24260d2bd60e1.tar.gz",
+      "hash": "sha256-WLXLqjGCXJeCw6XpIcI873LaVUVIHbpznZK75iSqDLc="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -353,7 +353,7 @@ function projectHistory(
 export default function App() {
   return (
     <SurfaceAppProvider
-      controlPlane={surfaceAppClient()}
+      controlPlane={surfaceAppClient}
       clientCommit={shellCommit()}
       ws={adminSocket()}
       probe={() => surfaceAppProbe(surfaceAppClient())}


### PR DESCRIPTION
The paired consumer PR for kolu's **W4 "the switch"** ([juspay/kolu#1708](https://github.com/juspay/kolu/pull/1708)) — the `.claude/rules/surface.md` gate.

## What changed in kolu
`SurfaceAppProvider.controlPlane` becomes `Accessor<ControlPlane<T>>` (the ratified S5 shape): a live host switch yields a new client, and the provider tears down the old build-identity stream and re-subscribes — a framework guarantee, so a consumer can't leak the old host's stream.

## Consumer impact
One line: `controlPlane={surfaceAppClient()}` → `controlPlane={surfaceAppClient}`. drishti's `surfaceAppClient` is already accessor-shaped (a lazy admin-client getter), so the adoption is passing the accessor itself instead of its invoked value. drishti's admin control plane is stable across the fleet, so its provider simply never trips the swap — but it compiles + runs green against the new prop type, which is the gate.

Re-pins `npins` to the kolu W4 branch HEAD (`d7ba2e9a62`). **Per the same-SHA gate, this will be re-pinned to kolu master after the kolu PR squash-merges**, and re-confirmed green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)