### PR TITLE
Consume the supervised SurfaceRuntime (kolu SRT-PR1 pair)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-runtime",
+      "branch": "master",
       "submodules": false,
-      "revision": "6a8cff0c8db3fd8a6d9f5122c92cf40b7433b93a",
-      "url": "https://github.com/juspay/kolu/archive/6a8cff0c8db3fd8a6d9f5122c92cf40b7433b93a.tar.gz",
-      "hash": "sha256-RR3+cfe3B1H39kxf49BpdGcFIesvO+3n/ThHSbpySpw="
+      "revision": "63fa922866645d0c1fc0a0328fa5102b803a7f95",
+      "url": "https://github.com/juspay/kolu/archive/63fa922866645d0c1fc0a0328fa5102b803a7f95.tar.gz",
+      "hash": "sha256-W1RipkWHvPeQ6sxoagmQsrprzWkF1flnaZy268NcePs="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-runtime",
       "submodules": false,
-      "revision": "52d60bf1bf06167659f1f732fef91e44a0549b79",
-      "url": "https://github.com/juspay/kolu/archive/52d60bf1bf06167659f1f732fef91e44a0549b79.tar.gz",
-      "hash": "sha256-HBIpLLDfwmv2u73LBeGOr0mc5nS/FmUxhSTPPP2lERk="
+      "revision": "d266c623b6a7cadbb2c6a4b6007169220f638edc",
+      "url": "https://github.com/juspay/kolu/archive/d266c623b6a7cadbb2c6a4b6007169220f638edc.tar.gz",
+      "hash": "sha256-N8vp1rgYW/cralVGZLb2T6UsD2+FZrbN7sBWJIqYkO8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-runtime",
       "submodules": false,
-      "revision": "d266c623b6a7cadbb2c6a4b6007169220f638edc",
-      "url": "https://github.com/juspay/kolu/archive/d266c623b6a7cadbb2c6a4b6007169220f638edc.tar.gz",
-      "hash": "sha256-N8vp1rgYW/cralVGZLb2T6UsD2+FZrbN7sBWJIqYkO8="
+      "revision": "ab74926bdacd265eb97e67f9d3215832551d7455",
+      "url": "https://github.com/juspay/kolu/archive/ab74926bdacd265eb97e67f9d3215832551d7455.tar.gz",
+      "hash": "sha256-OQTCoOxu6P0J2+2opK8UnCn2CcWAN7B/44NIe3eS1j8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -25,11 +25,9 @@
  * entirely for clarity.
  */
 
-import { implement } from "@orpc/server";
 import {
   implementSurface,
   inMemoryChannel,
-  inMemoryChannelByName,
   inMemoryStore,
 } from "@kolu/surface/server";
 import { serveOverStdio } from "@kolu/surface/peer-server";
