### PR TITLE
Adopt @kolu/surface SR9 — one connection authority (fix #102)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6ad0b4a811e68346b8219c07c237e6149f21d32f",
-      "url": "https://github.com/juspay/kolu/archive/6ad0b4a811e68346b8219c07c237e6149f21d32f.tar.gz",
-      "hash": "sha256-Gmd1IBhJrTqjhUbKUfRrgzYcGOJGoMyL7H9gwa6vkjk="
+      "revision": "c62af2f7d49887f9c3ca378c4aad622bf24d21d0",
+      "url": "https://github.com/juspay/kolu/archive/c62af2f7d49887f9c3ca378c4aad622bf24d21d0.tar.gz",
+      "hash": "sha256-7B+RFQIJbyuriSLUqqHEq0ZFTPrZWP7BfhhR+C5heak="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "41b48b17acf7a0e548f314b5328fa6bd9931d8b0",
-      "url": "https://github.com/juspay/kolu/archive/41b48b17acf7a0e548f314b5328fa6bd9931d8b0.tar.gz",
-      "hash": "sha256-bL4+u17ylOzewcJITGdvaz9nRwOBEVEAztmD+wjknnE="
+      "revision": "e35831de6d84087c26ef6f4b9d241b5841bece7c",
+      "url": "https://github.com/juspay/kolu/archive/e35831de6d84087c26ef6f4b9d241b5841bece7c.tar.gz",
+      "hash": "sha256-BDUPdj0KkFjiFPqOBy2Hqi7GxTPrsVCcSoYnJOuZTL0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "e35831de6d84087c26ef6f4b9d241b5841bece7c",
-      "url": "https://github.com/juspay/kolu/archive/e35831de6d84087c26ef6f4b9d241b5841bece7c.tar.gz",
-      "hash": "sha256-BDUPdj0KkFjiFPqOBy2Hqi7GxTPrsVCcSoYnJOuZTL0="
+      "revision": "6ad0b4a811e68346b8219c07c237e6149f21d32f",
+      "url": "https://github.com/juspay/kolu/archive/6ad0b4a811e68346b8219c07c237e6149f21d32f.tar.gz",
+      "hash": "sha256-Gmd1IBhJrTqjhUbKUfRrgzYcGOJGoMyL7H9gwa6vkjk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,8 +9,8 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c62af2f7d49887f9c3ca378c4aad622bf24d21d0",
-      "url": "https://github.com/juspay/kolu/archive/c62af2f7d49887f9c3ca378c4aad622bf24d21d0.tar.gz",
+      "revision": "07397fa22337eee6a0e1bef5a8bbc63617a3518c",
+      "url": "https://github.com/juspay/kolu/archive/07397fa22337eee6a0e1bef5a8bbc63617a3518c.tar.gz",
       "hash": "sha256-7B+RFQIJbyuriSLUqqHEq0ZFTPrZWP7BfhhR+C5heak="
     },
     "nixpkgs": {

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -63,6 +63,7 @@ import {
 } from "drishti-common/browser";
 import { reconcileRaiseTimes } from "./alertTiming";
 import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
+import { connectionOf } from "./entryStatusTone";
 import { HostDot } from "./HostDot";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";
@@ -856,7 +857,10 @@ function FleetView(props: {
 function HostCard(props: { host: string; onSelect: () => void }) {
   const entry = hostMap.entry(props.host);
   const system = entry.cells.system.use({});
-  const connection = entry.cells.connection.use({});
+  // SR9 — the fine connection (the word) rides the SAME entry as the dot; read it
+  // through `connectionOf` (the sole entry.state() seam) instead of a second
+  // `cells.connection` subscription (the drishti#102 split). Presentation unchanged.
+  const connection = () => connectionOf(entry.state());
   // The host's raised-alert set (kolu W5 `alerts` cell). A minimal pip on the
   // card surfaces "this host is in trouble" at a glance, alongside the OS
   // notification the app-scope `watchByEntry` fires — same source of truth. The
@@ -868,7 +872,7 @@ function HostCard(props: { host: string; onSelect: () => void }) {
 
   const sys = createMemo<SystemInfo>(() => system.value() ?? DEFAULT_SYSTEM);
   const state = createMemo<ConnectionState>(
-    () => (connection.value() ?? DEFAULT_CONNECTION).phase,
+    () => (connection() ?? DEFAULT_CONNECTION).phase,
   );
   // The dot + readiness gate read the host MAP's `EntryStatus` fact
   // (floored on real transport liveness by `connectSurfaceMap`) — the
@@ -1107,9 +1111,8 @@ function HostView(props: {
   const system = entry.cells.system.use({
     onError: (err) => console.error("system subscription failed", err),
   });
-  const connection = entry.cells.connection.use({
-    onError: (err) => console.error("connection subscription failed", err),
-  });
+  // SR9 — the word derives from the same entry the dot reads (no second subscription).
+  const connection = () => connectionOf(entry.state());
   const entryState = createMemo<EntryState<{ reason: string }>>(() => entry.state());
 
   // The host's raised-alert set (kolu W5 `alerts` cell). The fleet card shows a
@@ -1235,7 +1238,7 @@ function HostView(props: {
 
   const currentSystem = createMemo(() => system.value() ?? DEFAULT_SYSTEM);
   const currentConnection = createMemo(
-    () => connection.value() ?? DEFAULT_CONNECTION,
+    () => connection() ?? DEFAULT_CONNECTION,
   );
 
   // The connecting/failed overlay for the MIRROR axis (backend↔remote) —

--- a/packages/app/src/client/connectionAuthority.test.ts
+++ b/packages/app/src/client/connectionAuthority.test.ts
@@ -1,0 +1,76 @@
+/**
+ * SR9 · srid/drishti#102 regression pin — ONE connection authority.
+ *
+ * The bug: the connection DOT read the host-map entry's `EntryStatus`
+ * (transport-floored — it went green the moment the link was live) while the
+ * status WORD read a SEPARATE `cells.connection` subscription that could lag or
+ * wedge at "connecting…" forever. Result: a green dot beside a permanent
+ * "connecting" word, streaming metrics and all (#102).
+ *
+ * SR9 folds the fine connection ONTO the entry
+ * (`EntryState<Failure, ConnectionInfo>.connection`), co-produced with the coarse
+ * arm from one `SessionState` frame in kolu's single `serveHostMap` resolve — and
+ * kolu's `serveHostMap` asserts `EntryStatus === connected` iff
+ * `connection.phase === connected` before publication, so a half-updated pair has
+ * no construction path server-side. This test is the CLIENT-side fence: drishti
+ * derives BOTH the dot (`dotClass`) and the word (`connectionOf` → the fine
+ * `ConnectionInfo`) from the SAME `entry.state()` frame, so they cannot disagree —
+ * there is exactly one source. drishti has no browser e2e harness to drive a real
+ * connected host, so this steady-state joint-render assertion at the client's sole
+ * `entry.state()` seam is the achievable realization of the "dot AND word agree in
+ * one settled frame" invariant.
+ */
+import type { EntryState } from "@kolu/surface-map";
+import { testMembershipId } from "@kolu/surface-map/testing";
+import { describe, expect, it } from "bun:test";
+import type { ConnectionInfo } from "drishti-common/browser";
+import { STATE } from "./connectionColors";
+import { connectionOf, dotClass, statusTextClass } from "./entryStatusTone";
+
+/** One settled connected frame — the SINGLE object the dot AND the word read. */
+const connectedFrame: EntryState<{ reason: string }, ConnectionInfo> = {
+  kind: "connected",
+  membershipId: testMembershipId(),
+  clockOffset: 0,
+  connection: { phase: "connected", clockOffset: 0, log: [], sinceMs: 0 },
+};
+
+describe("connection authority (drishti#102 regression)", () => {
+  it("derives the dot and the word from ONE frame — both read connected", () => {
+    // The word is projected from the SAME frame the dot reads — the sole
+    // `entry.state()` seam, never a second `cells.connection` subscription.
+    const conn = connectionOf(connectedFrame);
+    expect(conn).toBeDefined();
+
+    // Coarse dot (status.kind) and fine word (connection.phase) both say
+    // "connected", and their colours agree — green beside "connected".
+    expect(dotClass(connectedFrame)).toContain("emerald"); // the dot
+    expect(statusTextClass(connectedFrame)).toContain("emerald");
+    expect(STATE[conn!.phase].label).toBe("connected"); // the word
+    expect(STATE[conn!.phase].text).toContain("emerald"); // word colour agrees
+    expect(STATE[conn!.phase].pending).toBe(false); // not "still connecting"
+  });
+
+  it("has no path to a connected dot beside a still-connecting word", () => {
+    // The #102 shape — a connected dot whose word is stuck "connecting" — is
+    // unrepresentable: the word's phase IS this frame's `connection.phase`, so a
+    // connected frame yields a non-pending, connected word by construction. There
+    // is no independent signal left that could sit at "connecting" on its own.
+    const conn = connectionOf(connectedFrame);
+    expect(conn?.phase).toBe("connected");
+    expect(STATE[conn!.phase].label).not.toBe("connecting…");
+  });
+
+  it("a warming frame's word tracks its own fine phase (still one source)", () => {
+    // A host still coming up: the dot is amber (warming) and the word rides the
+    // fine phase from the SAME frame — e.g. "copying" reads "provisioning agent…".
+    const warmingFrame: EntryState<{ reason: string }, ConnectionInfo> = {
+      kind: "warming",
+      membershipId: testMembershipId(),
+      connection: { phase: "copying", log: [], sinceMs: 0 },
+    };
+    expect(dotClass(warmingFrame)).not.toContain("emerald"); // dot: not green
+    const conn = connectionOf(warmingFrame);
+    expect(STATE[conn!.phase].pending).toBe(true); // word: in-flight, agrees
+  });
+});

--- a/packages/app/src/client/entryStatusTone.ts
+++ b/packages/app/src/client/entryStatusTone.ts
@@ -19,6 +19,7 @@
  */
 
 import type { EntryState } from "@kolu/surface-map";
+import type { ConnectionInfo } from "drishti-common/browser";
 
 // A pure kind→tone lookup as a `Record` keyed on the full `EntryState["kind"]`
 // union — so adding a fourth displayed kind is a compile error here
@@ -81,4 +82,23 @@ export function statusTitle(status: EntryState<{ reason: string }>): string {
  *  or fully-connected entry sits steady; only `warming` is "in flight". */
 export function statusPending(status: EntryState): boolean {
   return status.kind === "warming";
+}
+
+/**
+ * The FINE connection (the status *word*), read from the SAME `entry.state()`
+ * frame the dot reads — SR9's "one connection authority" on the drishti client.
+ *
+ * The word used to ride a SECOND, independent `cells.connection` subscription
+ * that could lag or wedge at "connecting…" while the entry's `EntryStatus` (the
+ * dot) had already gone green — srid/drishti#102. SR9 folds the fine connection
+ * ONTO the entry (`EntryState<Failure, ConnectionInfo>.connection`), co-produced
+ * with the coarse arm from one `SessionState` frame in kolu's single
+ * `serveHostMap` resolve. Deriving the word HERE — the sole `entry.state()` seam,
+ * beside `dotClass` — means the dot and the word cannot disagree: there is one
+ * source. A `not-a-member` entry (never reached) carries no connection.
+ */
+export function connectionOf<F>(
+  status: EntryState<F, ConnectionInfo>,
+): ConnectionInfo | undefined {
+  return status.kind === "not-a-member" ? undefined : status.connection;
 }

--- a/packages/app/src/common/hostMap.ts
+++ b/packages/app/src/common/hostMap.ts
@@ -19,6 +19,7 @@
  */
 
 import { defineSurfaceMap, type KeyCodec } from "@kolu/surface-map";
+import { ConnectionInfoSchema } from "@kolu/surface-remote/connection";
 import { browserSurface } from "drishti-common/browser";
 import { z } from "zod";
 
@@ -50,4 +51,8 @@ export const hostSurfaceMap = defineSurfaceMap({
   entry: browserSurface,
   codec: hostKeyCodec,
   failure: hostFailureSchema,
+  // SR9 — the fine connection payload rides every entry (the ONE authority): the client
+  // derives the connect overlay / status word from `entry.state().connection`, the SAME
+  // entry it reads the dot from — no second per-host subscription (fixes drishti#102).
+  connection: ConnectionInfoSchema,
 });

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -41,6 +41,7 @@ import { implement } from "@orpc/server";
 import { directLink } from "@kolu/surface/links/direct";
 import { implementSurfaces } from "@kolu/surface/server";
 import { serveHostMap } from "@kolu/surface-remote";
+import { sessionConnection } from "@kolu/surface-remote/connection";
 import { surfaceAppServer } from "@kolu/surface-app/server";
 import { adminContract, adminSurfaces } from "../common/admin-surface";
 import { hostSurfaceMap } from "../common/hostMap";
@@ -178,6 +179,14 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
       state.phase === "failed"
         ? { reason: (state as { error: string }).error }
         : null,
+    // SR9 — the entry's fine connection payload (the word), co-produced with the coarse
+    // dot from the SAME session frame; `sessionConnection` is the shared projection and
+    // `isConnected` the discriminant `serveHostMap` asserts the dot against (fail-loud on a
+    // dot/word disagreement — the drishti#102 divergence made structurally unspellable).
+    connection: {
+      project: sessionConnection,
+      isConnected: (c) => c.phase === "connected",
+    },
   });
 
   // `implement(adminContract).router(...)` WALKS `adminContract` to build the

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -45,15 +45,10 @@ import { type ProcedureForwarders } from "@kolu/surface/mirror";
 import {
   type AgentClient,
   pumpRemoteSurface,
-  seedConnectionCell,
   type Session,
   type SshProv,
 } from "@kolu/surface-remote";
-import {
-  type ConnectionInfo,
-  historySurface,
-  mirroredAgentSurface,
-} from "drishti-common/browser";
+import { historySurface, mirroredAgentSurface } from "drishti-common/browser";
 import {
   type CoreId,
   type CpuCore,
@@ -102,10 +97,6 @@ export function buildRouter(opts: BuildRouterOptions) {
   // re-served to the browser exactly like `system`. Seeds gate-closed
   // (`NO_ALERTS`) until the first agent frame lands.
   const alertsStore: CellStore<Alerts> = inMemoryStore({ ...NO_ALERTS });
-  // The seeded, gate-closed connection cell — the shared `seedConnectionCell()`,
-  // not a hand-rolled store. Written by `pumpRemoteSurface` off `session.onState`
-  // (the `connection` option below), which owns the subscription + teardown.
-  const connection = seedConnectionCell();
   const processCache = new Map<Pid, Process>();
   const coreCache = new Map<CoreId, CpuCore>();
   const netCache = new Map<IfaceName, NetInterface>();
@@ -134,15 +125,14 @@ export function buildRouter(opts: BuildRouterOptions) {
     current: ProcedureForwarders<typeof surface.spec> | null;
   } = { current: null };
 
-  // Implements the MIRRORED surface (base + the get-only `connection` cell). The
-  // base primitives are forwarded/folded from the agent; `connection` is the
+  // Implements the agent surface (SR9: no `connection` cell — link health rides the
+  // host-map entry). The base primitives are forwarded/folded from the agent; the
   // seeded local store the session pump writes — the agent's surface stays
   // connection-free.
   const runtime = implementSurface(mirroredAgentSurface, {
     cells: {
       system: { store: systemStore },
       alerts: { store: alertsStore },
-      connection,
     },
     collections: {
       processes: {
@@ -313,11 +303,6 @@ export function buildRouter(opts: BuildRouterOptions) {
     // the pump clears them the instant the link dies, so a kill in the gap
     // fails honestly rather than calling into a dead client.
     liveProcedures,
-    // The session's link health (copying / connecting / failed) onto the
-    // browser-facing `connection` cell — the pump OWNS this subscription for the
-    // session's lifetime and tears it down on exit (kolu #1568), so it can't be
-    // forgotten or leak. The cell tracks the SESSION's state, never a mirror frame.
-    connection: { set: (info) => runtime.ctx.cells.connection.set(info) },
     log,
   });
 
@@ -376,7 +361,6 @@ type FragmentCtx = {
     cells: {
       system: { set: (v: SystemInfo) => void };
       alerts: { set: (v: Alerts) => void };
-      connection: { set: (v: ConnectionInfo) => void };
     };
     collections: {
       processes: {

--- a/packages/common/src/browser.ts
+++ b/packages/common/src/browser.ts
@@ -8,16 +8,16 @@
  */
 
 import { defineSurface } from "@kolu/surface/define";
-import { mirroredSurface } from "@kolu/surface-remote/connection";
 import { z } from "zod";
 import { MetricHistoryMessage, surface } from "./surface";
 
-/** The MIRRORED agent surface: the agent's base `surface` augmented at the mirror
- *  seam with the gate-closed get-only `connection` cell. The PARENT mirrors this and
- *  serves the agent members from it (writing `connection` off `session.onState`).
- *  `metricHistory` is NOT here — it moved to parent-local policy (SR5), composed onto
- *  this via `extendSurface` (see app/server/router.ts). */
-export const mirroredAgentSurface = mirroredSurface(surface);
+/** The agent surface the parent serves, verbatim. SR9: no `connection` cell composed
+ *  here — link health rides the host-map entry's fine `connection` payload (the ONE
+ *  authority; see `hostMap.ts`'s `connection: ConnectionInfoSchema` + `admin-router.ts`'s
+ *  `serveHostMap` `connection.project`), which the client derives the word from off the
+ *  SAME entry it reads the dot. `metricHistory` is NOT here — it moved to parent-local
+ *  policy (SR5), composed on via `extendSurface` (see app/server/router.ts). */
+export const mirroredAgentSurface = surface;
 
 /** The parent-LOCAL metric-history member — retention lives on the parent, not the
  *  agent (whose inert stub is gone, SR5). The parent serves it from its own runtime


### PR DESCRIPTION
**Pins kolu to SR9 (`e35831de6`) and collapses drishti's dot and status word onto a single source**, fixing [#102](https://github.com/srid/drishti/issues/102) at the root: a green connection dot sitting beside a permanent "connecting…" word, streaming metrics and all.

The two were _independent_. The **dot** read the host-map entry's `EntryStatus` — transport-floored, so it went green the moment the link was live. The **word** read a *separate* `cells.connection` subscription that could lag or wedge at "connecting" forever. Nothing kept them in sync.

SR9 folds the fine connection **onto the entry** (`EntryState<Failure, ConnectionInfo>.connection`), co-produced with the coarse arm from one `SessionState` frame in kolu's single `serveHostMap` resolve — where kolu now asserts `EntryStatus === connected` **iff** `connection.phase === connected` before publication. drishti derives both facts from the same `entry.state()`:

| Fact | Before (#102) | After (SR9) |
| --- | --- | --- |
| Dot | `entry.state()` → `EntryStatus` | _unchanged_ |
| Word | a 2nd `cells.connection.use()` subscription | `connectionOf(entry.state())` — same frame |

- **server** — `hostSurfaceMap` gains `connection: ConnectionInfoSchema`; `admin-router` wires `sessionConnection` + `isConnected`, so every session-backed entry carries the fine `ConnectionInfo`.
- **client** — `entryStatusTone.connectionOf()` is the sole `entry.state()` seam for the word, beside `dotClass` for the dot. App.tsx's two `cells.connection.use({})` subscriptions are deleted; `router.ts` drops the connection-cell pump; `browser.ts` drops `mirroredSurface` (SR9 removes it kolu-side).

_`connectionColors` presentation is untouched — the word renders byte-identically, now sourced from the entry instead of a cell._

> ✅ **Acceptance (live).** srid deployed this pair + the kolu branch build to real hardware and **confirms #102 is fixed**: the dot and the word agree in the running app. The user-facing acceptance test has passed.

### Regression fence

`connectionAuthority.test.ts` pins the invariant at the client's sole seam: a connected frame yields a connected **dot** and a non-pending "connected" **word** from one source, and the #102 shape (green dot beside a stuck "connecting" word) has no construction path. _The row's steady-state e2e is realized as this **joint-render vitest pin**: drishti has no browser harness **by design** (only `bun:test` + GitHub Actions), and the delivery-divergence class **died with the second channel** — with one source there is nothing to go stale, so a Playwright harness would only re-prove an invariant that no longer has a construction path. Ratified by the SR9 coordinator._

> Pairs with **juspay/kolu#1836** — pinned to **kolu master @ `07397fa22`** — the commit that merged #1836 (identical tree to the `c62af2f7d` branch build this pair was verified green against; advanced off the merged branch per the #103/#104 pattern). Closes #102.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._


