### PR TITLE
Pair with Kolu's reactor loop guard + viewerIdentity (kolu#1991)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "port-forwarding-prt2",
       "submodules": false,
-      "revision": "3ff256f0d3de8cb585e588f490bae5b42eb7d89c",
-      "url": "https://github.com/juspay/kolu/archive/3ff256f0d3de8cb585e588f490bae5b42eb7d89c.tar.gz",
-      "hash": "sha256-8B20Dbw8IQuCWeJzkOO+WtCTMssDK5q3a+VfBBqouRo="
+      "revision": "15193a039ecaa45bf32be99585d17e5d0eb0f438",
+      "url": "https://github.com/juspay/kolu/archive/15193a039ecaa45bf32be99585d17e5d0eb0f438.tar.gz",
+      "hash": "sha256-GqHoGPm0frvk58BGLPDnLR+a9JkpdIsHOPnuEpAL+pg="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -217,17 +217,29 @@ export async function serveAgent(
       // The reactor owns the T+0 seed, the poll cadence, and the reconcile; the graph
       // is the one writer, so there is no ctx `upsert`/`remove` seam here.
       processes: derived.collection(
-        source({ read: () => reader.readProcesses(), install: pollInstall }),
+        source({
+          read: () => reader.readProcesses(),
+          install: pollInstall,
+          // Names this source in a reactor loop-guard error. Diagnostics only —
+          // there is no field that can silence the guard. Worth setting because
+          // the alternative is a stack trace pointing into framework code.
+          label: "processes",
+        }),
       ),
       cpuCores: derived.collection(
         source({
           // `readCpuCores` is synchronous (os.cpus()); the poll shape wants a promise.
           read: () => Promise.resolve(reader.readCpuCores()),
           install: pollInstall,
+          label: "cpuCores",
         }),
       ),
       networkInterfaces: derived.collection(
-        source({ read: () => reader.readNetwork(), install: pollInstall }),
+        source({
+          read: () => reader.readNetwork(),
+          install: pollInstall,
+          label: "networkInterfaces",
+        }),
       ),
     },
     // No `streams`: the whole-process-set protocol is the `processes` collection's


### PR DESCRIPTION
Pairs **[juspay/kolu#1991](https://github.com/juspay/kolu/pull/1991)** (PRT2 — port forwarding), which changes `@kolu/surface`.

## What changed upstream

- **`PollSourceOptions` gains an optional `label`** — diagnostics only, naming a poll source in a loop-guard error. There is deliberately no field that can *silence* the guard.
- **Every poll source gains a runtime loop guard.** A read that announces on the change edge that triggers it is an unbounded cycle the reactor executes forever — it froze a production Kolu server (UI dead, HTTP dead, `SIGTERM` ignored until systemd sent `SIGKILL`). The guard runs each read inside an `AsyncLocalStorage` context keyed to its source, so a tick firing *under that context* is self-caused by construction. Timers, I/O completions and other cells' microtask bursts carry a different context and can never count.
- **New module `@kolu/surface/viewerIdentity`** — which machine a viewer is actually at, behind a reverse proxy. Additive; unused here so far.

## What Drishti needs — nothing behavioural, and that is a finding rather than an assumption

Our three poll sources (`processes`, `cpuCores`, `networkInterfaces`) install a plain `setInterval` and none announces on its own edge, so none can be self-caused.

That is worth stating explicitly, because **an earlier cut of the guard used timing instead of provenance, and our shape was precisely its false positive**: it flagged any read slower than its own interval, and `readProcesses` runs `ps`+`lsof` on a 2 s interval. On a loaded box that guard would have crashed this agent. The shipped version is built on causation specifically so an honest slow poll is left alone — kolu's suite now carries that exact repro as a regression test.

What we *do* adopt is the `label`, on all three sources: without it a future loop report would carry a stack pointing into framework code instead of naming the cell.

## Verification against the pinned SHA (`15193a03`)

| check | result |
|---|---|
| `just typecheck` | ✅ common · agent · app |
| `just test` | ✅ 190 pass, 0 fail (497 assertions, 25 files) |
| `just fmt-check` | ✅ 0/13 would reformat |
| `just nix-build` | ✅ full closure builds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
