### PR TITLE
Pair Drishti with Kolu's lazy agent resolver

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,8 +38,8 @@
         "cleye": "^2.3.0",
         "drishti-common": "workspace:*",
         "hono": "^4.12.16",
-        "lru-cache": "^11.2.7",
         "partysocket": "^1.1.16",
+        "quick-lru": "^7.3.0",
         "solid-js": "^1.9.0",
         "ws": "^8.20.1",
         "zod": "^4.3.6",
@@ -329,7 +329,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -350,6 +350,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "quick-lru": ["quick-lru@7.3.0", "", {}, "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g=="],
 
     "radash": ["radash@12.1.1", "", {}, "sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA=="],
 
@@ -386,8 +388,6 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "cleye": "^2.3.0",
         "drishti-common": "workspace:*",
         "hono": "^4.12.16",
+        "lru-cache": "^11.2.7",
         "partysocket": "^1.1.16",
         "solid-js": "^1.9.0",
         "ws": "^8.20.1",
@@ -328,7 +329,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -385,6 +386,8 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -38,9 +38,12 @@
         "cleye": "^2.3.0",
         "drishti-common": "workspace:*",
         "hono": "^4.12.16",
+        "neverthrow": "^8.2.0",
         "partysocket": "^1.1.16",
         "quick-lru": "^7.3.0",
         "solid-js": "^1.9.0",
+        "split2": "^4.2.0",
+        "ts-pattern": "^5.9.0",
         "ws": "^8.20.1",
         "zod": "^4.3.6",
       },
@@ -48,6 +51,7 @@
         "@types/babel__core": "^7.20.5",
         "@types/bun": "^1.2.0",
         "@types/node": "^22.0.0",
+        "@types/split2": "^4.2.3",
         "@types/ws": "^8.18.1",
         "typescript": "^5.8.0",
       },
@@ -185,6 +189,8 @@
 
     "@preact/signals-core": ["@preact/signals-core@1.14.4", "", {}, "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA=="],
 
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="],
+
     "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.5", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA=="],
 
     "@solid-primitives/keyed": ["@solid-primitives/keyed@1.5.3", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-zNadtyYBhJSOjXtogkGHmRxjGdz9KHc8sGGVAGlUABkE8BED2tbIZoxkwSqzOwde8OcUEH0bb5DLZUWIMvyBSA=="],
@@ -242,6 +248,8 @@
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+
+    "@types/split2": ["@types/split2@4.2.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-59OXIlfUsi2k++H6CHgUQKEb2HKRokUA39HY1i1dS8/AIcqVjtAAFdf8u+HxTWK/4FUHMJQlKSZ4I6irCBJ1Zw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -337,6 +345,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
+
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-releases": ["node-releases@2.0.46", "", {}, "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ=="],
@@ -365,6 +375,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
@@ -372,6 +384,8 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
+
+    "ts-pattern": ["ts-pattern@5.9.0", "", {}, "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg=="],
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -268,6 +268,10 @@
     url = "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz";
     hash = "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==";
   };
+  "@rollup/rollup-linux-x64-gnu@4.62.2" = fetchurl {
+    url = "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz";
+    hash = "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==";
+  };
   "@solid-primitives/event-listener@2.4.5" = fetchurl {
     url = "https://registry.npmjs.org/@solid-primitives/event-listener/-/event-listener-2.4.5.tgz";
     hash = "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==";
@@ -387,6 +391,10 @@
   "@types/node@22.19.19" = fetchurl {
     url = "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz";
     hash = "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==";
+  };
+  "@types/split2@4.2.3" = fetchurl {
+    url = "https://registry.npmjs.org/@types/split2/-/split2-4.2.3.tgz";
+    hash = "sha512-59OXIlfUsi2k++H6CHgUQKEb2HKRokUA39HY1i1dS8/AIcqVjtAAFdf8u+HxTWK/4FUHMJQlKSZ4I6irCBJ1Zw==";
   };
   "@types/ws@8.18.1" = fetchurl {
     url = "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz";
@@ -567,6 +575,10 @@
     url = "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz";
     hash = "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
   };
+  "neverthrow@8.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/neverthrow/-/neverthrow-8.2.0.tgz";
+    hash = "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==";
+  };
   "node-addon-api@7.1.1" = fetchurl {
     url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz";
     hash = "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==";
@@ -623,6 +635,10 @@
     url = "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz";
     hash = "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==";
   };
+  "split2@4.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz";
+    hash = "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==";
+  };
   "tagged-tag@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz";
     hash = "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==";
