### PR TITLE
Inherit the framework-owned stdio-agent exit: pin kolu@c0b631c69

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,8 +9,8 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c0b631c6952916065da947241c50d2e5200c877c",
-      "url": "https://github.com/juspay/kolu/archive/c0b631c6952916065da947241c50d2e5200c877c.tar.gz",
+      "revision": "2b70d2caf0c2010ed878dd1d7926b852a211661d",
+      "url": "https://github.com/juspay/kolu/archive/2b70d2caf0c2010ed878dd1d7926b852a211661d.tar.gz",
       "hash": "sha256-4YaLUL5e2Q5se/FpsXoCrTIXZ94/jAzNd4e9UrWagKI="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "77116330f60ea1cc84df6cd9ce38857781c35c4d",
-      "url": "https://github.com/juspay/kolu/archive/77116330f60ea1cc84df6cd9ce38857781c35c4d.tar.gz",
-      "hash": "sha256-wdpERc+S29la14RJ+rgG+RUZiIICqHhshmQ3z5d+1Hs="
+      "revision": "c0b631c6952916065da947241c50d2e5200c877c",
+      "url": "https://github.com/juspay/kolu/archive/c0b631c6952916065da947241c50d2e5200c877c.tar.gz",
+      "hash": "sha256-4YaLUL5e2Q5se/FpsXoCrTIXZ94/jAzNd4e9UrWagKI="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -298,6 +298,15 @@ export async function serveAgent(
       log(`first RPC received — link is live (pid=${process.pid})`);
     },
   });
+  // Synchronous post-settle cleanup — the supported window before the
+  // FRAMEWORK-OWNED exit: since kolu#1858, `serveOverStdio` on the default
+  // transport exits this process itself once the serve promise settles
+  // (0 on a clean end, 1 on a transport error), so a live handle (the
+  // reactor's collection polls, this poll interval) can no longer keep a
+  // dead agent alive — the drishti#109 orphan is unspellable, inherited
+  // from the framework rather than hand-rolled here. These synchronous
+  // lines run before that exit; the injected test fake keeps caller-owned
+  // lifetime, so tests are unaffected.
   clearInterval(waitingHeartbeat);
   clearInterval(interval);
   log("stdin closed — agent exiting");


### PR DESCRIPTION
**Closes #109 by inheritance, not by hand-rolled exit.** [juspay/kolu#1858](https://github.com/juspay/kolu/pull/1858) moves a stdio agent's process lifetime into the framework: `serveOverStdio` on the default transport now exits the process itself when the link ends — `0` for a clean end (stdin EOF *or* a benign peer-gone write death), `1` for a real transport error — after letting the agent's synchronous post-settle cleanup run. Any live handle (the reactor's collection polls, the 2 s poll interval) can no longer keep a dead agent alive, so the **one-orphan-per-reconnect pile-up** #109 documents (ten 130–200 MB re-parented `--stdio` agents on one fleet host) becomes structurally impossible.

This agent never had an exit to delete — *that absence was the bug*, and the fix lives at the only layer that can make the guarantee (the serve loop that saw EOF). The diff is therefore just:

- **npins**: kolu `77116330f` → `c0b631c69` (the final post-gauntlet kolu PR HEAD, per the surface pairing rule; advances to the master merge commit once kolu#1858 lands),
- **one comment** at the serve site documenting the inherited lifetime and why the post-settle `clearInterval`s still run (the settle's microtask cascade precedes the framework exit; the injected test fake keeps caller-owned lifetime, so tests are untouched).

Validated at the pin on a clean box: install (hydrates `@kolu/*` from the pinned kolu) + typecheck (all three workspaces) + **169/169 unit tests**. Full CI on this PR is the pairing gate.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8[1m]`)._