### PR TITLE
Compose a localhost spawn env for surface-remote (pair for kolu#1884)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "spawn-localhost",
+      "branch": "master",
       "submodules": false,
-      "revision": "5c1ab103136a71f54832fd06dfa293111a91fd64",
-      "url": "https://github.com/juspay/kolu/archive/5c1ab103136a71f54832fd06dfa293111a91fd64.tar.gz",
-      "hash": "sha256-BwIr2cRsnAYcztb5D0oKqFze8Ij5q+H2AGTPpphcmDQ="
+      "revision": "8ce6fd1c4555a8ac98f79ccc7db675eb480593ca",
+      "url": "https://github.com/juspay/kolu/archive/8ce6fd1c4555a8ac98f79ccc7db675eb480593ca.tar.gz",
+      "hash": "sha256-uGxbWDb6tx14/5i7qxLrJrF7MQE7XcygZx/qjpydl3o="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "spawn-localhost",
       "submodules": false,
-      "revision": "bab9c1bde71bcf09b2e1a1c09f0052bf3bce67f1",
-      "url": "https://github.com/juspay/kolu/archive/bab9c1bde71bcf09b2e1a1c09f0052bf3bce67f1.tar.gz",
-      "hash": "sha256-NAtXCTsJWqowEm39jQUtFvreXsDFUpyaJQjeIO9L/2g="
+      "revision": "5c1ab103136a71f54832fd06dfa293111a91fd64",
+      "url": "https://github.com/juspay/kolu/archive/5c1ab103136a71f54832fd06dfa293111a91fd64.tar.gz",
+      "hash": "sha256-BwIr2cRsnAYcztb5D0oKqFze8Ij5q+H2AGTPpphcmDQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/hostRegistry.ts
+++ b/packages/app/src/server/hostRegistry.ts
@@ -93,6 +93,19 @@ export function buildHostPool(opts: HostPoolOptions): HostPool {
         connectOnce: sshConnector<typeof surface.contract>({
           host,
           binary: "drishti-agent",
+          // surface-remote is policy-free: the CONSUMER composes the localhost arm's
+          // spawn env (kolu#1884 / #1872). drishti dials "localhost" for real (every
+          // host, including localhost, dials through this connector — see below), so a
+          // localhost drishti-agent must run with EXACTLY this composed env, never
+          // drishti-server's ambient `process.env` (identity vars, secrets). drishti
+          // can't import kolu-pty's `composeSpawnEnv`, so it picks a clean base inline,
+          // omitting any UNSET key (an empty HOME/PATH would misdirect lookups). Unused
+          // on a real ssh host, where the local ssh client legitimately inherits.
+          localEnv: Object.fromEntries(
+            (["HOME", "PATH"] as const)
+              .map((k): [string, string | undefined] => [k, process.env[k]])
+              .filter((e): e is [string, string] => e[1] !== undefined),
+          ),
           resolveDrvPath: () => opts.resolveDrvPath(host),
         }),
         // `sshConnector` PROVISIONS (nix-copies the agent closure before


### PR DESCRIPTION
Pair for [juspay/kolu#1884](https://github.com/juspay/kolu/pull/1884) (PR1.5 of the agent-spawn-first-class plan, kolu#1872).

kolu#1884 makes `@kolu/surface-remote`'s `sshConnector` require a **`localEnv`** — the composed env for the localhost spawn arm — so a `localhost` dial can never silently inherit the caller's ambient `process.env` (identity vars, secrets). This updates drishti's consumer for the new required field.

**drishti dials `localhost` for real.** `hostRegistry.ts`'s comment is explicit — *"every drishti host, including 'localhost', dials through it"* — so this isn't a type formality: a localhost `drishti-agent` used to spawn carrying drishti-server's full ambient env. It now runs with a caller-composed clean env.

Since `@kolu/surface-remote` is **policy-free** (it routes the env, never composes it) and drishti can't import kolu's `kolu-pty`, drishti composes a clean base inline — the `HOME`/`PATH` a spawn needs, omitting any unset key (an empty `HOME`/`PATH` would misdirect lookups). Unused on a real ssh host, where the local ssh client legitimately inherits.

- kolu pin bumped to the pair HEAD of kolu#1884.
- One consumer site: `packages/app/src/server/hostRegistry.ts`.

Pairs-with: juspay/kolu#1884. Merge after (or alongside) it; drishti CI green against the new surface API.
