### PR TITLE
feat: adopt kolu SRT-PR3 — membershipId, typed connection key, clockNow-at-admit

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-pr3-membership",
       "submodules": false,
-      "revision": "4bc19abb07be3be49539b62695581b498ef9340c",
-      "url": "https://github.com/juspay/kolu/archive/4bc19abb07be3be49539b62695581b498ef9340c.tar.gz",
-      "hash": "sha256-PoDdaUCccbEdvMzwagiTIXWqTDDBbk36c8FgsKj1IHE="
+      "revision": "0b97dc1973059b3ca1440dfcb5b459c2414b1699",
+      "url": "https://github.com/juspay/kolu/archive/0b97dc1973059b3ca1440dfcb5b459c2414b1699.tar.gz",
+      "hash": "sha256-DG9MyS5aS+lBaCRezucvVAIzYmvb2ntQ9648zeeu01k="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-pr3-membership",
+      "branch": "master",
       "submodules": false,
-      "revision": "906272508d2e66abf9b3eddb6a864a4f00bedca2",
-      "url": "https://github.com/juspay/kolu/archive/906272508d2e66abf9b3eddb6a864a4f00bedca2.tar.gz",
-      "hash": "sha256-aERn5z3V9xM//BAG/Ay8DoLvH559aMn42X6t58zMDZE="
+      "revision": "3104ecb0a67f19fbcb68787e631b6c42124422d7",
+      "url": "https://github.com/juspay/kolu/archive/3104ecb0a67f19fbcb68787e631b6c42124422d7.tar.gz",
+      "hash": "sha256-e8ZdPVk5kVAI5o6F8HblS2XQCE+CzIaVG95Q+JLVFb0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-pr3-membership",
       "submodules": false,
-      "revision": "61640b0557757dd3bb7ee7b3a78459080f609bf1",
-      "url": "https://github.com/juspay/kolu/archive/61640b0557757dd3bb7ee7b3a78459080f609bf1.tar.gz",
-      "hash": "sha256-RYuTz/ox/LRr64aF2aKCNBSGIrE3joKptlelchQsC6U="
+      "revision": "906272508d2e66abf9b3eddb6a864a4f00bedca2",
+      "url": "https://github.com/juspay/kolu/archive/906272508d2e66abf9b3eddb6a864a4f00bedca2.tar.gz",
+      "hash": "sha256-aERn5z3V9xM//BAG/Ay8DoLvH559aMn42X6t58zMDZE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/entryStatusTone.test.ts
+++ b/packages/app/src/client/entryStatusTone.test.ts
@@ -1,4 +1,5 @@
 import type { EntryState } from "@kolu/surface-map";
