### PR TITLE
chore(deps): advance kolu pin to master @ 41b48b17a (#1827 pair, post-merge)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "stdio-residual",
+      "branch": "master",
       "submodules": false,
-      "revision": "ced032df21d74292c192e08913c21420791d5294",
-      "url": "https://github.com/juspay/kolu/archive/ced032df21d74292c192e08913c21420791d5294.tar.gz",
+      "revision": "41b48b17acf7a0e548f314b5328fa6bd9931d8b0",
+      "url": "https://github.com/juspay/kolu/archive/41b48b17acf7a0e548f314b5328fa6bd9931d8b0.tar.gz",
       "hash": "sha256-bL4+u17ylOzewcJITGdvaz9nRwOBEVEAztmD+wjknnE="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "stdio-residual",
       "submodules": false,
-      "revision": "26185085e196ba68b5f5acca242404f42927ba64",
-      "url": "https://github.com/juspay/kolu/archive/26185085e196ba68b5f5acca242404f42927ba64.tar.gz",
-      "hash": "sha256-AhY2RUI+8Hw3LMxSlmCoR6gG2vloy6i/d7DXMc1NM44="
+      "revision": "ced032df21d74292c192e08913c21420791d5294",
+      "url": "https://github.com/juspay/kolu/archive/ced032df21d74292c192e08913c21420791d5294.tar.gz",
+      "hash": "sha256-bL4+u17ylOzewcJITGdvaz9nRwOBEVEAztmD+wjknnE="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pin-proof pair for **kolu [#1827](https://github.com/juspay/kolu/pull/1827)** (the #1719 padi-reconnect flake fix) — **now merged**, so this pin points at the master commit carrying it: **`41b48b17a`** (branch `master`), advanced from the pre-merge `stdio-residual` tip (same post-merge pattern as #103).

**Additive-only @kolu/surface delta, unconsumed by drishti.** The kolu-side change is a retry in a test plus two ADDITIVE `@kolu/surface/client` exports (`isSurfaceStdioTransportClosed` / `isSurfaceRelayTransportLost`) — drishti consumes neither, and `streamHandlers` is unchanged from master. **No drishti code change.** This PR is only the npins kolu pin bump so drishti's build + typecheck + CI prove compat against the exact master SHA (P5). Box `just typecheck` corroborates green.