### PR TITLE
feat: adopt @kolu/surface-map PR4 — total, schema-valid entry failure

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-failure",
       "submodules": false,
-      "revision": "52d60bf1bf06167659f1f732fef91e44a0549b79",
-      "url": "https://github.com/juspay/kolu/archive/52d60bf1bf06167659f1f732fef91e44a0549b79.tar.gz",
-      "hash": "sha256-HBIpLLDfwmv2u73LBeGOr0mc5nS/FmUxhSTPPP2lERk="
+      "revision": "d52a4360a89b0023decb40f5d9d31ff8b5fd6268",
+      "url": "https://github.com/juspay/kolu/archive/d52a4360a89b0023decb40f5d9d31ff8b5fd6268.tar.gz",
+      "hash": "sha256-EaYzgodLjeRFv2LBipoKwfGJTmeDZZcrv7wQvubLifo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-failure",
       "submodules": false,
-      "revision": "d52a4360a89b0023decb40f5d9d31ff8b5fd6268",
-      "url": "https://github.com/juspay/kolu/archive/d52a4360a89b0023decb40f5d9d31ff8b5fd6268.tar.gz",
-      "hash": "sha256-EaYzgodLjeRFv2LBipoKwfGJTmeDZZcrv7wQvubLifo="
+      "revision": "c7d1c09865a9bf521dd94780f78126e10e8be443",
+      "url": "https://github.com/juspay/kolu/archive/c7d1c09865a9bf521dd94780f78126e10e8be443.tar.gz",
+      "hash": "sha256-y6MF2v5XD3rdn045SdaC/8sCURVbTpa/uY42w1HzoFk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-failure",
+      "branch": "master",
       "submodules": false,
-      "revision": "c7d1c09865a9bf521dd94780f78126e10e8be443",
-      "url": "https://github.com/juspay/kolu/archive/c7d1c09865a9bf521dd94780f78126e10e8be443.tar.gz",
-      "hash": "sha256-y6MF2v5XD3rdn045SdaC/8sCURVbTpa/uY42w1HzoFk="
+      "revision": "4bc19abb07be3be49539b62695581b498ef9340c",
+      "url": "https://github.com/juspay/kolu/archive/4bc19abb07be3be49539b62695581b498ef9340c.tar.gz",
+      "hash": "sha256-PoDdaUCccbEdvMzwagiTIXWqTDDBbk36c8FgsKj1IHE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -856,7 +856,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
   // WORD stays driven by the richer `ConnectionState` cell (copying vs
   // connecting vs the failure detail) — see `HostDot.tsx`'s docstring for
   // why the dot and the word now read two different facts.
-  const entryState = createMemo<EntryState>(() => entry.state());
+  const entryState = createMemo<EntryState<{ reason: string }>>(() => entry.state());
   // CPU% and the core count are read straight off the `system` cell — the agent
   // folds them in (`system.cpuPct` / `system.coreCount`). The card used to open
   // the per-key `cpuCores` collection (one value stream PER core PER host) just
