### PR TITLE
SR8.c pin-proof: kolu@c7a6ed388 (kolu#1838)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "sr8c-home",
       "submodules": false,
-      "revision": "07397fa22337eee6a0e1bef5a8bbc63617a3518c",
-      "url": "https://github.com/juspay/kolu/archive/07397fa22337eee6a0e1bef5a8bbc63617a3518c.tar.gz",
-      "hash": "sha256-7B+RFQIJbyuriSLUqqHEq0ZFTPrZWP7BfhhR+C5heak="
+      "revision": "c7a6ed388e2352451f4074dd4d5c746570118331",
+      "url": "https://github.com/juspay/kolu/archive/c7a6ed388e2352451f4074dd4d5c746570118331.tar.gz",
+      "hash": "sha256-ZQjEHmCcnf9QHAVvX4gEIPur8ci3xbL9ophf4e2Y3hY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "sr8c-home",
+      "branch": "master",
       "submodules": false,
-      "revision": "c7a6ed388e2352451f4074dd4d5c746570118331",
-      "url": "https://github.com/juspay/kolu/archive/c7a6ed388e2352451f4074dd4d5c746570118331.tar.gz",
+      "revision": "181382ebb78154efdab7f704f9f2688c3d0498bf",
+      "url": "https://github.com/juspay/kolu/archive/181382ebb78154efdab7f704f9f2688c3d0498bf.tar.gz",
       "hash": "sha256-ZQjEHmCcnf9QHAVvX4gEIPur8ci3xbL9ophf4e2Y3hY="
     },
     "nixpkgs": {


### PR DESCRIPTION
Pin-proof for [kolu#1838](https://github.com/juspay/kolu/pull/1838) (SR8.c). Bumps the npins kolu pin to the final post-gauntlet SR8.c HEAD `c7a6ed388`.

SR8.c's `@kolu/surface` change is **purely additive** (`everyMsOr` graduated beside `everyMs`); drishti consumes none of the changed exports (odu-impact + drishti-impact both `none` — drishti uses `derived.cell(scan)` for its `alerts` cell + a plain interval install, no cadence fuse). This PR carries **no drishti code change** — it exists to prove drishti still builds and CI-greens against the SR8.c HEAD, per `.claude/rules/surface.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Post-merge repin:** kolu#1838 merged to master as `181382ebb`. Pin advanced from the PR-branch tip `c7a6ed388` to the master commit carrying it (identical surface API). `install` + `typecheck` green on the master pin.
