### PR TITLE
feat(app): adopt @kolu/surface-map scopedByEntry for per-host expanded PID (kolu padi W7 pair)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@orpc/client": "^1.13.13",
         "@orpc/contract": "^1.13.13",
         "@orpc/server": "^1.13.13",
+        "@solid-primitives/keyed": "^1.5.3",
         "@solid-primitives/page-visibility": "^2.1.5",
         "@solid-primitives/scheduled": "^1.5.3",
         "@solidjs/meta": "^0.29.4",
@@ -181,6 +182,8 @@
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
     "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.5", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA=="],
+
+    "@solid-primitives/keyed": ["@solid-primitives/keyed@1.5.3", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-zNadtyYBhJSOjXtogkGHmRxjGdz9KHc8sGGVAGlUABkE8BED2tbIZoxkwSqzOwde8OcUEH0bb5DLZUWIMvyBSA=="],
 
     "@solid-primitives/page-visibility": ["@solid-primitives/page-visibility@2.1.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.5", "@solid-primitives/rootless": "^1.5.3", "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-ttCsV4jI9UVE60B/Ml0e5Fmkf59xO32Kb9VERuKUcO6zqv6MN0rkl9k7JIgbBypZZC62M8PU42CwWRIJWO0g1Q=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -268,6 +268,10 @@
     url = "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.5.tgz";
     hash = "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==";
   };
+  "@solid-primitives/keyed@1.5.3" = fetchurl {
+    url = "https://registry.npmjs.org/@solid-primitives/keyed/-/keyed-1.5.3.tgz";
+    hash = "sha512-zNadtyYBhJSOjXtogkGHmRxjGdz9KHc8sGGVAGlUABkE8BED2tbIZoxkwSqzOwde8OcUEH0bb5DLZUWIMvyBSA==";
+  };
   "@solid-primitives/page-visibility@2.1.5" = fetchurl {
     url = "https://registry.npmjs.org/@solid-primitives/page-visibility/-/page-visibility-2.1.5.tgz";
     hash = "sha512-ttCsV4jI9UVE60B/Ml0e5Fmkf59xO32Kb9VERuKUcO6zqv6MN0rkl9k7JIgbBypZZC62M8PU42CwWRIJWO0g1Q==";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "w7-per-host-ownership",
+      "branch": "master",
       "submodules": false,
-      "revision": "e39cd8e17a39c693a79d8f2a8f0084a731ee97a3",
-      "url": "https://github.com/juspay/kolu/archive/e39cd8e17a39c693a79d8f2a8f0084a731ee97a3.tar.gz",
+      "revision": "2424c934edd5b12b63bd1fce4cc1b6d69d87a189",
+      "url": "https://github.com/juspay/kolu/archive/2424c934edd5b12b63bd1fce4cc1b6d69d87a189.tar.gz",
       "hash": "sha256-sPB2tkIDfDYSXwIRHDCFC2X2mKtk0RNgmRoLJStD5TE="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-map",
+      "branch": "w7-per-host-ownership",
       "submodules": false,
-      "revision": "7d51cb2b290bdcaaabe6522c90152598d162d9bd",
-      "url": "https://github.com/juspay/kolu/archive/7d51cb2b290bdcaaabe6522c90152598d162d9bd.tar.gz",
-      "hash": "sha256-JeO5oKKXwLnrynIY9butaYh8YbpARNycZOK/wPFDhgo="
+      "revision": "d3f23fb9739181ea1077236f8b550d35ef1f517e",
+      "url": "https://github.com/juspay/kolu/archive/d3f23fb9739181ea1077236f8b550d35ef1f517e.tar.gz",
+      "hash": "sha256-a8J4zDe65Xe14LSDDhZAx7TWnI+4JoivmsWnT/Ab27U="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w7-per-host-ownership",
       "submodules": false,
-      "revision": "41d0ee344124c615b1b6d6469a5dc44ec385b264",
-      "url": "https://github.com/juspay/kolu/archive/41d0ee344124c615b1b6d6469a5dc44ec385b264.tar.gz",
-      "hash": "sha256-v80V515K7+3+u+Oqyi9HVIpOWRxFJRZKOEs38DLbuzI="
+      "revision": "e39cd8e17a39c693a79d8f2a8f0084a731ee97a3",
+      "url": "https://github.com/juspay/kolu/archive/e39cd8e17a39c693a79d8f2a8f0084a731ee97a3.tar.gz",
+      "hash": "sha256-sPB2tkIDfDYSXwIRHDCFC2X2mKtk0RNgmRoLJStD5TE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w7-per-host-ownership",
       "submodules": false,
-      "revision": "d3f23fb9739181ea1077236f8b550d35ef1f517e",
-      "url": "https://github.com/juspay/kolu/archive/d3f23fb9739181ea1077236f8b550d35ef1f517e.tar.gz",
-      "hash": "sha256-a8J4zDe65Xe14LSDDhZAx7TWnI+4JoivmsWnT/Ab27U="
+      "revision": "039b2ab283171dbd6cdae0102c29b9532ba5dd93",
+      "url": "https://github.com/juspay/kolu/archive/039b2ab283171dbd6cdae0102c29b9532ba5dd93.tar.gz",
+      "hash": "sha256-NJqhgBfXFQYmZNB1+ZndGdbwKli7ihanLr80jaI2CCc="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "w7-per-host-ownership",
       "submodules": false,
-      "revision": "039b2ab283171dbd6cdae0102c29b9532ba5dd93",
-      "url": "https://github.com/juspay/kolu/archive/039b2ab283171dbd6cdae0102c29b9532ba5dd93.tar.gz",
-      "hash": "sha256-NJqhgBfXFQYmZNB1+ZndGdbwKli7ihanLr80jaI2CCc="
+      "revision": "41d0ee344124c615b1b6d6469a5dc44ec385b264",
+      "url": "https://github.com/juspay/kolu/archive/41d0ee344124c615b1b6d6469a5dc44ec385b264.tar.gz",
+      "hash": "sha256-v80V515K7+3+u+Oqyi9HVIpOWRxFJRZKOEs38DLbuzI="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,6 +16,7 @@
     "@orpc/client": "^1.13.13",
     "@orpc/contract": "^1.13.13",
     "@orpc/server": "^1.13.13",
+    "@solid-primitives/keyed": "^1.5.3",
     "@solid-primitives/page-visibility": "^2.1.5",
     "@solid-primitives/scheduled": "^1.5.3",
     "@solidjs/meta": "^0.29.4",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -925,9 +925,20 @@ function HostView(props: {
   // below also resolves to null mid-tick, but clearing the signal here keeps a
   // later-reused pid from silently re-opening the panel. Tracks only the
   // selected pid's slot (not its fields), so a cpu/mem tick doesn't re-run it.
+  //
+  // Gate on the subscription having yielded its FIRST frame (`!processesSub
+  // .pending()`) — mirroring kolu's `pending()`-gated hydration in
+  // `useSessionRestore.ts`. `processesSub` REMOUNTS on a host switch and starts
+  // at its `initial: {}` (empty) with `pending() === true`; without this gate,
+  // switching back would read the RETAINED per-host `selectedPid` against that
+  // empty first frame and clear it BEFORE the first real snapshot arrives —
+  // silently defeating the scopedByEntry adoption (the expanded PID surviving
+  // tab-away). Once the first snapshot lands, `pending()` latches false and a
+  // genuinely-exited pid still clears against the LOADED table.
   createEffect(() => {
     const pid = selectedPid();
-    if (pid !== null && processes()[pid] === undefined) setSelectedPid(null);
+    if (pid !== null && !processesSub.pending() && processes()[pid] === undefined)
+      setSelectedPid(null);
   });
 
   // Escape closes the panel — the conventional dismiss key, wired once for the

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -32,10 +32,12 @@ import {
   type JSX,
   on,
   onCleanup,
+  type Setter,
   Show,
   type Signal,
   useContext,
 } from "solid-js";
+import { scopedByEntry, type ScopedByEntry } from "@kolu/surface-map/client";
 import {
   type CoreId,
   type CpuCore,
@@ -143,6 +145,15 @@ type ProcessSelection = {
   toggle: (pid: Pid) => void;
 };
 const SelectionContext = createContext<ProcessSelection>();
+
+// One host's per-host VIEW state, owned by the host map's `scopedByEntry` scope
+// (padi W7): the expanded PID lives in the host's OWN reactive scope, retained
+// across a tab switch and disposed when the host leaves the fleet — no longer a
+// `createSignal` reset on every keyed `HostView` remount.
+type HostScope = {
+  selectedPid: Accessor<Pid | null>;
+  setSelectedPid: Setter<Pid | null>;
+};
 
 // Bind a per-host preference to a signal: seed from localStorage and mirror
 // every change back, keyed by host (`defer` skips the redundant write of the
@@ -494,6 +505,23 @@ function MultiHostApp() {
     return v.kind === "host" ? v.host : null;
   });
 
+  // Per-host view state owned BY the host map (padi W7's `scopedByEntry`). Each
+  // host's expanded PID is born in its own reactive scope, RETAINED across a tab
+  // switch (restored verbatim on switch-back), and disposed when the host leaves
+  // the fleet. This replaces the per-`HostView` `createSignal` that reset to
+  // `null` on every keyed remount: "expanded pid lost on tab switch" dissolves
+  // into the scope's retention. `selectedHost` (nullable — the fleet view selects
+  // no host) stays the app-policy "which host is shown"; the framework owns the
+  // per-host lifetime.
+  const hostScopes: ScopedByEntry<string, HostScope> = scopedByEntry(
+    hostMap,
+    selectedHost,
+    () => {
+      const [selectedPid, setSelectedPid] = createSignal<Pid | null>(null);
+      return { selectedPid, setSelectedPid };
+    },
+  );
+
   // Theme is global app chrome (like `view`), so it lives here, not per
   // host. The signal seeds from the attribute the pre-paint bootstrap in
   // index.html already applied; toggling flips the attribute and persists
@@ -624,7 +652,7 @@ function MultiHostApp() {
               }
               keyed
             >
-              {(host) => <HostView host={host} />}
+              {(host) => <HostView host={host} scopes={hostScopes} />}
             </Show>
           </Show>
         </Show>
@@ -797,7 +825,10 @@ function CardMetric(props: { label: string; pct: number; detail: string }) {
 
 // ── Per-host body (the prior single-host App, now parametric) ──────────
 
-function HostView(props: { host: string }) {
+function HostView(props: {
+  host: string;
+  scopes: ScopedByEntry<string, HostScope>;
+}) {
   // `hostMap.entry(...)` is a PURE lens over the ONE admin transport's
   // key-folded link — the same map the tab chip's dot reads. Multiple
   // consumers on one socket is the supported shape; oRPC multiplexes calls
@@ -874,13 +905,19 @@ function HostView(props: { host: string }) {
   );
   const processes = (): Record<Pid, Process> => processesSub() ?? {};
 
-  // Which PID is expanded into the detail panel (null = none). Ephemeral —
-  // not a per-host persisted pref: it's a transient focus, not a setting to
-  // restore across reloads. Cleared when its process exits (the effect just
-  // below) so the panel never has to special-case a vanished pid — the same
-  // "resolve focus against the live set" shape the app-level `resolvedView`
-  // uses when a host disappears.
-  const [selectedPid, setSelectedPid] = createSignal<Pid | null>(null);
+  // Which PID is expanded into the detail panel (null = none). A transient focus,
+  // not a per-host persisted pref — but now OWNED per-host by the host-map scope,
+  // so it survives a tab switch (restored verbatim on switch-back) instead of
+  // resetting. Still cleared when its process exits (the effect just below) so the
+  // panel never has to special-case a vanished pid.
+  // Expanded PID — owned per-host by the host-map scope (survives tab-away). The
+  // active host's scope is stable for this HostView's lifetime (a tab switch
+  // remounts HostView with the new host's scope) and is defined by construction:
+  // HostView only mounts for a live `selectedHost`, which the map has activated.
+  const scope = props.scopes.active();
+  if (scope === undefined)
+    throw new Error("HostView: the active host has no scope");
+  const { selectedPid, setSelectedPid } = scope;
   const toggleSelected = (pid: Pid) =>
     setSelectedPid((cur) => (cur === pid ? null : pid));
 


### PR DESCRIPTION
The **paired consumer PR** for kolu's **padi W7** (`scopedByEntry` — the retained-per-key owner over the host map), per kolu's `.claude/rules/surface.md` framework-gate.

## What
drishti's expanded-PID selection was a per-`HostView` `createSignal` reset to `null` on every keyed remount — **lost on every tab switch**. Under `scopedByEntry(hostMap, selectedHost, …)` it now lives in the host's **own reactive scope**, RETAINED across a tab switch (restored verbatim on switch-back) and disposed when the host leaves the fleet — the shape-B behavior kolu's users have, now framework-owned. The manual "clear on tab switch" (implicit in the keyed remount) dissolves; the pid-exit clear stays.

This is the **demand-proof**: a second, independent consumer of `scopedByEntry`, exercising the same lazy-create / retain-across-switch / dispose-on-membership-exit contract kolu's canvas relies on.

## Changes
- Pins kolu to `w7-per-host-ownership` (`d3f23fb9`) — adds `scopedByEntry` + the `codec` on `SurfaceMapClient`.
- Adds `@solid-primitives/keyed` — `scopedByEntry`'s `keyArray` rides it. **The framework gate surfaced this**: drishti hydrates surface-map's source, so the consumer's own `node_modules` must carry `keyed` for tsc to resolve `keyArray`'s types. (regenerates `bun.nix`.)
- `App.tsx`: `hostScopes = scopedByEntry(hostMap, selectedHost, …)`; `HostView` reads `selectedPid` from the scope instead of minting its own.

## Status
- `typecheck` green; **143 bun tests pass**.
- ⚠️ Draft: full odu CI + re-pin to **final** kolu HEAD land before merge — the `surface.md` gate is CI-green against the *final* kolu commit, and the kolu PR is still pre-gauntlet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)