@@ -134,7 +132,7 @@ type Serve = (opts: {
 }) => Promise<unknown>;
 
 /**
- * Build the surface fragment + poll loop for `reader`, then serve it.
+ * Build the surface runtime + poll loop for `reader`, then serve it.
  *
  * **Serve before you enumerate.** The connect handshake — the parent's first
  * `system.get` — needs only the cheap `system` snapshot, so that is the one
@@ -178,7 +176,7 @@ export async function serveAgent(
   // Build the surface implementation. The `processes` collection's
   // `readAll` yields the current snapshot; `upsert`/`remove` are the
   // single in-process write seam — the poll loop calls
-  // `fragment.ctx.collections.processes.upsert/remove`, which mutates
+  // `runtime.ctx.collections.processes.upsert/remove`, which mutates
   // the snapshot AND publishes through the framework's keyed channels.
   // `processesSnapshot` stream subscribers read the current map on
   // first subscribe, then forward every delta the poll loop publishes.
@@ -204,8 +202,7 @@ export async function serveAgent(
     };
   });
 
-  const fragment = implementSurface(surface, {
-    channel: inMemoryChannelByName(),
+  const runtime = implementSurface(surface, {
     cells: {
       // The agent serves the connection-FREE base surface. Link health is the
       // PARENT's observation of the parent↔agent link (the agent can't see its
@@ -332,7 +329,7 @@ export async function serveAgent(
         ...cpuAggregate(nextCores),
         pollIntervalMs: POLL_INTERVAL_MS,
       };
-      fragment.ctx.cells.system.set(sys);
+      runtime.ctx.cells.system.set(sys);
       // Feed the alert reactor the frame just composed. `emitMetrics` was
       // installed synchronously when `scan` subscribed to the source at
       // construction (see above), so by the time this poll runs it is already
@@ -344,13 +341,13 @@ export async function serveAgent(
       for (const [pid, value] of nextProcesses) {
         const prev = processSnapshot.get(pid);
         if (prev === undefined || processChanged(prev, value)) {
-          fragment.ctx.collections.processes.upsert(pid, value);
+          runtime.ctx.collections.processes.upsert(pid, value);
           upserts.push([pid, value]);
         }
       }
       for (const pid of processSnapshot.keys()) {
         if (!nextProcesses.has(pid)) {
-          fragment.ctx.collections.processes.remove(pid);
+          runtime.ctx.collections.processes.remove(pid);
           removes.push(pid);
         }
       }
@@ -366,11 +363,11 @@ export async function serveAgent(
       // Evict cores that disappeared (hot-unplug / VM CPU resize) so stale bars
       // don't linger in the browser strip.
       for (const [core, value] of nextCores) {
-        fragment.ctx.collections.cpuCores.upsert(core, value);
+        runtime.ctx.collections.cpuCores.upsert(core, value);
       }
       for (const core of cpuCoreSnapshot.keys()) {
         if (!nextCores.has(core))
-          fragment.ctx.collections.cpuCores.remove(core);
+          runtime.ctx.collections.cpuCores.remove(core);
       }
 
       // Per-NIC network I/O — same Collection<K,T> publish shape as
@@ -381,11 +378,11 @@ export async function serveAgent(
       // (darwin `netstat`), so it rides alongside system/processes rather
       // than adding a serial leg to every tick's latency.
       for (const [iface, value] of nextNet) {
-        fragment.ctx.collections.networkInterfaces.upsert(iface, value);
+        runtime.ctx.collections.networkInterfaces.upsert(iface, value);
       }
       for (const iface of netSnapshot.keys()) {
         if (!nextNet.has(iface))
-          fragment.ctx.collections.networkInterfaces.remove(iface);
+          runtime.ctx.collections.networkInterfaces.remove(iface);
       }
     } catch (err) {
       log(`tick error: ${(err as Error).message}`);
@@ -401,12 +398,9 @@ export async function serveAgent(
   // before we ever serve.)
   void tick();
 
-  // `implementSurface` returns a fragment with shape `{ surface: ... }`;
-  // passing it straight to `serveOverStdio`'s `StandardRPCHandler`
-  // double-wraps the path (`/surface/surface/...`) and every client
-  // request 404s. Wrap once via `implement(contract).router(...)` to
-  // flatten the prefix.
-  const router = implement(surface.contract).router({ ...fragment.router });
+  // `implementSurface` returns a supervised runtime whose `.router` is the
+  // FINAL top-level router — hand it straight to `serveOverStdio`, no re-wrap.
+  const router = runtime.router;
 
   log("serving surface over stdio (read=stdin, write=stdout)");
   // Heartbeat while blocked on the first request. A healthy connect

--- a/packages/app/src/client/processesStream.test.ts
+++ b/packages/app/src/client/processesStream.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { defineSurface } from "@kolu/surface/define";
 import { directLink } from "@kolu/surface/links/direct";
-import { implementSurface, inMemoryChannelByName } from "@kolu/surface/server";
+import { implementSurface } from "@kolu/surface/server";
 import { unenrolledStreamCall } from "@kolu/surface/client";
 import { createSubscription } from "@kolu/surface/solid";
 import {
@@ -108,7 +108,6 @@ function makeFeed() {
 
 function serve(feed: ReturnType<typeof makeFeed>) {
   const { router } = implementSurface(probeSurface, {
-    channel: inMemoryChannelByName(),
     streams: {
       processesSnapshot: {
         source: async function* (_input, signal) {
@@ -120,7 +119,7 @@ function serve(feed: ReturnType<typeof makeFeed>) {
       },
     },
   });
-  return directLink<typeof probeSurface.contract>(router);
+  return directLink<typeof probeSurface.contract>(router as never);
 }
 
 const flush = () => new Promise((r) => setTimeout(r, 20));

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -39,7 +39,7 @@
 import { oc } from "@orpc/contract";
 import { implement } from "@orpc/server";
 import { directLink } from "@kolu/surface/links/direct";
-import { implementSurfaces, inMemoryChannelByName } from "@kolu/surface/server";
+import { implementSurfaces } from "@kolu/surface/server";
 import { serveHostMap } from "@kolu/surface-remote";
 import { surfaceAppServer } from "@kolu/surface-app/server";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
@@ -83,7 +83,8 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   const surfaceApp = surfaceAppServer();
   const { router: surfacesRouter } = implementSurfaces(
     adminSurfaces,
-    { channel: inMemoryChannelByName() },
+    // The ordinary constructor owns its in-memory channel internally now.
+    {},
     {
       // ── surface-app served as a sibling ──────────────────────────────
       // `surfaceAppServer()` is the surface-app deps bundle; pass it directly.
@@ -166,7 +167,7 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // falls back to `"other"` (reads amber/in-motion, never a red "needs you").
   const hostsMap = serveHostMap(hostSurfaceMap, opts.pool, {
     linkFor: (host, session) =>
-      directLink(buildRouter({ host, session }).router),
+      directLink(buildRouter({ host, session }).router as never),
     offsetOf: () => 0,
   });
 
@@ -195,13 +196,16 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
 
   // Splice the map's flat `{ surface: { <folded members>, entries } }`
   // router in under the `hosts` key, beside `admin`/`surfaceApp` —
-  // `surfacesRouter` (straight off `implementSurfaces`) is a plain object,
-  // so merging here reads its `.surface` directly. Mirrors kolu's own
-  // `surfaceRouter.surface = { ...koluSurfaceRouter.surface, padi: … }`.
+  // `surfacesRouter` (the runtime's FINAL router, opaque `unknown`) is a plain
+  // object at runtime, so merging here reads its `.surface` directly. Cast
+  // through `any` for the dynamic splice, mirroring kolu-server's own
+  // `{ ...(surfaceRouter as any), … }` — the runtime shape is a valid router.
+  // biome-ignore lint/suspicious/noExplicitAny: opaque runtime router spliced dynamically; runtime shape is valid (same cast kolu-server uses).
+  const surfacesRouterObj = surfacesRouter as any;
   const router = implement(servedAdminContract).router({
-    ...surfacesRouter,
+    ...surfacesRouterObj,
     surface: {
-      ...surfacesRouter.surface,
+      ...surfacesRouterObj.surface,
       hosts: (hostsMap.router as { surface: Record<string, unknown> })
         .surface,
     },

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -33,13 +33,11 @@
  * this file used to feed directly.
  */
 
