### PR TITLE
chore(deps): bump kolu pin to honest-liveness (LIVE-FIX pair, kolu#1852)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "honest-liveness",
+      "branch": "master",
       "submodules": false,
-      "revision": "7a81984d353b0d633538642222773bc6662d2303",
-      "url": "https://github.com/juspay/kolu/archive/7a81984d353b0d633538642222773bc6662d2303.tar.gz",
-      "hash": "sha256-KepIx7XC1CIeFgBfFMVBj2NkGDXmZC4Rd0CkWWX8BwM="
+      "revision": "77116330f60ea1cc84df6cd9ce38857781c35c4d",
+      "url": "https://github.com/juspay/kolu/archive/77116330f60ea1cc84df6cd9ce38857781c35c4d.tar.gz",
+      "hash": "sha256-wdpERc+S29la14RJ+rgG+RUZiIICqHhshmQ3z5d+1Hs="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "honest-liveness",
       "submodules": false,
-      "revision": "181382ebb78154efdab7f704f9f2688c3d0498bf",
-      "url": "https://github.com/juspay/kolu/archive/181382ebb78154efdab7f704f9f2688c3d0498bf.tar.gz",
-      "hash": "sha256-ZQjEHmCcnf9QHAVvX4gEIPur8ci3xbL9ophf4e2Y3hY="
+      "revision": "3a4646981ad74ac79c3d05342c465909c5c7d858",
+      "url": "https://github.com/juspay/kolu/archive/3a4646981ad74ac79c3d05342c465909c5c7d858.tar.gz",
+      "hash": "sha256-j5HofJAiAtIhp34cBEDzwoQXmqk17yJ/Mt5Ck4hbOXU="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
The `@kolu/surface-remote` companion PR for **[juspay/kolu#1852](https://github.com/juspay/kolu/pull/1852)** (LIVE-FIX — honest synchronous liveness at the surface-remote seam), per `.claude/rules/surface.md`. **kolu#1852 is now merged** (squash `77116330f`).

**Pins kolu `master@77116330f`** — the merge commit, so the pair validates against merged master (repinned from the pre-merge `honest-liveness` branch). Sits on drishti master's SR11 adoption ([#107](https://github.com/srid/drishti/pull/107), merged).

**Zero-code repin.** The only surface-API change kolu#1852 adds is the **additive** `Session.currentState()` (the synchronous point-read twin of `onState`). Drishti consumes `Session` via `makeSession` (`onState`/`reconnect`/`recheck`), never `currentClient`/`currentState`, so an additive interface method can't affect it.

**CI: green on both platforms** — two-platform `ci::default` at `4c2ea3b`: `x86_64-linux` (10/10) + `aarch64-darwin` (10/10) — `_ci-setup`, `_prefetch-crates`, `agent-boots`, `bun-nix-fresh`, `drv-stability`, `fmt-check`, `install`, `nix`, `typecheck`, `home-manager` all `ok`.

Pairs with kolu#1852. Ready.