### PR TITLE
Bump kolu pin to #1876 (kaval contract-skew fix)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2b70d2caf0c2010ed878dd1d7926b852a211661d",
-      "url": "https://github.com/juspay/kolu/archive/2b70d2caf0c2010ed878dd1d7926b852a211661d.tar.gz",
-      "hash": "sha256-4YaLUL5e2Q5se/FpsXoCrTIXZ94/jAzNd4e9UrWagKI="
+      "revision": "619d0659048d9c1b8d0e3ef4e841db58c5ebf8af",
+      "url": "https://github.com/juspay/kolu/archive/619d0659048d9c1b8d0e3ef4e841db58c5ebf8af.tar.gz",
+      "hash": "sha256-gWcNEwWWgX86aUg86o/VX4n+4rmRVfYXFQMKrwddEz8="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pairs [juspay/kolu#1876](https://github.com/juspay/kolu/pull/1876) — the remote-host kaval contract-skew fix — per the `surface.md` pair-gate.

That PR changes the shared `@kolu/surface` / `@kolu/surface-remote` API:

- **`ProcedureSpec.errors`** — a new *optional* declared-error map (additive; existing spec literals compile unchanged).
- **`BoundProcedure`** now returns oRPC's `ClientPromiseResult<O, E>` instead of `Promise<O>` — a **subtype** of `Promise<O>`, so awaiting and assignment are unaffected.
- **`makeSession`**'s `onLog` → `log: Logger` — drishti passes neither.

**No drishti code change is needed** — a grounded grep of drishti at its pin found no `onLog` use, no `errors` specs, and drishti's consumers `await`/assign procedure results (a `ClientPromiseResult` *is* a `Promise`). This PR's job is to **prove** that: green drishti CI against the new surface API is the pair-gate.

> Bump only — `npins/sources.json` kolu → `619d0659`.

_Generated pairing juspay/kolu#1876 on Claude Code (model `claude-opus-4-8[1m]`)._