-import { implement } from "@orpc/server";
 import {
   type CellStore,
   type Channel,
   implementSurface,
   inMemoryChannel,
-  inMemoryChannelByName,
   inMemoryStore,
 } from "@kolu/surface/server";
 import { type ProcedureForwarders } from "@kolu/surface/mirror";
@@ -138,10 +136,7 @@ export function buildRouter(opts: BuildRouterOptions) {
   // base primitives are forwarded/folded from the agent; `connection` is the
   // seeded local store the session pump writes — the agent's surface stays
   // connection-free.
-  const fragment = implementSurface(browserSurface, {
-    // Name-keyed in-memory channel factory — publish/subscribe sites
-    // land on the same `Channel<T>` instance per name.
-    channel: inMemoryChannelByName(),
+  const runtime = implementSurface(browserSurface, {
     cells: {
       system: { store: systemStore },
       alerts: { store: alertsStore },
@@ -234,11 +229,11 @@ export function buildRouter(opts: BuildRouterOptions) {
   });
 
   // Compile-time guard for the least-privilege narrowing: the real
-  // fragment must satisfy the pump sink's write-only view. Stated here (not
+  // runtime must satisfy the pump sink's write-only view. Stated here (not
   // only implied by the `makeSink` closure below) so a refactor of that sink
   // can't quietly drop the check — a surface collection rename surfaces as
   // an error on this line.
-  const _pumpCtx: FragmentCtx = fragment;
+  const _pumpCtx: FragmentCtx = runtime;
   void _pumpCtx;
 
   // Sample the metric ring once per agent system tick. Every series reads off
@@ -293,7 +288,7 @@ export function buildRouter(opts: BuildRouterOptions) {
               );
             }
             session.markConnected();
-            fragment.ctx.cells.system.set(remoteSystem);
+            runtime.ctx.cells.system.set(remoteSystem);
             recordSample(remoteSystem);
           },
           // The agent's `alerts` cell → the parent's. Wire-read-only downstream;
@@ -301,7 +296,7 @@ export function buildRouter(opts: BuildRouterOptions) {
           // agent's own `equals` (`alertsEqual`) already gated the frame, so a
           // frame arriving here is a genuine raise/clear worth re-publishing.
           alerts: (remoteAlerts) => {
-            fragment.ctx.cells.alerts.set(remoteAlerts);
+            runtime.ctx.cells.alerts.set(remoteAlerts);
           },
         },
         collections: {
@@ -315,15 +310,15 @@ export function buildRouter(opts: BuildRouterOptions) {
           // (kolu #1661; mirrors surface-remote's reServeSurface).
           cpuCores: {
             upsert: (key, value) =>
-              fragment.ctx.collections.cpuCores.upsert(key, value),
-            remove: (key) => fragment.ctx.collections.cpuCores.remove(key),
+              runtime.ctx.collections.cpuCores.upsert(key, value),
+            remove: (key) => runtime.ctx.collections.cpuCores.remove(key),
             initialKeys: () => new Set(coreCache.keys()),
           },
           networkInterfaces: {
             upsert: (key, value) =>
-              fragment.ctx.collections.networkInterfaces.upsert(key, value),
+              runtime.ctx.collections.networkInterfaces.upsert(key, value),
             remove: (key) =>
-              fragment.ctx.collections.networkInterfaces.remove(key),
+              runtime.ctx.collections.networkInterfaces.remove(key),
             initialKeys: () => new Set(netCache.keys()),
           },
         },
@@ -338,7 +333,7 @@ export function buildRouter(opts: BuildRouterOptions) {
             input: {},
             onFrame: (msg) => {
               frames += 1;
-              applySnapshotMessage(log, msg, processCache, fragment, frames);
+              applySnapshotMessage(log, msg, processCache, runtime, frames);
               browserSnapshotBus.publish(msg);
             },
           },
@@ -353,18 +348,13 @@ export function buildRouter(opts: BuildRouterOptions) {
     // browser-facing `connection` cell — the pump OWNS this subscription for the
     // session's lifetime and tears it down on exit (kolu #1568), so it can't be
     // forgotten or leak. The cell tracks the SESSION's state, never a mirror frame.
-    connection: { set: (info) => fragment.ctx.cells.connection.set(info) },
+    connection: { set: (info) => runtime.ctx.cells.connection.set(info) },
     log,
   });
 
-  // `implementSurface` returns a router *fragment* — `{ surface: ... }`
-  // wrapping the per-key namespaces. Passing it directly to RPCHandler
-  // produces a `surface/surface/...` double-prefix in the matcher tree
-  // (no procedure matches what the client sends). Wrap once via
-  // `implement(contract).router({...fragment})` to flatten the prefix.
-  const router = implement(browserSurface.contract).router({
-    ...fragment.router,
-  });
+  // `implementSurface` returns a supervised runtime whose `.router` is the
+  // FINAL top-level router — hand it straight to RPCHandler, no re-wrap.
+  const router = runtime.router;
   return { router, session };
 }
 
@@ -373,7 +363,7 @@ export function buildRouter(opts: BuildRouterOptions) {
  *  not the full ctx. The sink only ever mirrors remote data inward, so it
  *  gets `set` / `upsert` / `remove`; `readAll` and the underlying stores
  *  stay out of reach. This is a boundary, not a maintenance chore: the
- *  `_pumpCtx` guard above assigns the real fragment to this type, so a
+ *  `_pumpCtx` guard above assigns the real runtime to this type, so a
  *  collection renamed or retyped on the surface becomes a compile error
  *  here rather than silent drift. */
 type FragmentCtx = {
@@ -410,16 +400,16 @@ function applySnapshotMessage(
   log: Logger,
   msg: ProcessesSnapshotMsg,
   processCache: Map<Pid, Process>,
-  fragment: FragmentCtx,
+  runtime: FragmentCtx,
   frameNumber: number,
 ): void {
   if (msg.kind === "snapshot") {
     const next = new Set(msg.entries.map(([pid]) => pid));
     for (const pid of [...processCache.keys()]) {
-      if (!next.has(pid)) fragment.ctx.collections.processes.remove(pid);
+      if (!next.has(pid)) runtime.ctx.collections.processes.remove(pid);
     }
     for (const [pid, value] of msg.entries) {
-      fragment.ctx.collections.processes.upsert(pid, value);
+      runtime.ctx.collections.processes.upsert(pid, value);
     }
     log(
       `processes: snapshot frame #${frameNumber} — ${msg.entries.length} PIDs (cold-start or reconnect)`,
@@ -427,10 +417,10 @@ function applySnapshotMessage(
     return;
   }
   for (const [pid, value] of msg.upserts) {
-    fragment.ctx.collections.processes.upsert(pid, value);
+    runtime.ctx.collections.processes.upsert(pid, value);
   }
   for (const pid of msg.removes) {
-    fragment.ctx.collections.processes.remove(pid);
+    runtime.ctx.collections.processes.remove(pid);
   }
   // Per-tick delta frames are intentionally NOT logged — the agent
   // polls every 2s, so steady-state deltas would dominate stderr. The


### PR DESCRIPTION
Paired with **kolu [#1805](https://github.com/juspay/kolu/pull/1805)** (`@kolu/surface` PR 1: a supervised `SurfaceRuntime`) per `.claude/rules/surface.md`.

kolu's `implementSurface` / `implementSurfaces` now return a supervised `SurfaceRuntime` whose `.router` is the **FINAL** top-level oRPC router. This PR updates drishti to consume it — the fragment-flatten wraps (`implement(contract).router({ ...fragment.router })`) delete, which is the proven-by-deletion the plan cites for drishti.

## Changes
- **agent/main.ts** + **app/server/router.ts** — consume `runtime.router` directly; the two `implement(...).router({...fragment.router})` wraps are gone. `fragment` locals renamed to `runtime`.
- The ordinary constructor owns its in-memory channel internally now, so the `channel: inMemoryChannelByName()` deps drop (agent, browser surface, admin-router, the `processesStream` test).
- **admin-router.ts** keeps its `hosts`-map splice — that `as any` contract/router collapse is kolu **plan PR 3** (the typed connection key), not PR 1. `SurfaceRuntime.router` is opaque `unknown`, so `directLink` / the splice cast through `never` / `any` at the oRPC boundary (same shape kolu-server uses).
- **npins**: kolu repinned to the final SurfaceRuntime HEAD `d266c623b`.

## Verification
`bun run typecheck` (common + agent + app) green against the pinned kolu. Full two-platform CI below, pinned to the exact final kolu HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)