### PR TITLE
Pair with kolu #2018: declare the binary cache agent provisioning prefetches from

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,8 +21,10 @@
 #   drishti        — the monitor (default attr). Wraps bun →
 #                     packages/app/src/server/main.ts; bakes
 #                     DRISHTI_AGENT_DRVS_JSON (system→drv map, sourced
-#                     from flake.nix) and DRISHTI_DIST_DIR (drishti-
-#                     client). meta.mainProgram is "drishti" so `nix run`
+#                     from flake.nix), DRISHTI_AGENT_BINARY_CACHE (the
+#                     prefetch cache declaration, from flake.nix's
+#                     nixConfig) and DRISHTI_DIST_DIR (drishti-client).
+#                     meta.mainProgram is "drishti" so `nix run`
 #                     resolves cleanly.
 #
 # `b2n` carries the bun2nix helpers; passed in from flake.nix via
@@ -36,6 +38,11 @@
 { pkgs ? null
 , b2n ? null
 , agentDrvBySystem ? null
+  # Binary-cache declaration ({ substituters; trustedPublicKeys; } — lists,
+  # both non-empty) baked for @kolu/surface-remote's agent prefetch. flake.nix
+  # derives it from its own nixConfig block; like agentDrvBySystem, only the
+  # `drishti` monitor needs it — throws on use if missing.
+, binaryCache ? null
   # Build commit, stamped into the client bundle AND the server wrapper from
   # one source (flake.nix passes `self.rev`), so the freshness rail is
   # self-consistent. Defaults to "dev" for non-flake (`nix-build`) invocations.
@@ -85,8 +92,8 @@ let
   '';
 
   drishti =
-    if agentDrvBySystem == null
-    then throw "the `drishti` monitor wrapper requires `agentDrvBySystem` — invoke via flake.nix (which threads in the per-system agent .drv map)"
+    if agentDrvBySystem == null || binaryCache == null
+    then throw "the `drishti` monitor wrapper requires `agentDrvBySystem` and `binaryCache` — invoke via flake.nix (which threads in the per-system agent .drv map and the cache declaration)"
     else
       resolvedPkgs.runCommand "drishti"
         {
@@ -110,6 +117,12 @@ let
           `# and this wrapper compiles fine but HostSession crashes at` \
           `# 'nix copy --derivation' time.` \
           --set-default DRISHTI_AGENT_DRVS_JSON '${builtins.toJSON agentDrvBySystem}' \
+          `# DRISHTI_AGENT_BINARY_CACHE: {substituters, trustedPublicKeys}` \
+          `# JSON (surface-remote's AgentBinaryCache shape) — the caches the` \
+          `# agent closure is prefetched from before shipping to a remote` \
+          `# host. Sourced from flake.nix's nixConfig block, so the cache CI` \
+          `# pushes builds to is the cache provisioning pulls from.` \
+          --set-default DRISHTI_AGENT_BINARY_CACHE '${builtins.toJSON binaryCache}' \
           --prefix PATH : ${resolvedPkgs.lib.makeBinPath [ resolvedPkgs.openssh resolvedPkgs.nix ]}
       '';
 in

--- a/flake.nix
+++ b/flake.nix
@@ -66,11 +66,24 @@
           builtins.unsafeDiscardStringContext
             (import ./default.nix { inherit pkgs b2n; }).drishti-agent.drvPath)
         perSystemAttrs;
+
+      # The caches provisioning prefetches the agent closure from before
+      # shipping it to a remote host (@kolu/surface-remote's AgentBinaryCache
+      # shape — both lists must be non-empty, the constructor throws
+      # otherwise). Sourced from THIS flake's own nixConfig block (flake.nix
+      # is a plain attrset, so importing it reads the same strings nix itself
+      # uses) — the cache CI pushes agent builds to is, by construction, the
+      # cache provisioning pulls from.
+      flakeNixConfig = (import ./flake.nix).nixConfig;
+      binaryCache = {
+        substituters = [ flakeNixConfig.extra-substituters ];
+        trustedPublicKeys = [ flakeNixConfig.extra-trusted-public-keys ];
+      };
     in
     {
       packages = eachSystem ({ pkgs, b2n }:
         let
-          drvs = import ./default.nix { inherit pkgs b2n agentDrvBySystem rev; };
+          drvs = import ./default.nix { inherit pkgs b2n agentDrvBySystem binaryCache rev; };
 
         in
         {
@@ -92,6 +105,10 @@
       # DRISHTI_AGENT_DRVS_JSON without having to know about the per-
       # system attr structure.
       agentDrvsJson = builtins.toJSON agentDrvBySystem;
+
+      # Twin of agentDrvsJson for the cache declaration — `just dev` exports
+      # this verbatim as DRISHTI_AGENT_BINARY_CACHE.
+      agentBinaryCacheJson = builtins.toJSON binaryCache;
 
       # home-manager module — runs the monitor as a systemd user service on
       # Linux and a launchd LaunchAgent on macOS. System-independent; the

--- a/justfile
+++ b/justfile
@@ -40,8 +40,11 @@ dev host='localhost' *args: install
     #!/usr/bin/env bash
     set -euo pipefail
     drvs_json=$(nix eval --raw "{{ justfile_directory() }}#agentDrvsJson")
+    cache_json=$(nix eval --raw "{{ justfile_directory() }}#agentBinaryCacheJson")
     echo "» agent drvs: $drvs_json"
+    echo "» agent binary cache: $cache_json"
     DRISHTI_AGENT_DRVS_JSON="$drvs_json" \
+    DRISHTI_AGENT_BINARY_CACHE="$cache_json" \
     {{ nix_shell }} bun --cwd packages/app dev {{ host }} {{ args }}
 
 # TypeScript type checking (every workspace member: common, agent, app)

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "feat/provision-cache-prefetch",
+      "branch": "master",
       "submodules": false,
-      "revision": "06905f252e3788481fa08dd4b08e3398b6cb64fb",
-      "url": "https://github.com/juspay/kolu/archive/06905f252e3788481fa08dd4b08e3398b6cb64fb.tar.gz",
-      "hash": "sha256-YqMGgDdMuSkPmbZI9kRjORPqt3/x71kDnLKqHn8O0bY="
+      "revision": "810f8c4ab081b7c47e7dd30bb4980aae57f35701",
+      "url": "https://github.com/juspay/kolu/archive/810f8c4ab081b7c47e7dd30bb4980aae57f35701.tar.gz",
+      "hash": "sha256-C/cp6r6GthhIdsXuQmNrJWpEzseGgFP7B2IS4uL4bN0="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "feat/provision-cache-prefetch",
       "submodules": false,
-      "revision": "480496c67d8a982336b20a4decc09be9d2ad3211",
-      "url": "https://github.com/juspay/kolu/archive/480496c67d8a982336b20a4decc09be9d2ad3211.tar.gz",
-      "hash": "sha256-iDMNmwqmKmba0fSaMCBvvYJJKpIWiXKSKx8U/NWHp1I="
+      "revision": "e7fd1aec1f9b29cab08ae77a09b07e22dc5b9c76",
+      "url": "https://github.com/juspay/kolu/archive/e7fd1aec1f9b29cab08ae77a09b07e22dc5b9c76.tar.gz",
+      "hash": "sha256-VQQONdztLGXpQu+LLijltf5Yi7IrppHSfUiJAe4qibA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "feat/provision-cache-prefetch",
       "submodules": false,
-      "revision": "e7fd1aec1f9b29cab08ae77a09b07e22dc5b9c76",
-      "url": "https://github.com/juspay/kolu/archive/e7fd1aec1f9b29cab08ae77a09b07e22dc5b9c76.tar.gz",
-      "hash": "sha256-VQQONdztLGXpQu+LLijltf5Yi7IrppHSfUiJAe4qibA="
+      "revision": "06905f252e3788481fa08dd4b08e3398b6cb64fb",
+      "url": "https://github.com/juspay/kolu/archive/06905f252e3788481fa08dd4b08e3398b6cb64fb.tar.gz",
+      "hash": "sha256-YqMGgDdMuSkPmbZI9kRjORPqt3/x71kDnLKqHn8O0bY="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "port-forwarding-prt2",
+      "branch": "feat/provision-cache-prefetch",
       "submodules": false,
-      "revision": "15193a039ecaa45bf32be99585d17e5d0eb0f438",
-      "url": "https://github.com/juspay/kolu/archive/15193a039ecaa45bf32be99585d17e5d0eb0f438.tar.gz",
-      "hash": "sha256-GqHoGPm0frvk58BGLPDnLR+a9JkpdIsHOPnuEpAL+pg="
+      "revision": "480496c67d8a982336b20a4decc09be9d2ad3211",
+      "url": "https://github.com/juspay/kolu/archive/480496c67d8a982336b20a4decc09be9d2ad3211.tar.gz",
+      "hash": "sha256-iDMNmwqmKmba0fSaMCBvvYJJKpIWiXKSKx8U/NWHp1I="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/archMap.test.ts
+++ b/packages/app/src/server/archMap.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { type AgentBinaryCache, resolveSystem } from "@kolu/surface-remote";
+import { agentBinaryCache, resolveSystem } from "@kolu/surface-remote";
 import { resolveDrvForHost } from "./archMap";
 
-const TEST_BINARY_CACHE: AgentBinaryCache = {
+const TEST_BINARY_CACHE = agentBinaryCache({
   substituters: ["https://cache.example.org"],
   trustedPublicKeys: ["example:AAAA"],
-};
+});
 
 describe("resolveDrvForHost", () => {
   it("returns the .drv from the map when localhost's system is present", async () => {

--- a/packages/app/src/server/archMap.test.ts
+++ b/packages/app/src/server/archMap.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { resolveSystem } from "@kolu/surface-remote";
+import { type AgentBinaryCache, resolveSystem } from "@kolu/surface-remote";
 import { resolveDrvForHost } from "./archMap";
+
+const TEST_BINARY_CACHE: AgentBinaryCache = {
+  substituters: ["https://cache.example.org"],
+  trustedPublicKeys: ["example:AAAA"],
+};
 
 describe("resolveDrvForHost", () => {
   it("returns the .drv from the map when localhost's system is present", async () => {
@@ -14,11 +19,13 @@ describe("resolveDrvForHost", () => {
       {
         [sys]: "/nix/store/test.drv",
       },
+      TEST_BINARY_CACHE,
       { signal, localProgress: () => {} },
     );
     expect(drv).toMatchObject({
       kind: "drv-path",
       drvPath: "/nix/store/test.drv",
+      binaryCache: TEST_BINARY_CACHE,
     });
   });
 
@@ -27,6 +34,7 @@ describe("resolveDrvForHost", () => {
       resolveDrvForHost(
         "localhost",
         { "fake-system": "/nix/store/x" },
+        TEST_BINARY_CACHE,
         {
           signal: new AbortController().signal,
           localProgress: () => {},

--- a/packages/app/src/server/archMap.ts
+++ b/packages/app/src/server/archMap.ts
@@ -5,12 +5,14 @@
  *
  * The probe table and ssh-argv shape now live upstream (juspay/kolu's
  * `surface-remote` package); the only drishti-specific piece left
- * here is the composition — given a host and a map, produce the
- * matching drvPath, with a clear error if no entry was baked for the
- * resolved system.
+ * here is the composition — given a host, a map, and the baked
+ * binary-cache declaration (`DRISHTI_AGENT_BINARY_CACHE`, from the
+ * flake's nixConfig), produce the matching derivation, with a clear
+ * error if no entry was baked for the resolved system.
  */
 
 import {
+  type AgentBinaryCache,
   type AgentDerivation,
   directAgentDerivation,
   type ResolveDrvPathContext,
@@ -25,6 +27,7 @@ type HostProbeContext = Pick<
 export async function resolveDrvForHost(
   host: string,
   drvBySystem: Readonly<Record<string, string>>,
+  binaryCache: AgentBinaryCache,
   context: HostProbeContext,
 ): Promise<AgentDerivation> {
   const sys = await resolveSystem(host, {
@@ -37,5 +40,5 @@ export async function resolveDrvForHost(
       `${host}: no agent .drv baked for system=${sys} (known: ${Object.keys(drvBySystem).join(", ")})`,
     );
   }
-  return directAgentDerivation(drv);
+  return directAgentDerivation(drv, binaryCache);
 }

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -96,10 +96,30 @@ async function main(): Promise<void> {
     `agent drvs (${Object.keys(agentDrvBySystem).length}): ${Object.keys(agentDrvBySystem).join(", ")}`,
   );
 
+  const binaryCacheJson = process.env.DRISHTI_AGENT_BINARY_CACHE;
+  if (binaryCacheJson === undefined || binaryCacheJson.length === 0) {
+    log(
+      "DRISHTI_AGENT_BINARY_CACHE is required (no fallback). Set it to a JSON object { substituters: string[], trustedPublicKeys: string[] } naming the caches the agent closure is prefetched from — e.g. `DRISHTI_AGENT_BINARY_CACHE=$(nix eval --raw .#agentBinaryCacheJson)`. The monitor wrapper bakes this from flake.nix's nixConfig.",
+    );
+    process.exit(1);
+  }
+  const binaryCacheSchema = z.object({
+    substituters: z.array(z.string().min(1)).min(1),
+    trustedPublicKeys: z.array(z.string().min(1)).min(1),
+  });
+  let binaryCache: z.infer<typeof binaryCacheSchema>;
+  try {
+    binaryCache = binaryCacheSchema.parse(JSON.parse(binaryCacheJson));
+  } catch (err) {
+    log(`DRISHTI_AGENT_BINARY_CACHE: invalid — ${(err as Error).message}`);
+    process.exit(1);
+  }
+  log(`agent binary cache: ${binaryCache.substituters.join(", ")}`);
+
   const resolveDrvPath: Parameters<typeof buildHostPool>[0]["resolveDrvPath"] = (
     host,
     context,
-  ) => resolveDrvForHost(host, agentDrvBySystem, context);
+  ) => resolveDrvForHost(host, agentDrvBySystem, binaryCache, context);
 
   const hostsFile = resolveHostsFile();
   const cliHosts = argv._.host;

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -36,6 +36,10 @@ import { WebSocketServer } from "ws";
 import { z } from "zod";
 import { gateWsOrigin, parseAllowedOrigins } from "@kolu/surface/ws-origin";
 import {
+  type AgentBinaryCache,
+  agentBinaryCache,
+} from "@kolu/surface-remote";
+import {
   gateStaleSocket,
   installSurfaceApp,
   startWsHeartbeat,
@@ -103,13 +107,13 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
-  const binaryCacheSchema = z.object({
-    substituters: z.array(z.string().min(1)).min(1),
-    trustedPublicKeys: z.array(z.string().min(1)).min(1),
-  });
-  let binaryCache: z.infer<typeof binaryCacheSchema>;
+  // `agentBinaryCache` is surface-remote's own smart constructor: it owns the
+  // "could this declaration act?" gate (non-empty, non-blank, trimmed) and is
+  // the ONLY way to produce the nominal AgentBinaryCache. Validating here
+  // instead would be a second, drifting copy of that gate.
+  let binaryCache: AgentBinaryCache;
   try {
-    binaryCache = binaryCacheSchema.parse(JSON.parse(binaryCacheJson));
+    binaryCache = agentBinaryCache(JSON.parse(binaryCacheJson));
   } catch (err) {
     log(`DRISHTI_AGENT_BINARY_CACHE: invalid — ${(err as Error).message}`);
     process.exit(1);


### PR DESCRIPTION
This is the drishti half of a paired change with kolu PR https://github.com/juspay/kolu/pull/2018, which is now **merged**. That PR changes `@kolu/surface-remote`'s `directAgentDerivation(drvPath)` to `directAgentDerivation(drvPath, binaryCache)`: every agent derivation must now carry an `AgentBinaryCache` — a *nominal* type (brand symbol) that only the exported smart constructor `agentBinaryCache({ substituters, trustedPublicKeys })` can produce, and which it validates as non-empty, non-blank and trimmed. `provisionAgent` uses the declaration to prefetch the agent's output closure from those caches into the local store before shipping it to the remote host, so a cache-blind provisioning path is unspellable rather than merely discouraged.

**Pairing gate: satisfied against the merged commit.** The kolu pin in `npins/sources.json` now tracks the **master branch** at `810f8c4ab081b7c47e7dd30bb4980aae57f35701` — the squash-merge of kolu #2018 ("Provisioning carries cache binaries to the host — and a cache-blind path is unspellable"). No pre-merge branch pin remains, so there is nothing left to re-bump before this merges.

What this PR does:

- **npins**: kolu pinned to merged master @ `810f8c4ab081`.
- **flake.nix**: `binaryCache` is derived from the flake's *own* `nixConfig` block (`extra-substituters` / `extra-trusted-public-keys`) — flake.nix is a plain attrset, so importing it reads the same strings nix itself uses. The cache CI pushes agent builds to is, by construction, the cache provisioning pulls from. A top-level `agentBinaryCacheJson` output twins `agentDrvsJson` for `just dev`.
- **default.nix**: the monitor wrapper bakes `DRISHTI_AGENT_BINARY_CACHE` (sibling to `DRISHTI_AGENT_DRVS_JSON`), and now throws unless both are threaded in.
- **main.ts**: reads the baked env var and routes the parsed JSON straight through `agentBinaryCache()`, so upstream owns the "could this declaration act?" gate rather than drishti keeping a second copy that would drift. Missing or malformed exits with an actionable message, matching the drv map's fail-loud contract.
- **archMap.ts**: `resolveDrvForHost` takes the cache and passes it to `directAgentDerivation`.
- **justfile**: `just dev` exports `DRISHTI_AGENT_BINARY_CACHE` from the new flake output, so the non-wrapper dev path satisfies the same requirement.

Local gate against the merged pin, with drishti master (#125) merged in: `just typecheck` clean, `just test` 193/193 pass, `just fmt` no changes, `nix build .#default` succeeds and the built wrapper bakes the expected JSON.

_Generated by Claude Code (model `claude-fable-5`)._