+import { testMembershipId } from "@kolu/surface-map/testing";
 import { describe, expect, it } from "bun:test";
 import {
   dotClass,
@@ -8,19 +9,24 @@ import {
   statusTitle,
 } from "./entryStatusTone";
 
-// PR3: every published EntryStatus arm carries an opaque `membershipId` — a fixture
-// uses `""` since these tone/label helpers read `.kind`/`.failure`/`.clockOffset` only.
+// PR3: every published EntryStatus arm carries an opaque `membershipId` (a branded
+// `MembershipId` — a bare `""` is a type error). These tone/label helpers read
+// `.kind`/`.failure`/`.clockOffset` only, so a fixture mints one through the
+// sanctioned `testMembershipId()` helper, never a literal.
 const CONNECTED: EntryState = {
   kind: "connected",
-  membershipId: "",
+  membershipId: testMembershipId(),
   clockOffset: 0,
 };
-const WARMING: EntryState = { kind: "warming", membershipId: "" };
+const WARMING: EntryState = {
+  kind: "warming",
+  membershipId: testMembershipId(),
+};
 // PR4: the failed arm carries a schema-valid domain `failure` value (drishti's is
 // `{ reason }`), not a bare `reason`/`cause` pair — read as `.failure.reason`.
 const FAILED: EntryState<{ reason: string }> = {
   kind: "failed",
-  membershipId: "",
+  membershipId: testMembershipId(),
   failure: { reason: "connection refused" },
 };
 const NOT_A_MEMBER: EntryState = { kind: "not-a-member" };

--- a/packages/app/src/client/entryStatusTone.test.ts
+++ b/packages/app/src/client/entryStatusTone.test.ts
@@ -8,12 +8,19 @@ import {
   statusTitle,
 } from "./entryStatusTone";
 
-const CONNECTED: EntryState = { kind: "connected", clockOffset: 0 };
-const WARMING: EntryState = { kind: "warming" };
+// PR3: every published EntryStatus arm carries an opaque `membershipId` — a fixture
+// uses `""` since these tone/label helpers read `.kind`/`.failure`/`.clockOffset` only.
+const CONNECTED: EntryState = {
+  kind: "connected",
+  membershipId: "",
+  clockOffset: 0,
+};
+const WARMING: EntryState = { kind: "warming", membershipId: "" };
 // PR4: the failed arm carries a schema-valid domain `failure` value (drishti's is
 // `{ reason }`), not a bare `reason`/`cause` pair — read as `.failure.reason`.
 const FAILED: EntryState<{ reason: string }> = {
   kind: "failed",
+  membershipId: "",
   failure: { reason: "connection refused" },
 };
 const NOT_A_MEMBER: EntryState = { kind: "not-a-member" };

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -89,12 +89,13 @@ export const ws = conn.ws;
 //    `connection` rides `hostMap.entry(host)` (a pure point lens) or
 //    `hostMap.useEntry(activeHost)` (a reactive lens that re-keys on
 //    switch). The map is dialled over the `hosts` SIBLING of `conn`'s
-//    BRANDED transport handle: `connectSurfaceMap` slices `hosts` from it
-//    and recovers the parent `connectSurfaces` watchdog `live` by
+//    BRANDED transport handle: `connectSurfaceMap` slices the sibling named
+//    by the map itself (`hostSurfaceMap.name === "hosts"`, PR3 — no separate
+//    siblingKey arg) and recovers the parent `connectSurfaces` watchdog `live` by
 //    construction (the handle is unforgeable), so every chip floors on the
 //    real socket — there is no raw `{ live }` seam to pass a
 //    green-over-dead accessor through.
-export const hostMap = connectSurfaceMap(hostSurfaceMap, conn.transport, "hosts");
+export const hostMap = connectSurfaceMap(hostSurfaceMap, conn.transport);
 
 // The origin's ONE notification seam (kolu W5, `@kolu/surface-app/notify`) —
 // the last hop of cross-host attention. App-scoped alongside the host map it

--- a/packages/app/src/common/hostMap.ts
+++ b/packages/app/src/common/hostMap.ts
@@ -45,6 +45,7 @@ export type HostFailure = z.infer<typeof hostFailureSchema>;
  *  (`serveHostMap`, in `admin-router.ts`) and client (`connectSurfaceMap`,
  *  in `wire.ts`) share this ONE definition, so the two sides can't drift. */
 export const hostSurfaceMap = defineSurfaceMap({
+  name: "hosts",
   key: HostKeySchema,
   entry: browserSurface,
   codec: hostKeyCodec,

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -156,11 +156,11 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // kill forward) that used to back a dedicated `?host=` `RPCHandler`, folded
   // into the map's one combined link instead of a separate socket.
   //
-  // `offsetOf: () => 0` is drishti's OWN honest offset story: the clock offset
-  // is no longer a type BOUND on the session (which is exactly what forced the
-  // clone — drishti's ssh sessions measure none), it's an INJECTED capability.
-  // drishti stamps every metric with the PARENT's own clock, never a
-  // host-stamped one, so there is no true offset being hidden behind the `0`.
+  // No `offsetOf` (PR3 removed it): the clock offset is no longer an injected
+  // capability NOR a type BOUND on the session — the framework measures it at
+  // admit off the reserved `system.clockNow` and rides it on the `connected`
+  // arm. drishti stamps every metric with the PARENT's own clock, so it simply
+  // reads whatever the framework measures; it fabricates no offset.
   //
   // `failureOf` is REQUIRED and TOTAL now (PR4 — no framework fallback cause).
   // drishti carries no domain taxonomy, so it classifies structurally on the
@@ -173,7 +173,6 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   const hostsMap = serveHostMap(hostSurfaceMap, opts.pool, {
     linkFor: (host, session) =>
       directLink(buildRouter({ host, session }).router),
-    offsetOf: () => 0,
     failureOf: (_host, _session, state) =>
       state.phase === "failed"
         ? { reason: (state as { error: string }).error }
@@ -187,19 +186,17 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // what extra keys the handlers object carries (confirmed live: the
   // `entries` subscription 404s). A SERVER-ONLY WIDENED contract is
   // required — mirroring kolu's own `servedContract` (`packages/server/src/
-  // surface.ts`), which composes the client contract + `padiHostMap.contract`
-  // the identical way. `hostSurfaceMap.contract` is `SurfaceMapContract`
-  // (structurally `{ surface: { <member>: contract, entries: contract } }`,
-  // the contract-level twin of `serveSurfaceMap`'s router shape) — spread its
-  // `.surface` in as the `hosts` key, never shared with the client (the
-  // client dials the map SEPARATELY via `connectSurfaceMap`, never through
-  // this widened contract).
+  // surface.ts`), which composes the client contract + `padiHostMap.surfaceContract`
+  // the identical way. `hostSurfaceMap.surfaceContract` (PR3) is the first-class
+  // folded fragment `{ <member>: contract, entries: contract }` the map exposes
+  // for exactly this splice — spliced in as the `hosts` key with no `as any`,
+  // never shared with the client (the client dials the map SEPARATELY via
+  // `connectSurfaceMap`, never through this widened contract).
   const servedAdminContract = oc.router({
     ...adminContract,
     surface: {
       ...adminContract.surface,
-      // biome-ignore lint/suspicious/noExplicitAny: SurfaceMapContract is AnyContractRouter; its `.surface` is the folded map fragment (mirrors kolu's identical cast in surface.ts).
-      hosts: (hostSurfaceMap.contract as any).surface,
+      hosts: hostSurfaceMap.surfaceContract,
     },
   });
 


### PR DESCRIPTION
Paired drishti PR for kolu **[#1811](https://github.com/juspay/kolu/pull/1811)** (Surface plan PR 3 — "membership is time"), pinned to kolu HEAD `61640b0557757dd3bb7ee7b3a78459080f609bf1`.

## What kolu PR3 changed, and how drishti absorbs it
- **Opaque `membershipId` on `EntryStatus`** (every arm) — drishti reads status by `.kind`/`.failure`, so reads are unaffected; the `entryStatusTone` fixtures gained `membershipId`.
- **Typed connection key** — `defineSurfaceMap` takes a mount `name` and exposes `surfaceContract`; `connectSurfaceMap` derives the transport slice from `map.name`. drishti's host map now declares `name: "hosts"`, `wire.ts` drops the `"hosts"` string arg, and `admin-router.ts` splices `surfaceContract` (no `as any`).
- **`clockNow` a framework-reserved member, measured at admit; `offsetOf` removed** — drishti's `offsetOf: () => 0` stub deleted (the framework measures the offset). `EntryStatus.connected.clockOffset` is now `number | null` (readiness decoupled from the offset) — drishti's tone/label helpers switch on `.kind` only, so a connected-but-unmeasured entry already renders connected, no code change needed.

Also folds in kolu #1815's bound-procedures face (via drishti #98, merged to master): the map's `.procedures`/`.streams` bound faces replace the `HostRpc`/`AdminScopedRpc` casts.

## Status
Typecheck green + unit tests green (169) against the pinned kolu HEAD. Draft until CI is green on this exact pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)