@@ -1089,7 +1089,7 @@ function HostView(props: {
   const connection = entry.cells.connection.use({
     onError: (err) => console.error("connection subscription failed", err),
   });
-  const entryState = createMemo<EntryState>(() => entry.state());
+  const entryState = createMemo<EntryState<{ reason: string }>>(() => entry.state());
 
   // The host's raised-alert set (kolu W5 `alerts` cell). The fleet card shows a
   // count pip and the app fires an OS notification; the DETAIL view must EXPLAIN
@@ -1424,7 +1424,7 @@ function pidComparator(
 function Header(props: {
   system: ReturnType<() => typeof DEFAULT_SYSTEM>;
   connection: ReturnType<() => typeof DEFAULT_CONNECTION>;
-  entryState: Accessor<EntryState>;
+  entryState: Accessor<EntryState<{ reason: string }>>;
   count: number;
 }) {
   // The component body runs ONCE at mount — when props.system is still

--- a/packages/app/src/client/HostDot.tsx
+++ b/packages/app/src/client/HostDot.tsx
@@ -23,8 +23,11 @@ import type { EntryState } from "@kolu/surface-map";
 import type { Accessor } from "solid-js";
 import { dotClass, statusPending, statusTitle } from "./entryStatusTone";
 
+// PR4: the map's `failed` arm carries a schema-valid domain `failure` value;
+// `statusTitle` reads its human `reason`, so the state this dot paints from must
+// carry at least `{ reason }` on that arm (drishti's `HostFailure` satisfies it).
 export function HostDot(props: {
-  state: Accessor<EntryState>;
+  state: Accessor<EntryState<{ reason: string }>>;
   class?: string;
 }) {
   return (

--- a/packages/app/src/client/entryStatusTone.test.ts
+++ b/packages/app/src/client/entryStatusTone.test.ts
@@ -10,10 +10,11 @@ import {
 
 const CONNECTED: EntryState = { kind: "connected", clockOffset: 0 };
 const WARMING: EntryState = { kind: "warming" };
-const FAILED: EntryState = {
+// PR4: the failed arm carries a schema-valid domain `failure` value (drishti's is
+// `{ reason }`), not a bare `reason`/`cause` pair — read as `.failure.reason`.
+const FAILED: EntryState<{ reason: string }> = {
   kind: "failed",
-  reason: "connection refused",
-  cause: "other",
+  failure: { reason: "connection refused" },
 };
 const NOT_A_MEMBER: EntryState = { kind: "not-a-member" };
 

--- a/packages/app/src/client/entryStatusTone.ts
+++ b/packages/app/src/client/entryStatusTone.ts
@@ -5,10 +5,11 @@
  * reads `entry.state()` and turns it into a connection-dot tone / status
  * label, mirroring kolu's own `hostChipTone.ts`. Every host indicator (the
  * tab chip, the fleet card) goes through `dotClass`/`statusLabel` here, so
- * absorbing a future wire change to `EntryStatus` — e.g. a typed
- * `failed.cause` discriminant (`EntryStatus<Cause extends string =
- * string>`, pending upstream review) — is a ONE-FILE edit, not a scatter
- * across every component that paints a dot.
+ * absorbing a wire change to `EntryStatus` is a ONE-FILE edit, not a scatter
+ * across every component that paints a dot. PR4 landed exactly such a change:
+ * the `failed` arm now carries a schema-valid domain `failure` value
+ * (`EntryStatus<Failure>`), read here as `status.failure.reason` — drishti's
+ * `HostFailure` is just `{ reason }`, since it paints a cause-blind dot.
  *
  * `EntryStatus` is the map's FACT, floored on real transport liveness by
  * `connectSurfaceMap` (see its README) — it replaces the old per-host
@@ -63,14 +64,14 @@ export function statusLabel(status: EntryState): string {
 
 /** A one-line human note for the dot's `title` — the failure reason when
  *  failed. */
-export function statusTitle(status: EntryState): string {
+export function statusTitle(status: EntryState<{ reason: string }>): string {
   switch (status.kind) {
     case "connected":
       return "connected";
     case "warming":
       return "connecting…";
     case "failed":
-      return `failed: ${status.reason}`;
+      return `failed: ${status.failure.reason}`;
     default:
       return "not a member";
   }

--- a/packages/app/src/common/hostMap.ts
+++ b/packages/app/src/common/hostMap.ts
@@ -34,11 +34,19 @@ const hostKeyCodec: KeyCodec<string> = {
   decode: (s) => s,
 };
 
+/** Drishti's DOMAIN failure — a plain human `reason` (a failed host chip shows
+ *  `failed: <reason>` and nothing more; drishti carries no cause taxonomy, unlike
+ *  kolu's padi). The `failed` arm can only carry a value this schema validates —
+ *  there is no fabricated fallback cause (the framework's PR4 invariant). */
+export const hostFailureSchema = z.object({ reason: z.string() });
+export type HostFailure = z.infer<typeof hostFailureSchema>;
+
 /** The map of every configured host's `browserSurface`. Server
  *  (`serveHostMap`, in `admin-router.ts`) and client (`connectSurfaceMap`,
  *  in `wire.ts`) share this ONE definition, so the two sides can't drift. */
-export const hostSurfaceMap = defineSurfaceMap(
-  HostKeySchema,
-  browserSurface,
-  hostKeyCodec,
-);
+export const hostSurfaceMap = defineSurfaceMap({
+  key: HostKeySchema,
+  entry: browserSurface,
+  codec: hostKeyCodec,
+  failure: hostFailureSchema,
+});

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -161,13 +161,23 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // clone — drishti's ssh sessions measure none), it's an INJECTED capability.
   // drishti stamps every metric with the PARENT's own clock, never a
   // host-stamped one, so there is no true offset being hidden behind the `0`.
-  // `causeFor` is omitted — drishti carries no domain failure-cause taxonomy,
-  // so a down entry rides through cause-less and the map's `projectStatus`
-  // falls back to `"other"` (reads amber/in-motion, never a red "needs you").
+  //
+  // `failureOf` is REQUIRED and TOTAL now (PR4 — no framework fallback cause).
+  // drishti carries no domain taxonomy, so it classifies structurally on the
+  // transport phase: a TERMINAL `failed` session is a genuine failure carrying its
+  // real transport `error` as the human `reason` (→ a red "failed: <reason>" chip);
+  // a `disconnected` (the reconnect-backoff window) returns `null` — "not a standing
+  // failure, keep warming" — so a live host's normal reconnect reads amber, never a
+  // red chip. This preserves the exact behavior the old omitted-`causeFor` had
+  // (disconnected → warming, terminal → failed) without any fabricated cause.
   const hostsMap = serveHostMap(hostSurfaceMap, opts.pool, {
     linkFor: (host, session) =>
       directLink(buildRouter({ host, session }).router),
     offsetOf: () => 0,
+    failureOf: (_host, _session, state) =>
+      state.phase === "failed"
+        ? { reason: (state as { error: string }).error }
+        : null,
   });
 
   // `implement(adminContract).router(...)` WALKS `adminContract` to build the


### PR DESCRIPTION
## Adopt @kolu/surface-map PR4 — failure is total, schema-valid domain data

Paired consumer PR for **juspay/kolu#1804**. Kolu's map now carries a **schema-valid domain `failure` value** on the `failed` arm (not a loose `{ reason, cause: z.string() }`), and `serveHostMap`'s classifier is the **required, total `failureOf`**. This updates drishti's four consumer sites and repins kolu.

- **`hostMap.ts`** — `defineSurfaceMap({ key, entry, codec, failure })` with a minimal `hostFailureSchema` (`{ reason }`). Drishti paints a **cause-blind** dot, so a plain human `reason` is all its failure needs to carry.
- **`admin-router.ts`** — pass the now-required `failureOf`: a terminal `failed` session → `{ reason: <transport error> }`; a `disconnected` (reconnect-backoff window) → `null` ("not a standing failure, keep warming"). This is **behavior-neutral** vs the old omitted-`causeFor` path (`disconnected → warming`, `terminal → failed`) — minus the fabricated `"other"`.
- **`entryStatusTone.ts`** (+ its test) — read `status.failure.reason` on the failed arm; the chip still renders `failed: <reason>`, byte-identical.
- **npins** — kolu repinned to the `surface-failure` HEAD carrying PR4. (Re-pinned to the final HEAD before merge, per `.claude/rules/surface.md`.)

CI green here against that kolu HEAD is the gate for #1804.
