### PR TITLE
Pair for kolu#1964: pin kolu@conn-progress (provision progress + quiet fail-through)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "conn-progress",
       "submodules": false,
-      "revision": "ceb1eae05ea04eee8215f64d8542510021f5c225",
-      "url": "https://github.com/juspay/kolu/archive/ceb1eae05ea04eee8215f64d8542510021f5c225.tar.gz",
-      "hash": "sha256-BPYVPDrHms67YCqn6iocnqWAJdVIJEbPfkbOhscG5F4="
+      "revision": "8cf4857c86dfcf100f84661aec9e8bc492bb0c88",
+      "url": "https://github.com/juspay/kolu/archive/8cf4857c86dfcf100f84661aec9e8bc492bb0c88.tar.gz",
+      "hash": "sha256-3rsl9y71O0Uc2o+6wjRn6U38cLEZLN/nI8g9kHz1byc="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "conn-progress",
       "submodules": false,
-      "revision": "928a7d79c17d6c1c14d6b80abd648922df4f15d8",
-      "url": "https://github.com/juspay/kolu/archive/928a7d79c17d6c1c14d6b80abd648922df4f15d8.tar.gz",
-      "hash": "sha256-Fn0kcVW0Uh0otdeMsp9RSFckXXIYKlfPOSGNtwDGo1U="
+      "revision": "a37a879f6d260c6b2a86bdb132dd8d5425e51140",
+      "url": "https://github.com/juspay/kolu/archive/a37a879f6d260c6b2a86bdb132dd8d5425e51140.tar.gz",
+      "hash": "sha256-vFeWNffQhZ8lkIPNgZ9/QnzuB3bSz3yLoJzfH2lM4TI="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "conn-progress",
       "submodules": false,
-      "revision": "c02bd1b249182b4bcf6d9299d89bcab2058e92ce",
-      "url": "https://github.com/juspay/kolu/archive/c02bd1b249182b4bcf6d9299d89bcab2058e92ce.tar.gz",
-      "hash": "sha256-Mh3oph55kqHgClbKQ314Wg+ev8mq/lQW4770OgX1yJk="
+      "revision": "928a7d79c17d6c1c14d6b80abd648922df4f15d8",
+      "url": "https://github.com/juspay/kolu/archive/928a7d79c17d6c1c14d6b80abd648922df4f15d8.tar.gz",
+      "hash": "sha256-Fn0kcVW0Uh0otdeMsp9RSFckXXIYKlfPOSGNtwDGo1U="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "conn-progress",
+      "branch": "master",
       "submodules": false,
-      "revision": "a37a879f6d260c6b2a86bdb132dd8d5425e51140",
-      "url": "https://github.com/juspay/kolu/archive/a37a879f6d260c6b2a86bdb132dd8d5425e51140.tar.gz",
-      "hash": "sha256-vFeWNffQhZ8lkIPNgZ9/QnzuB3bSz3yLoJzfH2lM4TI="
+      "revision": "29642d4ed5618d3db14b983dadeb7229835752b2",
+      "url": "https://github.com/juspay/kolu/archive/29642d4ed5618d3db14b983dadeb7229835752b2.tar.gz",
+      "hash": "sha256-mxZuVSOgdYXFWjES1QC1EureeDscPfKJgLb+Y17jhDA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "conn-progress",
       "submodules": false,
-      "revision": "8cf4857c86dfcf100f84661aec9e8bc492bb0c88",
-      "url": "https://github.com/juspay/kolu/archive/8cf4857c86dfcf100f84661aec9e8bc492bb0c88.tar.gz",
-      "hash": "sha256-3rsl9y71O0Uc2o+6wjRn6U38cLEZLN/nI8g9kHz1byc="
+      "revision": "c02bd1b249182b4bcf6d9299d89bcab2058e92ce",
+      "url": "https://github.com/juspay/kolu/archive/c02bd1b249182b4bcf6d9299d89bcab2058e92ce.tar.gz",
+      "hash": "sha256-Mh3oph55kqHgClbKQ314Wg+ev8mq/lQW4770OgX1yJk="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pair PR for **[juspay/kolu#1964](https://github.com/juspay/kolu/pull/1964)** — remote-host connect UX: live nix byte/path progress during provisioning, wall-clock connect elapsed timer, and fail-through streams that **wait** for a live spawn instead of throwing every second during building.

Bumps drishti's kolu pin to `8cf4857c` on the `conn-progress` branch.

### Impact on drishti: **none** (pin-only)

| Changed kolu surface | drishti usage |
| --- | --- |
| `relayFailThroughStream` / `failThroughStreamCore` now take `ObservableHolder` | **not imported** — re-serve assembly is kolu-server-only; drishti uses `pumpRemoteSurface` |
| `provisionAgent` realises via `nix build --log-format internal-json` + progress reporter | rides through `sshConnector` unchanged at the call site; progress lines still land on `onProgress` as strings |
| ConnectCanvas wall-clock timer | client-only (kolu) |

drishti continues to consume only high-level exports (`buildRemotePool`, `makeSession`, `sshConnector`, `serveHostMap`, `resolveSystem`, `pumpRemoteSurface`, `sessionConnection` / connection schemas) — grep-verified none require a code change. This bump re-validates CI green against the new API.

Link: juspay/kolu#1964

_Generated by Grok CLI (model `grok-4.5`)._