### PR TITLE
Install attic from the pinned nixpkgs; drop attic-action

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Pin by commit (CodeQL: unpinned third-party action). v35 → 9f63be7.
-      # v35 defaults to Nix 2.34.7, new enough for attic-action's `nix profile add`.
+      # v35 defaults to Nix 2.34.7, new enough for `nix profile add`.
       - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           nix_conf: |
@@ -35,11 +35,35 @@ jobs:
             extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
             accept-flake-config = true
 
-      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
-        with:
-          endpoint: https://cache.nixos.asia
-          cache: oss
-          token: ${{ secrets.ATTIC_TOKEN }}
+      # ryanccn/attic-action used to do the install/login/push below, but it
+      # installs attic by resolving UNPINNED nixpkgs-unstable through the
+      # GitHub API at run time — one API 503 fails the job (it did, here and
+      # repo-wide in kolu, 2026-07-16), and even green runs re-fetch an
+      # unpinned rev. Its logic is four CLI calls, so do them directly,
+      # installing attic from the repo's own npins-pinned nixpkgs: the exact
+      # tarball URL nix/nixpkgs.nix builds from (no ref resolution, no
+      # api.github.com), with attic-client substituted from cache.nixos.org.
+      # No `attic use` — the nix_conf above already wires the substituter.
+      # Ported from kolu #1869 (merge 5c687e0b0).
+      - name: Install attic (pinned) and log in
+        run: |
+          nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"
+          attic login --set-default oss https://cache.nixos.asia '${{ secrets.ATTIC_TOKEN }}'
+          nix path-info --all | sort > "$RUNNER_TEMP/pre-build-paths"
 
       - name: Build
         run: nix build -L --print-out-paths
+
+      # Push every store path the build produced (post minus pre snapshot,
+      # minus .drv/.check/.lock clutter) — same set attic-action pushed from
+      # its post step, without the action. A failed build pushes nothing
+      # (deliberate difference: the action's post-step pushed partial paths).
+      - name: Push to Attic
+        # Explicit `shell: bash` turns on pipefail, so a failure anywhere in
+        # the pipe fails the step — not just the final `attic push`.
+        shell: bash
+        run: |
+          nix path-info --all | sort \
+            | comm -13 "$RUNNER_TEMP/pre-build-paths" - \
+            | grep -Ev '\.(drv|drv\.chroot|check|lock)$' \
+            | attic push --stdin oss


### PR DESCRIPTION
**The `nix-cache` workflow no longer resolves unpinned `nixpkgs-unstable` through the GitHub API at run time** — the fragility that red-flagged #113's runs on both matrix legs today (`Unable to locate executable file: attic` after five 503s), and the reason even green runs re-fetched an unpinned rev. This is a structural port of juspay/kolu#1869 (merge `5c687e0b0`) to drishti's identical workflow: same zero-inputs flake, same npins pin shape (`nix/nixpkgs.nix` builds from the exact tarball URL the new step installs attic from), same `oss` cache and `ATTIC_TOKEN` wiring.

| attic-action did | now |
| --- | --- |
| `nix profile add github:NixOS/nixpkgs/nixpkgs-unstable#attic-client` (unpinned, API ref-resolution) | `nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"` (pinned, no api.github.com) |
| `attic login --set-default …` | same, direct |
| `attic use oss` (duplicate substituter config) | dropped — `nix_conf` already wires the substituter |
| post-step path diff → `attic push --stdin` | explicit `Push to Attic` step with `pipefail` |

_No retry knobs — a retry around an unpinned fetch would be a fallback, not a fix._ One deliberate semantic difference: a failed build pushes nothing, where the action's post-step pushed partial paths.

> Validation: this workflow runs on `pull_request`, so its own run on this PR is the test — watch `build-and-push` on both matrix legs. #113's attic red clears once this lands and its runs re-fire.

_Generated by the DRATTIC lane on Claude Code (model `claude-opus-4-8`)._