@@ -638,6 +654,10 @@
   "terminal-columns@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/terminal-columns/-/terminal-columns-2.0.0.tgz";
     hash = "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ==";
+  };
+  "ts-pattern@5.9.0" = fetchurl {
+    url = "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz";
+    hash = "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==";
   };
   "tslib@2.8.1" = fetchurl {
     url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";

--- a/bun.nix
+++ b/bun.nix
@@ -551,6 +551,10 @@
     url = "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz";
     hash = "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==";
   };
+  "lru-cache@11.5.2" = fetchurl {
+    url = "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz";
+    hash = "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==";
+  };
   "lru-cache@5.1.1" = fetchurl {
     url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
     hash = "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";

--- a/bun.nix
+++ b/bun.nix
@@ -551,10 +551,6 @@
     url = "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz";
     hash = "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==";
   };
-  "lru-cache@11.5.2" = fetchurl {
-    url = "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz";
-    hash = "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==";
-  };
   "lru-cache@5.1.1" = fetchurl {
     url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
     hash = "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
@@ -598,6 +594,10 @@
   "picomatch@4.0.4" = fetchurl {
     url = "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz";
     hash = "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==";
+  };
+  "quick-lru@7.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz";
+    hash = "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==";
   };
   "radash@12.1.1" = fetchurl {
     url = "https://registry.npmjs.org/radash/-/radash-12.1.1.tgz";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "deocouple-flake",
       "submodules": false,
-      "revision": "6c1a8824a6bf48a250efc545c3a3b672cd2f962f",
-      "url": "https://github.com/juspay/kolu/archive/6c1a8824a6bf48a250efc545c3a3b672cd2f962f.tar.gz",
-      "hash": "sha256-XJBqkvVyJPtPGaQE9Z7l7OKJAYXl/5ROchIIlxg1SlY="
+      "revision": "f9c891d8100c675664562c48244a9bf8b405e51e",
+      "url": "https://github.com/juspay/kolu/archive/f9c891d8100c675664562c48244a9bf8b405e51e.tar.gz",
+      "hash": "sha256-6PaLBhqYMf6OQyzzPWt5q76Rpyu7Uy6LhFh0FE2RtnM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "deocouple-flake",
       "submodules": false,
-      "revision": "434961cf32a82c2503ea7f00488c9daacbdc01f9",
-      "url": "https://github.com/juspay/kolu/archive/434961cf32a82c2503ea7f00488c9daacbdc01f9.tar.gz",
-      "hash": "sha256-nXyM/aFlHYu28qeeAfo+jCnEztvh+p9rMIxPqGd0P1A="
+      "revision": "6f1b5bceabf029f6e8bb23f4de732648b1635395",
+      "url": "https://github.com/juspay/kolu/archive/6f1b5bceabf029f6e8bb23f4de732648b1635395.tar.gz",
+      "hash": "sha256-8B20Dbw8IQuCWeJzkOO+WtCTMssDK5q3a+VfBBqouRo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "deocouple-flake",
+      "branch": "master",
       "submodules": false,
-      "revision": "6f1b5bceabf029f6e8bb23f4de732648b1635395",
-      "url": "https://github.com/juspay/kolu/archive/6f1b5bceabf029f6e8bb23f4de732648b1635395.tar.gz",
+      "revision": "3ff256f0d3de8cb585e588f490bae5b42eb7d89c",
+      "url": "https://github.com/juspay/kolu/archive/3ff256f0d3de8cb585e588f490bae5b42eb7d89c.tar.gz",
       "hash": "sha256-8B20Dbw8IQuCWeJzkOO+WtCTMssDK5q3a+VfBBqouRo="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "deocouple-flake",
       "submodules": false,
-      "revision": "f9c891d8100c675664562c48244a9bf8b405e51e",
-      "url": "https://github.com/juspay/kolu/archive/f9c891d8100c675664562c48244a9bf8b405e51e.tar.gz",
-      "hash": "sha256-6PaLBhqYMf6OQyzzPWt5q76Rpyu7Uy6LhFh0FE2RtnM="
+      "revision": "434961cf32a82c2503ea7f00488c9daacbdc01f9",
+      "url": "https://github.com/juspay/kolu/archive/434961cf32a82c2503ea7f00488c9daacbdc01f9.tar.gz",
+      "hash": "sha256-nXyM/aFlHYu28qeeAfo+jCnEztvh+p9rMIxPqGd0P1A="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "deocouple-flake",
       "submodules": false,
-      "revision": "9a8e0ce587aa84791497699e88678b20dabdd0bb",
-      "url": "https://github.com/juspay/kolu/archive/9a8e0ce587aa84791497699e88678b20dabdd0bb.tar.gz",
-      "hash": "sha256-FqlBl9DbRbNtvKtcT5sF8f36i1VU5rxl7cWu6oZreR0="
+      "revision": "6c1a8824a6bf48a250efc545c3a3b672cd2f962f",
+      "url": "https://github.com/juspay/kolu/archive/6c1a8824a6bf48a250efc545c3a3b672cd2f962f.tar.gz",
+      "hash": "sha256-XJBqkvVyJPtPGaQE9Z7l7OKJAYXl/5ROchIIlxg1SlY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "deocouple-flake",
       "submodules": false,
-      "revision": "29642d4ed5618d3db14b983dadeb7229835752b2",
-      "url": "https://github.com/juspay/kolu/archive/29642d4ed5618d3db14b983dadeb7229835752b2.tar.gz",
-      "hash": "sha256-mxZuVSOgdYXFWjES1QC1EureeDscPfKJgLb+Y17jhDA="
+      "revision": "9a8e0ce587aa84791497699e88678b20dabdd0bb",
+      "url": "https://github.com/juspay/kolu/archive/9a8e0ce587aa84791497699e88678b20dabdd0bb.tar.gz",
+      "hash": "sha256-FqlBl9DbRbNtvKtcT5sF8f36i1VU5rxl7cWu6oZreR0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; quick-lru backs surface-remote's bounded successful derivation cache. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
+  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; neverthrow carries Surface Remote's explicit agent-source result, quick-lru bounds its successful derivation cache, split2 frames child output, and ts-pattern keeps its closed state folds exhaustive. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
   "scripts": {
     "dev": "bun --watch src/server/main.ts",
     "start": "bun src/server/main.ts",
@@ -25,9 +25,12 @@
     "cleye": "^2.3.0",
     "drishti-common": "workspace:*",
     "hono": "^4.12.16",
+    "neverthrow": "^8.2.0",
     "partysocket": "^1.1.16",
     "quick-lru": "^7.3.0",
     "solid-js": "^1.9.0",
+    "split2": "^4.2.0",
+    "ts-pattern": "^5.9.0",
     "ws": "^8.20.1",
     "zod": "^4.3.6"
   },
@@ -35,6 +38,7 @@
     "@types/babel__core": "^7.20.5",
     "@types/bun": "^1.2.0",
     "@types/node": "^22.0.0",
+    "@types/split2": "^4.2.3",
     "@types/ws": "^8.18.1",
     "typescript": "^5.8.0"
   }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch surface-map (juspay/kolu's dynamic host-map framework) which ships the package source, those signals, and defineSurfaceMap/serveSurfaceMap/connectSurfaceMap.",
+  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; lru-cache backs surface-remote's bounded successful derivation cache. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
   "scripts": {
     "dev": "bun --watch src/server/main.ts",
     "start": "bun src/server/main.ts",
@@ -25,6 +25,7 @@
     "cleye": "^2.3.0",
     "drishti-common": "workspace:*",
     "hono": "^4.12.16",
+    "lru-cache": "^11.2.7",
     "partysocket": "^1.1.16",
     "solid-js": "^1.9.0",
     "ws": "^8.20.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; lru-cache backs surface-remote's bounded successful derivation cache. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
+  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; quick-lru backs surface-remote's bounded successful derivation cache. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
   "scripts": {
     "dev": "bun --watch src/server/main.ts",
     "start": "bun src/server/main.ts",
@@ -25,8 +25,8 @@
     "cleye": "^2.3.0",
     "drishti-common": "workspace:*",
     "hono": "^4.12.16",
-    "lru-cache": "^11.2.7",
     "partysocket": "^1.1.16",
+    "quick-lru": "^7.3.0",
     "solid-js": "^1.9.0",
     "ws": "^8.20.1",
     "zod": "^4.3.6"

--- a/packages/app/src/client/connectionAuthority.test.ts
+++ b/packages/app/src/client/connectionAuthority.test.ts
@@ -32,7 +32,13 @@ const connectedFrame: EntryState<{ reason: string }, ConnectionInfo> = {
   kind: "connected",
   membershipId: testMembershipId(),
   clockOffset: 0,
-  connection: { phase: "connected", clockOffset: 0, log: [], sinceMs: 0 },
+  connection: {
+    phase: "connected",
+    clockOffset: 0,
+    log: [],
+    sinceMs: 0,
+    campaignEpoch: 0,
+  },
 };
 
 describe("connection authority (drishti#102 regression)", () => {
@@ -67,7 +73,12 @@ describe("connection authority (drishti#102 regression)", () => {
     const warmingFrame: EntryState<{ reason: string }, ConnectionInfo> = {
       kind: "warming",
       membershipId: testMembershipId(),
-      connection: { phase: "copying", log: [], sinceMs: 0 },
+      connection: {
+        phase: "copying",
+        log: [],
+        sinceMs: 0,
+        campaignEpoch: 0,
+      },
     };
     expect(dotClass(warmingFrame)).not.toContain("emerald"); // dot: not green
     const conn = connectionOf(warmingFrame);

--- a/packages/app/src/client/connectionAuthority.test.ts
+++ b/packages/app/src/client/connectionAuthority.test.ts
@@ -69,12 +69,12 @@ describe("connection authority (drishti#102 regression)", () => {
 
   it("a warming frame's word tracks its own fine phase (still one source)", () => {
     // A host still coming up: the dot is amber (warming) and the word rides the
-    // fine phase from the SAME frame — e.g. "copying" reads "provisioning agent…".
+    // fine phase from the SAME frame — "provisioning" reads "provisioning agent…".
     const warmingFrame: EntryState<{ reason: string }, ConnectionInfo> = {
       kind: "warming",
       membershipId: testMembershipId(),
       connection: {
-        phase: "copying",
+        phase: "provisioning",
         log: [],
         sinceMs: 0,
         campaignEpoch: 0,

--- a/packages/app/src/client/connectionColors.test.ts
+++ b/packages/app/src/client/connectionColors.test.ts
@@ -28,8 +28,8 @@ describe("connection STATE presentation", () => {
   it("only connected is non-pending and emerald", () => {
     expect(STATE.connected.pending).toBe(false);
     expect(STATE.connected.text).toBe("text-emerald-500");
-    // copying/connecting are in-flight → pending.
-    expect(STATE.copying.pending).toBe(true);
+    // provisioning/connecting are in-flight → pending.
+    expect(STATE.provisioning.pending).toBe(true);
     expect(STATE.connecting.pending).toBe(true);
   });
 });
@@ -55,8 +55,8 @@ describe("withElapsed", () => {
   it("appends the elapsed seconds once a second has ticked", () => {
     expect(withElapsed("Connecting…", 1)).toBe("Connecting… 1s");
     expect(withElapsed("Connecting…", 18)).toBe("Connecting… 18s");
-    expect(withElapsed("Copying agent to remote…", 42)).toBe(
-      "Copying agent to remote… 42s",
+    expect(withElapsed("Provisioning agent on remote…", 42)).toBe(
+      "Provisioning agent on remote… 42s",
     );
   });
 });

--- a/packages/app/src/client/connectionColors.ts
+++ b/packages/app/src/client/connectionColors.ts
@@ -64,8 +64,8 @@ export const STATE: Record<ConnectionState, StatePresentation> = {
     message: "Connecting…",
     pending: true,
   },
-  // kolu W6 added `probing` as the ssh connector's FIRST up-phase (before
-  // `copying`/`building`). It's a calm "reaching the host" beat — presented
+  // `probing` is the ssh connector's first up-phase, before potentially long
+  // provisioning. It's a calm "reaching the host" beat — presented
   // exactly like `connecting` (amber, pulsing) rather than a distinct chip,
   // since the fine phase story rides the progress line, not this coarse map.
   probing: {
@@ -74,16 +74,10 @@ export const STATE: Record<ConnectionState, StatePresentation> = {
     message: "Connecting…",
     pending: true,
   },
-  copying: {
+  provisioning: {
     text: "text-amber-500",
     label: "provisioning agent…",
-    message: "Copying agent to remote…",
-    pending: true,
-  },
-  building: {
-    text: "text-amber-500",
-    label: "building agent…",
-    message: "Building agent on remote…",
+    message: "Provisioning agent on remote…",
     pending: true,
   },
   // Transient: the link dropped and the parent is cycling through

--- a/packages/app/src/client/entryStatusTone.ts
+++ b/packages/app/src/client/entryStatusTone.ts
@@ -27,7 +27,7 @@ import type { ConnectionInfo } from "drishti-common/browser";
 // hide.
 const DOT_TONE: Record<EntryState["kind"], string> = {
   connected: "bg-emerald-500", // live — the map floors this on transport liveness
-  warming: "bg-amber-500", // copying / connecting / pre-clock-offset — coming up
+  warming: "bg-amber-500", // probing / provisioning / connecting — coming up
   failed: "bg-red-500", // provisioning or link failed
   "not-a-member": "bg-gray-400 dark:bg-gray-600", // unreached — we only render members
 };

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -126,7 +126,7 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
             },
             reconnect: ({ input }: { input: { host: string } }) => {
               // No `entries` publish here either: membership is unchanged.
-              // The session's copying→connecting→connected transition
+              // The session's probing→provisioning→connecting→connected transition
               // streams back through the per-host `connection` cell AND the
               // map's fused per-session `onState` → `EntryStatus` republish.
               if (!opts.pool.has(input.host)) return { ok: false };

--- a/packages/app/src/server/archMap.test.ts
+++ b/packages/app/src/server/archMap.test.ts
@@ -4,16 +4,34 @@ import { resolveDrvForHost } from "./archMap";
 
 describe("resolveDrvForHost", () => {
   it("returns the .drv from the map when localhost's system is present", async () => {
-    const sys = await resolveSystem("localhost");
-    const drv = await resolveDrvForHost("localhost", {
-      [sys]: "/nix/store/test-drv",
+    const signal = new AbortController().signal;
+    const sys = await resolveSystem("localhost", {
+      signal,
+      onProgress: () => {},
     });
-    expect(drv).toBe("/nix/store/test-drv");
+    const drv = await resolveDrvForHost(
+      "localhost",
+      {
+        [sys]: "/nix/store/test.drv",
+      },
+      { signal, localProgress: () => {} },
+    );
+    expect(drv).toMatchObject({
+      kind: "drv-path",
+      drvPath: "/nix/store/test.drv",
+    });
   });
 
   it("throws 'no agent .drv baked' when localhost's system is missing", async () => {
     await expect(
-      resolveDrvForHost("localhost", { "fake-system": "/nix/store/x" }),
+      resolveDrvForHost(
+        "localhost",
+        { "fake-system": "/nix/store/x" },
+        {
+          signal: new AbortController().signal,
+          localProgress: () => {},
+        },
+      ),
     ).rejects.toThrow(/no agent \.drv baked for system=/);
   });
 });

--- a/packages/app/src/server/archMap.ts
+++ b/packages/app/src/server/archMap.ts
@@ -10,18 +10,32 @@
  * resolved system.
  */
 
-import { resolveSystem } from "@kolu/surface-remote";
+import {
+  type AgentDerivation,
+  directAgentDerivation,
+  type ResolveDrvPathContext,
+  resolveSystem,
+} from "@kolu/surface-remote";
+
+type HostProbeContext = Pick<
+  ResolveDrvPathContext,
+  "signal" | "localProgress"
+>;
 
 export async function resolveDrvForHost(
   host: string,
   drvBySystem: Readonly<Record<string, string>>,
-): Promise<string> {
-  const sys = await resolveSystem(host);
+  context: HostProbeContext,
+): Promise<AgentDerivation> {
+  const sys = await resolveSystem(host, {
+    signal: context.signal,
+    onProgress: context.localProgress,
+  });
   const drv = drvBySystem[sys];
   if (drv === undefined) {
     throw new Error(
       `${host}: no agent .drv baked for system=${sys} (known: ${Object.keys(drvBySystem).join(", ")})`,
     );
   }
-  return drv;
+  return directAgentDerivation(drv);
 }

--- a/packages/app/src/server/hostRegistry.ts
+++ b/packages/app/src/server/hostRegistry.ts
@@ -25,9 +25,11 @@
 
 import {
   type AgentClient,
+  type AgentDerivation,
   buildRemotePool,
   makeSession,
   type PoolControls,
+  type ResolveDrvPathContext,
   type RemotePool,
   type Session,
   sshConnector,
@@ -64,7 +66,10 @@ export interface HostPoolOptions {
    *  business knowing how the answer was reached (arch probe, map
    *  lookup, a static value for localhost-only dev) — it just awaits
    *  the resolved path per host. */
-  resolveDrvPath: (host: string) => Promise<string>;
+  resolveDrvPath: (
+    host: string,
+    context: ResolveDrvPathContext,
+  ) => Promise<AgentDerivation>;
   hostsFile: string;
 }
 
@@ -79,7 +84,7 @@ export function buildHostPool(opts: HostPoolOptions): HostPool {
     buildEntry: (host) => {
       // `makeSession` over an `sshConnector` transport plug (kolu S9/S10 —
       // the deleted `getHostSession` is now this composition). The connector
-      // owns everything transport-specific (resolve .drv per dial, nix copy,
+          // owns everything transport-specific (resolve .drv per dial, provision,
       // spawn ssh, wire stdio to a typed client); `makeSession` owns the
       // durable lifecycle (pin/ref-count, backoff, give-up, watchdogs,
       // reconnect/recheck, the connection-state cell). The agent .drv is
@@ -106,12 +111,12 @@ export function buildHostPool(opts: HostPoolOptions): HostPool {
               .map((k): [string, string | undefined] => [k, process.env[k]])
               .filter((e): e is [string, string] => e[1] !== undefined),
           ),
-          resolveDrvPath: () => opts.resolveDrvPath(host),
+          resolveDrvPath: (context) => opts.resolveDrvPath(host, context),
         }),
         // `sshConnector` PROVISIONS (nix-copies the agent closure before
         // dialing), so its true opening phase is the connector's FIRST
-        // provisioning phase, "probing" (kolu W6 widened `SshProv` to
-        // `probing → copying → building`) — every drishti host, including
+        // provisioning phase, "probing" (the remote connector advances
+        // `probing → provisioning`) — every drishti host, including
         // "localhost", dials through it (kolu#1716/#1808: the connector's own
         // opening phase, never a LOCAL-set one).
         initialConnection: "probing",

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -96,8 +96,10 @@ async function main(): Promise<void> {
     `agent drvs (${Object.keys(agentDrvBySystem).length}): ${Object.keys(agentDrvBySystem).join(", ")}`,
   );
 
-  const resolveDrvPath = (host: string): Promise<string> =>
-    resolveDrvForHost(host, agentDrvBySystem);
+  const resolveDrvPath: Parameters<typeof buildHostPool>[0]["resolveDrvPath"] = (
+    host,
+    context,
+  ) => resolveDrvForHost(host, agentDrvBySystem, context);
 
   const hostsFile = resolveHostsFile();
   const cliHosts = argv._.host;

--- a/packages/app/src/server/router.ts
+++ b/packages/app/src/server/router.ts
@@ -7,7 +7,7 @@
  * On a fresh subscriber, the parent:
  *
  *   1. Synchronously yields the parent's connection-state-aware
- *      `system` snapshot (state = "copying" / "connecting" / etc.).
+ *      `system` snapshot (state = "probing" / "provisioning" / "connecting" / etc.).
  *   2. Once the agent's link is up, mirrors the agent's `system` and
  *      `processes` updates into the parent's local store/collection.
  *   3. Per-key process upserts/removes from the agent flow through to


### PR DESCRIPTION
Drishti now consumes Kolu's merged lazy agent resolver from `master`, providing the external Surface consumer gate for [juspay/kolu#1974](https://github.com/juspay/kolu/pull/1974). This keeps source selection inside Surface Remote while proving a real downstream app compiles and builds against the typed, per-dial resolver contract.

Because Drishti hydrates the raw `@kolu/*` TypeScript packages, it explicitly declares Surface Remote's runtime support packages. Its resolver accepts each dial's cancellation and progress context, uses the nominal `directAgentDerivation` constructor for its already-baked path, and follows the new `probing` → `provisioning` phase vocabulary.

The cold Darwin gate also caught a real dependency-layout problem before merge: `lru-cache` displaced Babel's older transitive copy into a nested read-only Bun cache path. Kolu's bounded cache leaf now uses `quick-lru`, so the consumer has one non-conflicting direct dependency without an override or fallback.

### Compatibility evidence

- Exact Drishti commit: `bd0a3536599eb0c4d9b416350372385a69642850`
- Exact merged Kolu pin: `3ff256f0d3de8cb585e588f490bae5b42eb7d89c` on `master`
- Full Odu ledger `31dc8d8#1`: 20/20 Linux and Darwin nodes passed against the content-identical PR head
- Both platform typechecks, wrapped Nix builds, agent boots, derivation-stability checks, formatting, and `bun.nix` freshness passed
- 190 local tests passed
- After advancing to the merge commit, npins verification, formatting, and the default Nix build pass; the content hash is unchanged because the merge commit has the reviewed PR tree

### Try it locally

```sh
nix build github:srid/drishti/agent/kolu-decouple-flake
```

_Generated by Codex (model `gpt-5.6`)._