### PR TITLE
feat(ci): push Nix builds to Juspay's OSS Attic cache

### DIFF
--- a/.claude/skills/nix-oss-cache/SKILL.md
+++ b/.claude/skills/nix-oss-cache/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: nix-oss-cache
+description: Use this when setting up a GitHub repo to push its Nix builds to Juspay's shared OSS Attic cache (cache.nixos.asia/oss) — adds the substituter to flake.nix, a nix-cache.yml GitHub Actions workflow, and prompts for the ATTIC_TOKEN secret.
+---
+
+# Push to Juspay's OSS Nix cache
+
+Wire a GitHub repo into the shared Attic cache at [`cache.nixos.asia/oss`](https://cache.nixos.asia). CI builds the flake's default package on every push to the default branch and pushes the resulting closure, warming both CI and local `nix build`s for everyone. Reference: [juspay/kolu#1731](https://github.com/juspay/kolu/pull/1731), [#1733](https://github.com/juspay/kolu/pull/1733).
+
+Three pieces are needed: the cache as a **substituter** (so the repo _pulls_ from it), a **workflow** (so CI _pushes_ to it), and the **`ATTIC_TOKEN` secret** (so the push authenticates). Do all three.
+
+## Initial setup questionnaire
+
+Before touching any files, use the **Ask tool** (`AskUserQuestion`) to settle the **trigger scope** — which branches should trigger a build-and-push?
+
+- **Default branch only** — push on the default branch (`main`/`master`) plus `pull_request` and `workflow_dispatch`. Warms the cache from merged, reviewed code. Recommended for most repos.
+- **All branches** — push on every branch too, so feature branches warm the cache. Costs more CI minutes and can push closures from unreviewed code.
+
+Assume the user already has an `ATTIC_TOKEN` push token (they obtain it from the cache admin — Juspay infra — via `atticadm make-token`, scoped to the `oss` cache). Don't block on it here; step 3 confirms it's set on the repo and loops until it is.
+
+## 1. Add the cache as a substituter
+
+In the repo's top-level `flake.nix`, add (or extend) `nixConfig`:
+
+```nix
+nixConfig = {
+  extra-substituters = "https://cache.nixos.asia/oss";
+  extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
+};
+```
+
+## 2. Add the workflow
+
+Set the `on:` triggers to match the **trigger scope** answer from the questionnaire. The template below is the default-branch-only variant.
+
+### Already have a `nix build` workflow? Piggyback on it.
+
+If the repo already has a workflow that runs `nix build` (e.g. a CI job), **don't add a second one** — just drop the `ryanccn/attic-action` step into the existing job, *before* the build step, so its end-of-job hook pushes whatever that job builds:
+
+```yaml
+      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+        with:
+          endpoint: https://cache.nixos.asia
+          cache: oss
+          token: ${{ secrets.ATTIC_TOKEN }}
+```
+
+The action pushes every store path realised during the job, so no explicit push step is needed. Only create the standalone `nix-cache.yml` below when there's no existing build job to hook into. (Note: if the existing job uses the DeterminateSystems installer rather than `nix-quick-install-action`, verify attic-action still finds a new-enough Nix for `nix profile add`.)
+
+### Standalone workflow
+
+Create `.github/workflows/nix-cache.yml`. `ryanccn/attic-action` handles install, login, substituter config, and pushing every store path the job produced at job end.
+
+```yaml
+# Build the default package on linux + darwin and push each closure to the
+# shared Attic cache (https://cache.nixos.asia/oss).
+name: nix-cache
+
+on:
+  push:
+    branches: [master]   # set to the repo's default branch
+  pull_request:
+  workflow_dispatch:
+
+# Least privilege — this job only needs the checkout and ATTIC_TOKEN secret.
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest → x86_64-linux; macos-latest → aarch64-darwin.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin by commit (CodeQL: unpinned third-party action). v35 → 9f63be7.
+      # v35 defaults to Nix 2.34.7, new enough for attic-action's `nix profile add`.
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+        with:
+          nix_conf: |
+            extra-substituters = https://cache.nixos.asia/oss
+            extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
+            accept-flake-config = true
+
+      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+        with:
+          endpoint: https://cache.nixos.asia
+          cache: oss
+          token: ${{ secrets.ATTIC_TOKEN }}
+
+      - name: Build
+        run: nix build -L --print-out-paths
+```
+
+Rules:
+
+- For **default branch only**, set the `push.branches` filter to the repo's actual default branch (kolu uses `master`; many repos use `main`). For **all branches**, drop the `branches:` filter so `push:` fires everywhere.
+- Keep both actions **pinned by commit SHA** (CodeQL flags unpinned third-party actions). The `# v35` / `# v0.5.0` trailing comments record the tag. Prefer the SHAs above unless a newer release is needed; do not replace them with floating tags.
+
+## 3. Set the ATTIC_TOKEN secret
+
+The token is a repo secret you can't set for the user — it's their token, entered interactively so it stays out of shell history. **Give them this command and ask them to run it**, then confirm:
+
+```bash
+gh secret set ATTIC_TOKEN --repo <owner>/<repo>
+```
+
+`gh` prompts for the value interactively (never paste the token into a command line that gets logged). After they say they've run it, **re-check** and **re-ask until it's present**:
+
+```bash
+gh secret list --repo <owner>/<repo>   # ATTIC_TOKEN should appear
+```
+
+If it's missing, tell them and ask again — loop until `gh secret list` shows `ATTIC_TOKEN`. The workflow fails loudly without this secret; there is no silent skip.
+
+## Verify
+
+Push to the default branch (or trigger via **Actions → nix-cache → Run workflow**). A green run means the closure was pushed. To confirm the pull side works, on another machine run `nix build` and check the log shows paths fetched from `cache.nixos.asia/oss`.

--- a/.claude/skills/nix-oss-cache/SKILL.md
+++ b/.claude/skills/nix-oss-cache/SKILL.md
@@ -121,6 +121,29 @@ gh secret list --repo <owner>/<repo>   # ATTIC_TOKEN should appear
 
 If it's missing, tell them and ask again — loop until `gh secret list` shows `ATTIC_TOKEN`. The workflow fails loudly without this secret; there is no silent skip.
 
-## Verify
+## 4. Open a PR
 
-Push to the default branch (or trigger via **Actions → nix-cache → Run workflow**). A green run means the closure was pushed. To confirm the pull side works, on another machine run `nix build` and check the log shows paths fetched from `cache.nixos.asia/oss`.
+Commit the `flake.nix` and workflow changes on a branch and open a PR:
+
+```bash
+gh pr create --title "Push Nix builds to the OSS Attic cache" --body "..."
+```
+
+The workflow's `pull_request` trigger means the run fires on the PR itself, so you get a green/red signal before merge — no need to merge blind.
+
+## 5. Monitor the run to success
+
+Watch the run and don't declare success until it's actually green:
+
+```bash
+gh run list --workflow nix-cache.yml --limit 1     # find the run
+gh run watch <run-id>                              # stream to completion
+```
+
+If it fails, diagnose with `gh run view <run-id> --log-failed` and fix. Common causes:
+
+- **`ATTIC_TOKEN` missing / unauthorized** — the secret isn't set or lacks push scope; loop back to step 3.
+- **Build failure** — `nix build` itself is broken; that's a repo problem, not a cache one. Fix the build.
+- **Unpinned-action / permissions warnings** — check the pins and `permissions:` block from step 2.
+
+A green run means the closure was pushed. To confirm the pull side, on another machine run `nix build` and check the log shows paths fetched from `cache.nixos.asia/oss`.

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,0 +1,45 @@
+# Build the default package on linux + darwin and push each closure to the
+# shared Attic cache (https://cache.nixos.asia/oss).
+name: nix-cache
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# Least privilege — this job only needs the checkout and ATTIC_TOKEN secret.
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest → x86_64-linux; macos-latest → aarch64-darwin.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin by commit (CodeQL: unpinned third-party action). v35 → 9f63be7.
+      # v35 defaults to Nix 2.34.7, new enough for attic-action's `nix profile add`.
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+        with:
+          nix_conf: |
+            extra-substituters = https://cache.nixos.asia/oss
+            extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
+            accept-flake-config = true
+
+      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+        with:
+          endpoint: https://cache.nixos.asia
+          cache: oss
+          token: ${{ secrets.ATTIC_TOKEN }}
+
+      - name: Build
+        run: nix build -L --print-out-paths

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ One upstream issue currently shapes how CI runs:
 
 - **crates.io blocks `curl/*` User-Agent.** Every `crate-*.tar.gz` fetched by `bun2nix`'s rust dep tree fails its `pkgs.fetchurl` with HTTP 403. `ci/mod.just`'s `_prefetch-crates` recipe (`scripts/ci-prefetch-crates.sh`) sidesteps this by fetching missing crates with a Mozilla UA and injecting them via `nix-store --add-fixed`. Idempotent and content-addressed, so the workaround disappears the first time upstream fetchurl learns to set a non-curl UA — or once bun2nix's Rust deps fetch from `static.crates.io` directly. Tracking issue: TBD.
 
+### Binary cache
+
+Builds are pushed to Juspay's shared OSS Attic cache at [`cache.nixos.asia/oss`](https://cache.nixos.asia). The `.github/workflows/nix-cache.yml` workflow builds the default package on linux + darwin for every push and PR and pushes each closure via [`ryanccn/attic-action`](https://github.com/ryanccn/attic-action). The cache is wired in as a substituter through the flake's `nixConfig`, so a local `nix build` pulls prebuilt closures instead of rebuilding — accept the flake config (`accept-flake-config = true`, or answer `y` when prompted) to opt in.
+
 ### License
 
 AGPL-3.0-or-later (matches upstream `@kolu/surface`).

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-13T15:01:42.893566+00:00'
+generated_at: '2026-07-11T16:37:55.216242+00:00'
 apm_version: 0.20.0
 dependencies:
 - repo_url: anthropics/claude-code
@@ -66,6 +66,19 @@ dependencies:
   deployed_file_hashes:
     .claude/skills/nix-justfile/SKILL.md: sha256:730345294a6536793ede474dc7f624faa83af6e97dbcbeb10fed1954a0d408fd
   content_hash: sha256:8f48e067e59da48c3ac90b4e2228ebb4ecfd988375b40efe831339d9a493accd
+- repo_url: juspay/skills
+  host: github.com
+  resolved_commit: f9acd37c52b0af1a80b53cd871ef04f81a20ed87
+  resolved_ref: nix-oss-cache
+  virtual_path: skills/nix-oss-cache
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/nix-oss-cache
+  - .claude/skills/nix-oss-cache/SKILL.md
+  deployed_file_hashes:
+    .claude/skills/nix-oss-cache/SKILL.md: sha256:6075a2e030cc7cebaaf0cf00878006f5f86d7e1b533be9b672fd1e0ab000acf9
+  content_hash: sha256:127f072350623c9004ea47c004ffae7acd67519a6abd442d6af1a7387cd28cb4
 - repo_url: srid/agency
   host: github.com
   resolved_commit: d274039c47ee8d0cc13e9d42d1bbf61e5f5b706f

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -68,8 +68,7 @@ dependencies:
   content_hash: sha256:8f48e067e59da48c3ac90b4e2228ebb4ecfd988375b40efe831339d9a493accd
 - repo_url: juspay/skills
   host: github.com
-  resolved_commit: f9acd37c52b0af1a80b53cd871ef04f81a20ed87
-  resolved_ref: nix-oss-cache
+  resolved_commit: 77c6a360a04a5a3a099ab5fea004b6ea65be919b
   virtual_path: skills/nix-oss-cache
   is_virtual: true
   package_type: claude_skill
@@ -77,8 +76,8 @@ dependencies:
   - .claude/skills/nix-oss-cache
   - .claude/skills/nix-oss-cache/SKILL.md
   deployed_file_hashes:
-    .claude/skills/nix-oss-cache/SKILL.md: sha256:6075a2e030cc7cebaaf0cf00878006f5f86d7e1b533be9b672fd1e0ab000acf9
-  content_hash: sha256:127f072350623c9004ea47c004ffae7acd67519a6abd442d6af1a7387cd28cb4
+    .claude/skills/nix-oss-cache/SKILL.md: sha256:bd5b9e9f646612337932b3bc2bffe0b7576dd96e8dc60741cd08b36ba728a393
+  content_hash: sha256:d11c43caf068a63ac55a04307b4f1d5c61d47d080170db956fbdb5dd1ca7d198
 - repo_url: srid/agency
   host: github.com
   resolved_commit: d274039c47ee8d0cc13e9d42d1bbf61e5f5b706f

--- a/apm.yml
+++ b/apm.yml
@@ -18,4 +18,5 @@ dependencies:
     - anthropics/claude-code/plugins/frontend-design/skills/frontend-design#main
     - juspay/skills/skills/nix-for-dev
     - juspay/skills/skills/nix-justfile
+    - juspay/skills/skills/nix-oss-cache#nix-oss-cache
     - juspay/nix-chrome-devtools-mcp

--- a/apm.yml
+++ b/apm.yml
@@ -18,5 +18,5 @@ dependencies:
     - anthropics/claude-code/plugins/frontend-design/skills/frontend-design#main
     - juspay/skills/skills/nix-for-dev
     - juspay/skills/skills/nix-justfile
-    - juspay/skills/skills/nix-oss-cache#nix-oss-cache
+    - juspay/skills/skills/nix-oss-cache
     - juspay/nix-chrome-devtools-mcp

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,14 @@
 {
   inputs.bun2nix.url = "github:juspay/bun2nix/rawflake";
 
+  # Pull prebuilt closures from Juspay's shared OSS Attic cache. CI (see
+  # .github/workflows/nix-cache.yml) pushes each build here, warming both CI
+  # and local `nix build`s.
+  nixConfig = {
+    extra-substituters = "https://cache.nixos.asia/oss";
+    extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
+  };
+
   outputs = { self, bun2nix, ... }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];


### PR DESCRIPTION
Wires the repo into Juspay's shared OSS Attic cache at [`cache.nixos.asia/oss`](https://cache.nixos.asia), so CI builds warm both CI and local `nix build`s for everyone.

Three pieces (via the [`juspay/skills` `nix-oss-cache` skill](https://github.com/juspay/skills/pull/39)):

| Piece | What |
|---|---|
| **Substituter** | `flake.nix` `nixConfig` pulls prebuilt closures from `cache.nixos.asia/oss`. |
| **Workflow** | `.github/workflows/nix-cache.yml` builds the default package on linux + darwin for every push/PR and pushes each closure via SHA-pinned [`ryanccn/attic-action`](https://github.com/ryanccn/attic-action) (least-privilege, `contents: read`). Triggers on **all branches** + `pull_request` + `workflow_dispatch`. |
| **Secret** | `ATTIC_TOKEN` repo secret (set out-of-band). |

`apm.yml` adopts the `nix-oss-cache` skill (pinned to the `nix-oss-cache` branch) that codifies this setup; `apm.lock.yaml` and the deployed `.claude/skills/nix-oss-cache/` follow. README gains a "Binary cache" subsection.

Ref: [juspay/kolu#1731](https://github.com/juspay/kolu/pull/1731), [#1733](https://github.com/juspay/kolu/pull/1733)

🤖 Generated with [Claude Code](https://claude.com/claude-code)