### PR TITLE
chore(deps): bump kolu pin to #1908 PR1 (surface-remote lifetime ownership)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "provision-deadline",
+      "branch": "master",
       "submodules": false,
-      "revision": "9b3851740166ff8ec7bf9ec86281e8933e9366a4",
-      "url": "https://github.com/juspay/kolu/archive/9b3851740166ff8ec7bf9ec86281e8933e9366a4.tar.gz",
-      "hash": "sha256-9ZmpMT0/cH5OZoBv55yG8zQuAyz+O4jSP5MS7qAqTBA="
+      "revision": "ceb1eae05ea04eee8215f64d8542510021f5c225",
+      "url": "https://github.com/juspay/kolu/archive/ceb1eae05ea04eee8215f64d8542510021f5c225.tar.gz",
+      "hash": "sha256-BPYVPDrHms67YCqn6iocnqWAJdVIJEbPfkbOhscG5F4="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "provision-deadline",
       "submodules": false,
-      "revision": "8ce6fd1c4555a8ac98f79ccc7db675eb480593ca",
-      "url": "https://github.com/juspay/kolu/archive/8ce6fd1c4555a8ac98f79ccc7db675eb480593ca.tar.gz",
-      "hash": "sha256-uGxbWDb6tx14/5i7qxLrJrF7MQE7XcygZx/qjpydl3o="
+      "revision": "8587cebef416b84664d34a98fda9fc223a0948bc",
+      "url": "https://github.com/juspay/kolu/archive/8587cebef416b84664d34a98fda9fc223a0948bc.tar.gz",
+      "hash": "sha256-qtDssWPu5OLjebHPBYVF14aznQ74jyIOPp3HNiW9ytI="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "provision-deadline",
       "submodules": false,
-      "revision": "8587cebef416b84664d34a98fda9fc223a0948bc",
-      "url": "https://github.com/juspay/kolu/archive/8587cebef416b84664d34a98fda9fc223a0948bc.tar.gz",
-      "hash": "sha256-qtDssWPu5OLjebHPBYVF14aznQ74jyIOPp3HNiW9ytI="
+      "revision": "9b3851740166ff8ec7bf9ec86281e8933e9366a4",
+      "url": "https://github.com/juspay/kolu/archive/9b3851740166ff8ec7bf9ec86281e8933e9366a4.tar.gz",
+      "hash": "sha256-9ZmpMT0/cH5OZoBv55yG8zQuAyz+O4jSP5MS7qAqTBA="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pair PR for **juspay/kolu#1913** (#1908 outage fix — provisioning subprocess lifetime ownership + honest campaign clock).

Bumps drishti's kolu pin to PR1 HEAD (`8587cebef`, tracks the `provision-deadline` branch).

**Impact: none.** drishti consumes only high-level `@kolu/surface-remote` exports (`serveHostMap`, `buildRemotePool`, `resolveSystem`, `sessionConnection`, `ConnectionInfoSchema`) — grep-verified none changed. The changed/new surface is all lower-level (`runProgress`/`runCapture` required `LifetimePolicy`, `ConnectContext.signal`/`.campaignEpoch`, `ProvisionOptions` budgets) which drishti does not import. This bump re-validates drishti CI stays green against the new API.

Link: juspay/kolu#1913