### PR TITLE
Show a failed host's evidence, read off the record that survives

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@tailwindcss/cli": "^4.1.0",
         "babel-preset-solid": "^1.9.0",
         "cleye": "^2.3.0",
+        "dequal": "^2.0.3",
         "drishti-common": "workspace:*",
         "hono": "^4.12.16",
         "neverthrow": "^8.2.0",
@@ -274,6 +275,8 @@
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -444,6 +444,10 @@
     url = "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz";
     hash = "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==";
   };
+  "dequal@2.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz";
+    hash = "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==";
+  };
   "detect-libc@2.1.2" = fetchurl {
     url = "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz";
     hash = "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "port-forwarding-prt2",
+      "branch": "surface-failure-evidence",
       "submodules": false,
-      "revision": "15193a039ecaa45bf32be99585d17e5d0eb0f438",
-      "url": "https://github.com/juspay/kolu/archive/15193a039ecaa45bf32be99585d17e5d0eb0f438.tar.gz",
-      "hash": "sha256-GqHoGPm0frvk58BGLPDnLR+a9JkpdIsHOPnuEpAL+pg="
+      "revision": "c432080fae4433f660eb4e84e415b6772d288f05",
+      "url": "https://github.com/juspay/kolu/archive/c432080fae4433f660eb4e84e415b6772d288f05.tar.gz",
+      "hash": "sha256-vWR6K/V+MzMjFt8etjKSLRSvLG/V0ZOMJrO8RT3CQbA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-failure-evidence",
       "submodules": false,
-      "revision": "c432080fae4433f660eb4e84e415b6772d288f05",
-      "url": "https://github.com/juspay/kolu/archive/c432080fae4433f660eb4e84e415b6772d288f05.tar.gz",
-      "hash": "sha256-vWR6K/V+MzMjFt8etjKSLRSvLG/V0ZOMJrO8RT3CQbA="
+      "revision": "928d9bced1002c4f77c8986e05ce508a3f50e8cc",
+      "url": "https://github.com/juspay/kolu/archive/928d9bced1002c4f77c8986e05ce508a3f50e8cc.tar.gz",
+      "hash": "sha256-k6HC2Y1ny2gjBC8Tkuqn4kQG1sA+7Boc+8uYuLoqT6g="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; neverthrow carries Surface Remote's explicit agent-source result, quick-lru bounds its successful derivation cache, split2 frames child output, and ts-pattern keeps its closed state folds exhaustive. @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
+  "//": "@kolu/surface-app is NOT a bun dependency — like @kolu/surface, @kolu/surface-remote, and @kolu/surface-map it is hydrated into node_modules/@kolu/surface-app (its raw .ts sources are consumed directly: no build step). It is sourced hermetically from the npins-pinned kolu tree (npins/sources.json → kolu): nix/overlay.nix extracts it as a nix-store path, nix/env.nix exports it as $DRISHTI_KOLU_SURFACE_APP, and the dev shell / install recipe / build derivation copy it into node_modules exactly like the other @kolu/* packages. Runtime dependencies of those hydrated sources are declared here; neverthrow carries Surface Remote's explicit agent-source result, quick-lru bounds its successful derivation cache, split2 frames child output, ts-pattern keeps its closed state folds exhaustive, and dequal backs Surface Map's STRUCTURAL republish gate (kolu#2022 — an entry status is republished only when its value actually changed, so a producer no longer owes reference-stable failure values). @kolu/solid-pwa-install (the PWA install-card adapter) is hydrated the same way; src/client/TabStrip.tsx's Pin-app button consumes it (createPwaInstall + installInstructions), gated on the canInstallPwa/isInstalled signals from useSurfaceApp(). The kolu pin tracks branch deocouple-flake, which ships lazy per-system agent derivation resolution along with the shared surface packages.",
   "scripts": {
     "dev": "bun --watch src/server/main.ts",
     "start": "bun src/server/main.ts",
@@ -23,6 +23,7 @@
     "@tailwindcss/cli": "^4.1.0",
     "babel-preset-solid": "^1.9.0",
     "cleye": "^2.3.0",
+    "dequal": "^2.0.3",
     "drishti-common": "workspace:*",
     "hono": "^4.12.16",
     "neverthrow": "^8.2.0",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -43,6 +43,7 @@ import {
   type ScopedByEntry,
   watchByEntry,
 } from "@kolu/surface-map/client";
+import type { FailureEvidence } from "@kolu/surface-map";
 import { type AlertId, CLEAR_PCT, RAISE_PCT } from "drishti-common/alerts";
 import {
   type CoreId,
@@ -63,7 +64,7 @@ import {
 } from "drishti-common/browser";
 import { reconcileRaiseTimes } from "./alertTiming";
 import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
-import { connectionOf } from "./entryStatusTone";
+import { connectionOf, failureRecord } from "./entryStatusTone";
 import { HostDot } from "./HostDot";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";
@@ -1238,12 +1239,20 @@ function HostView(props: {
     () => connection() ?? DEFAULT_CONNECTION,
   );
 
+  // The standing failure, read off the ENTRY (`failureRecord`) rather than off the
+  // live `connection.log` the overlay used to narrow on. Same seam the dot reads, so
+  // the page and the chip agree — and, unlike the live payload, it survives the
+  // liveness floor: a host that failed while the admin link was down still shows its
+  // reason AND its evidence instead of silently reverting to "connecting…".
+  const failure = createMemo(() => failureRecord(entryState()));
+
   // The connecting/failed overlay for the MIRROR axis (backend↔remote) —
   // the fallback the connection-cell gate below renders while not yet
   // `connected`.
   const connectingView = () => (
     <ConnectingOverlay
       connection={currentConnection()}
+      failure={failure()}
       onReconnect={onReconnect}
     />
   );
@@ -1585,16 +1594,14 @@ function FilterBar(props: {
 
 function ConnectingOverlay(props: {
   connection: ConnectionInfo;
+  /** The entry's standing failure + its evidence (`failureRecord`), `null` while the
+   *  host is merely coming up. This USED to be narrowed out of `connection` itself
+   *  (`phase === "failed"`), a second authority that also lost the failure entirely
+   *  once the liveness floor dropped the live payload — see `failureRecord`. */
+  failure: { reason: string; evidence: FailureEvidence } | null;
   onReconnect: () => void;
 }) {
   const c = () => props.connection;
-  // The terminal-failure arm, keyed once so the FailedCard reads `error`/`log`
-  // off a narrowed value instead of the raw union. `null` when the link isn't
-  // failed, which the `<Show>` below treats as "render the connecting view".
-  const failedArm = () => {
-    const conn = c();
-    return conn.phase === "failed" ? conn : null;
-  };
   // The freshest parent progress line (e.g. "reconnecting in 4000ms…
   // (attempt 2/5)"). Display only — never parsed for control flow.
   const lastProgress = () => c().log.at(-1)?.line ?? null;
@@ -1637,7 +1644,7 @@ function ConnectingOverlay(props: {
   return (
     <div class="px-4 py-12 text-center text-gray-600 dark:text-gray-400">
       <Show
-        when={failedArm()}
+        when={props.failure}
         fallback={
           <>
             <div class="mb-2 text-lg">
@@ -1659,8 +1666,8 @@ function ConnectingOverlay(props: {
       >
         {(f) => (
           <FailedCard
-            lastError={f().error}
-            progressLines={f().log.map((e) => e.line)}
+            reason={f().reason}
+            evidence={f().evidence}
             onReconnect={props.onReconnect}
           />
         )}
@@ -1669,38 +1676,50 @@ function ConnectingOverlay(props: {
   );
 }
 
-// Terminal-failure card: the real error, the captured connection log, and
-// a button to re-arm the parent's session (the only recovery short of
-// restarting drishti). Shown when `connection.state === "failed"`.
+// Terminal-failure card: the real error, its retained evidence, and a button to
+// re-arm the parent's session (the only recovery short of restarting drishti).
+// Shown when the entry carries a standing failure (`failureRecord`).
 function FailedCard(props: {
-  lastError: string | null;
-  progressLines: readonly string[];
+  // The failure's human `reason`. A `string`, not `string | null`: the framework has
+  // no fabricated fallback cause, so a failed entry ALWAYS carries a real one.
+  reason: string;
+  evidence: FailureEvidence;
   onReconnect: () => void;
 }) {
-  // The tail of the parent/agent link log — the *actual* failure output
-  // (nix-copy stderr, ssh auth errors, the give-up line). This replaces a
-  // hardcoded "maybe your user isn't in trusted-users" tip that was shown
-  // for every failure regardless of cause: a guess decoupled from the real
-  // error buries it. `lastError` is the terse headline ("exited with code
-  // 1"); the log carries the why.
-  const logTail = createMemo(() => props.progressLines.slice(-8));
+  // The tail of the failure's EVIDENCE — the *actual* failure output (nix-copy
+  // stderr, ssh auth errors, the give-up line), stapled to the failure record by
+  // `serveHostMap` at the moment it classified the reason. This replaces a
+  // hardcoded "maybe your user isn't in trusted-users" tip that was shown for
+  // every failure regardless of cause: a guess decoupled from the real error
+  // buries it. `reason` is the terse headline ("exited with code 1"); these
+  // lines carry the why. Each keeps its `source` — whether drishti's own parent
+  // said it or the far end did is often the diagnosis.
+  const logTail = createMemo(() => props.evidence.slice(-8));
   return (
     <div class="mx-auto max-w-lg rounded border border-red-500/40 bg-red-500/5 p-4 text-left">
       <div class="mb-1 text-lg text-red-500">Couldn't reach this host</div>
       <div class="mb-2 text-xs text-gray-500">
         Gave up after repeated connection failures.
       </div>
-      <Show when={props.lastError}>
-        {(err) => (
-          <pre class="mb-3 overflow-x-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-left text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-            {err()}
-          </pre>
-        )}
-      </Show>
+      <pre class="mb-3 overflow-x-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-left text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+        {props.reason}
+      </pre>
       <Show when={logTail().length > 0}>
-        <div class="mb-1 text-xs text-gray-500">Connection log</div>
-        <pre class="mb-3 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-left text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-          {logTail().join("\n")}
+        <div class="mb-1 text-xs text-gray-500">Evidence</div>
+        <pre
+          data-testid="failure-evidence"
+          class="mb-3 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-gray-100 p-2 text-left font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+        >
+          <For each={logTail()}>
+            {(e) => (
+              <div>
+                <span class="mr-2 text-gray-400 dark:text-gray-500">
+                  {e.source === "remote" ? "remote" : "local "}
+                </span>
+                {e.line}
+              </div>
+            )}
+          </For>
         </pre>
       </Show>
       <button

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -64,7 +64,11 @@ import {
 } from "drishti-common/browser";
 import { reconcileRaiseTimes } from "./alertTiming";
 import { disconnectedMessage, STATE, withElapsed } from "./connectionColors";
-import { connectionOf, failureRecord } from "./entryStatusTone";
+import {
+  connectionOf,
+  connectionPhaseOf,
+  failureRecord,
+} from "./entryStatusTone";
 import { HostDot } from "./HostDot";
 import type { View } from "./view";
 import { searchForView, viewFromSearch } from "./urlState";
@@ -858,10 +862,6 @@ function FleetView(props: {
 function HostCard(props: { host: string; onSelect: () => void }) {
   const entry = hostMap.entry(props.host);
   const system = entry.cells.system.use({});
-  // SR9 — the fine connection (the word) rides the SAME entry as the dot; read it
-  // through `connectionOf` (the sole entry.state() seam) instead of a second
-  // `cells.connection` subscription (the drishti#102 split). Presentation unchanged.
-  const connection = () => connectionOf(entry.state());
   // The host's raised-alert set (kolu W5 `alerts` cell). A minimal pip on the
   // card surfaces "this host is in trouble" at a glance, alongside the OS
   // notification the app-scope `watchByEntry` fires — same source of truth. The
@@ -872,17 +872,18 @@ function HostCard(props: { host: string; onSelect: () => void }) {
   const alertCount = createMemo(() => alerts.value()?.items.length ?? 0);
 
   const sys = createMemo<SystemInfo>(() => system.value() ?? DEFAULT_SYSTEM);
-  const state = createMemo<ConnectionState>(
-    () => (connection() ?? DEFAULT_CONNECTION).phase,
-  );
   // The dot + readiness gate read the host MAP's `EntryStatus` fact
   // (floored on real transport liveness by `connectSurfaceMap`) — the
   // per-host `SurfaceHealth`/`app.health()` this used to gate on no longer
-  // exists now that every host rides the ONE admin transport. The status
-  // WORD stays driven by the richer `ConnectionState` cell (copying vs
-  // connecting vs the failure detail) — see `HostDot.tsx`'s docstring for
-  // why the dot and the word now read two different facts.
-  const entryState = createMemo<EntryState<{ reason: string }>>(() => entry.state());
+  // exists now that every host rides the ONE admin transport.
+  const entryState = createMemo<EntryState<{ reason: string }, ConnectionInfo>>(
+    () => entry.state(),
+  );
+  // SR9 — the WORD rides the SAME entry frame as the dot (never a second
+  // `cells.connection` subscription: the drishti#102 split). `connectionPhaseOf` is
+  // total over every arm, so a failed host reads "failed" in red rather than falling
+  // through the gate-closed `DEFAULT_CONNECTION` to an amber "connecting…".
+  const state = createMemo<ConnectionState>(() => connectionPhaseOf(entryState()));
   // CPU% and the core count are read straight off the `system` cell — the agent
   // folds them in (`system.cpuPct` / `system.coreCount`). The card used to open
   // the per-key `cpuCores` collection (one value stream PER core PER host) just
@@ -1111,9 +1112,14 @@ function HostView(props: {
   // `browser.ts`), routed through the ONE `interpretClientError` — no per-use-site
   // `onError` — in case a future dependency drift reintroduces this class of bug.
   const system = entry.cells.system.use();
+  const entryState = createMemo<EntryState<{ reason: string }, ConnectionInfo>>(
+    () => entry.state(),
+  );
   // SR9 — the word derives from the same entry the dot reads (no second subscription).
-  const connection = () => connectionOf(entry.state());
-  const entryState = createMemo<EntryState<{ reason: string }>>(() => entry.state());
+  // `connection()` is the LIVE payload, absent on a failed entry (kolu#2022); `phase()`
+  // is the word, total over every arm.
+  const connection = () => connectionOf(entryState());
+  const phase = createMemo<ConnectionState>(() => connectionPhaseOf(entryState()));
 
   // The host's raised-alert set (kolu W5 `alerts` cell). The fleet card shows a
   // count pip and the app fires an OS notification; the DETAIL view must EXPLAIN
@@ -1235,9 +1241,6 @@ function HostView(props: {
   );
 
   const currentSystem = createMemo(() => system.value() ?? DEFAULT_SYSTEM);
-  const currentConnection = createMemo(
-    () => connection() ?? DEFAULT_CONNECTION,
-  );
 
   // The standing failure, read off the ENTRY (`failureRecord`) rather than off the
   // live `connection.log` the overlay used to narrow on. Same seam the dot reads, so
@@ -1251,7 +1254,7 @@ function HostView(props: {
   // `connected`.
   const connectingView = () => (
     <ConnectingOverlay
-      connection={currentConnection()}
+      connection={connection()}
       failure={failure()}
       onReconnect={onReconnect}
     />
@@ -1350,24 +1353,21 @@ function HostView(props: {
     <>
       <Header
         system={currentSystem()}
-        connection={currentConnection()}
+        phase={phase()}
         entryState={entryState}
         count={allPids().length}
       />
-      {/* The readiness gate is now just the connection CELL's own state — the
-          per-host `SurfaceHealth` `<SurfaceGate>` used to fold (transport ∧
-          every sub's pending/error) no longer exists as a per-host fact now
-          that every host's data rides the ONE admin transport instead of its
-          own socket. `connectingView` covers both the cold-connect and the
-          not-yet-`connected` mirror cases the old fallback did; there is no
-          separate "degraded" amber notice left to distinguish a live-but-
+      {/* The readiness gate is the entry's own connection PHASE (`connectionPhaseOf`,
+          the same word the header paints) — the per-host `SurfaceHealth`
+          `<SurfaceGate>` used to fold (transport ∧ every sub's pending/error) no
+          longer exists as a per-host fact now that every host's data rides the ONE
+          admin transport instead of its own socket. `connectingView` covers both the
+          cold-connect and the not-yet-`connected` mirror cases the old fallback did;
+          there is no separate "degraded" amber notice left to distinguish a live-but-
           erroring sub from a still-warming one — each subscription below
           already surfaces its OWN error via its member's declared `client.onError`
           policy (SR11), routed through the ONE `interpretClientError`. */}
-      <Show
-        when={currentConnection().phase === "connected"}
-        fallback={connectingView()}
-      >
+      <Show when={phase() === "connected"} fallback={connectingView()}>
         <AlertsPanel
           ids={raisedIds()}
           system={currentSystem()}
@@ -1460,8 +1460,10 @@ function pidComparator(
 
 function Header(props: {
   system: ReturnType<() => typeof DEFAULT_SYSTEM>;
-  connection: ReturnType<() => typeof DEFAULT_CONNECTION>;
-  entryState: Accessor<EntryState<{ reason: string }>>;
+  /** The status WORD beside the dot — `connectionPhaseOf(entryState)`, not a phase
+   *  dug out of the live payload: a failed entry has no live payload to dig in. */
+  phase: ConnectionState;
+  entryState: Accessor<EntryState<{ reason: string }, ConnectionInfo>>;
   count: number;
 }) {
   // The component body runs ONCE at mount — when props.system is still
@@ -1485,11 +1487,9 @@ function Header(props: {
             <span class="text-gray-500">host:</span>{" "}
             <span class="font-semibold">{props.system.hostname || "—"}</span>
           </span>
-          <span
-            class={`flex items-center gap-1.5 ${STATE[props.connection.phase].text}`}
-          >
+          <span class={`flex items-center gap-1.5 ${STATE[props.phase].text}`}>
             <HostDot state={props.entryState} />
-            {props.connection.phase}
+            {props.phase}
           </span>
           <span class="text-gray-500">·</span>
           <span class="text-gray-500">
@@ -1593,7 +1593,11 @@ function FilterBar(props: {
 }
 
 function ConnectingOverlay(props: {
-  connection: ConnectionInfo;
+  /** The LIVE connection payload — `undefined` before the first frame lands, and on a
+   *  failed entry, which carries none at all (kolu#2022). Only the coming-up branch
+   *  below reads it; the failed branch renders off `failure` instead, so a missing
+   *  payload is never defaulted into a fabricated "connecting…". */
+  connection: ConnectionInfo | undefined;
   /** The entry's standing failure + its evidence (`failureRecord`), `null` while the
    *  host is merely coming up. This USED to be narrowed out of `connection` itself
    *  (`phase === "failed"`), a second authority that also lost the failure entirely
@@ -1604,13 +1608,14 @@ function ConnectingOverlay(props: {
   const c = () => props.connection;
   // The freshest parent progress line (e.g. "reconnecting in 4000ms…
   // (attempt 2/5)"). Display only — never parsed for control flow.
-  const lastProgress = () => c().log.at(-1)?.line ?? null;
+  const lastProgress = () => c()?.log.at(-1)?.line ?? null;
   // The pending-state headline. `disconnected` refines by cause
   // ("Host unreachable — retrying…" for a network fault); every other
   // state takes its static message. `cause` lives only on the `disconnected`
-  // arm, so narrow on `.phase` before reading it.
+  // arm, so narrow on `.phase` before reading it. No frame yet reads as the
+  // gate-closed default, which is exactly what that value means.
   const statusMessage = () => {
-    const conn = c();
+    const conn = c() ?? DEFAULT_CONNECTION;
     return conn.phase === "disconnected"
       ? disconnectedMessage(conn.cause)
       : STATE[conn.phase].message;
@@ -1623,14 +1628,15 @@ function ConnectingOverlay(props: {
   const [elapsedSec, setElapsedSec] = createSignal(0);
   createEffect(
     on(
-      () => c().phase,
+      () => c()?.phase,
       (state) => {
         setElapsedSec(0);
         // Only the in-progress states render the counter — `pending` is
         // the canonical "is this state in-flight" flag, so consult it
         // rather than leave the interval running in `connected`/`failed`
-        // where `elapsedSec()` is never read.
-        if (!STATE[state].pending) return;
+        // where `elapsedSec()` is never read. No payload = nothing in flight
+        // to count (a failed entry), so the interval never starts.
+        if (state === undefined || !STATE[state].pending) return;
         const startedAt = performance.now();
         const id = setInterval(
           () =>

--- a/packages/app/src/client/connectionAuthority.test.ts
+++ b/packages/app/src/client/connectionAuthority.test.ts
@@ -19,13 +19,22 @@
  * connected host, so this steady-state joint-render assertion at the client's sole
  * `entry.state()` seam is the achievable realization of the "dot AND word agree in
  * one settled frame" invariant.
+ *
+ * kolu#2022 reopened the same defect on the FAILED arm — see the failed-frame case at
+ * the bottom, which is why the word goes through `connectionPhaseOf` rather than
+ * defaulting `connectionOf`'s absence.
  */
 import type { EntryState } from "@kolu/surface-map";
 import { testMembershipId } from "@kolu/surface-map/testing";
 import { describe, expect, it } from "bun:test";
 import type { ConnectionInfo } from "drishti-common/browser";
 import { STATE } from "./connectionColors";
-import { connectionOf, dotClass, statusTextClass } from "./entryStatusTone";
+import {
+  connectionOf,
+  connectionPhaseOf,
+  dotClass,
+  statusTextClass,
+} from "./entryStatusTone";
 
 /** One settled connected frame — the SINGLE object the dot AND the word read. */
 const connectedFrame: EntryState<{ reason: string }, ConnectionInfo> = {
@@ -83,5 +92,51 @@ describe("connection authority (drishti#102 regression)", () => {
     expect(dotClass(warmingFrame)).not.toContain("emerald"); // dot: not green
     const conn = connectionOf(warmingFrame);
     expect(STATE[conn!.phase].pending).toBe(true); // word: in-flight, agrees
+  });
+
+  // kolu#2022 — the same "one frame, two disagreeing renders" defect, on the OTHER
+  // arm. A failed entry carries no live `connection` at all now (a live word is
+  // work-in-flight; a failed host has none), so the old
+  // `connectionOf(...) ?? DEFAULT_CONNECTION` read a gate-closed placeholder whose
+  // phase is `connecting` — painting an amber "connecting…" beside the red dot, with
+  // the real reason sitting right there on the entry. Nothing covered this frame, and
+  // before kolu#2022 it already bit whenever the liveness floor dropped `connection`
+  // off a failed entry (a dead admin link — juspay/kolu#2007). `connectionPhaseOf` is
+  // the fence: the word for a failed entry comes off the coarse arm the dot reads.
+  it("a failed frame's word is failed — never defaulted to connecting", () => {
+    const failedFrame: EntryState<{ reason: string }, ConnectionInfo> = {
+      kind: "failed",
+      membershipId: testMembershipId(),
+      failure: { reason: "ssh exited with code 255" },
+      evidence: [{ source: "local", line: "ssh: connect to host box port 22" }],
+    };
+
+    // There is no live payload to read — the arm does not carry one.
+    expect(connectionOf(failedFrame)).toBeUndefined();
+
+    // …and the word says so, in the dot's own tone.
+    const phase = connectionPhaseOf(failedFrame);
+    expect(phase).toBe("failed");
+    expect(STATE[phase].text).toContain("red");
+    expect(STATE[phase].pending).toBe(false); // steady — nothing is in flight
+    expect(dotClass(failedFrame)).toContain("red");
+    expect(statusTextClass(failedFrame)).toContain("red");
+  });
+
+  // The live arms keep their own fine phase — the fold above is a failed-arm answer,
+  // not a coarsening of the word to `EntryStatus.kind`.
+  it("keeps the live arms' fine phase (provisioning is not flattened to warming)", () => {
+    const provisioningFrame: EntryState<{ reason: string }, ConnectionInfo> = {
+      kind: "warming",
+      membershipId: testMembershipId(),
+      connection: {
+        phase: "provisioning",
+        log: [],
+        sinceMs: 0,
+        campaignEpoch: 0,
+      },
+    };
+    expect(connectionPhaseOf(provisioningFrame)).toBe("provisioning");
+    expect(connectionPhaseOf(connectedFrame)).toBe("connected");
   });
 });

--- a/packages/app/src/client/entryStatusTone.test.ts
+++ b/packages/app/src/client/entryStatusTone.test.ts
@@ -3,6 +3,7 @@ import { testMembershipId } from "@kolu/surface-map/testing";
 import { describe, expect, it } from "bun:test";
 import {
   dotClass,
+  failureRecord,
   statusLabel,
   statusPending,
   statusTextClass,
@@ -13,23 +14,29 @@ import {
 // `MembershipId` — a bare `""` is a type error). These tone/label helpers read
 // `.kind`/`.failure`/`.clockOffset` only, so a fixture mints one through the
 // sanctioned `testMembershipId()` helper, never a literal.
-const CONNECTED: EntryState = {
+const CONNECTED: EntryState<{ reason: string }> = {
   kind: "connected",
   membershipId: testMembershipId(),
   clockOffset: 0,
 };
-const WARMING: EntryState = {
+const WARMING: EntryState<{ reason: string }> = {
   kind: "warming",
   membershipId: testMembershipId(),
 };
 // PR4: the failed arm carries a schema-valid domain `failure` value (drishti's is
 // `{ reason }`), not a bare `reason`/`cause` pair — read as `.failure.reason`.
+// kolu#2022: it ALSO carries that reason's `evidence` — required, so a fixture can no
+// longer spell a reason whose retained output tail is missing.
 const FAILED: EntryState<{ reason: string }> = {
   kind: "failed",
   membershipId: testMembershipId(),
   failure: { reason: "connection refused" },
+  evidence: [
+    { source: "local", line: "ssh: connect to host box port 22" },
+    { source: "remote", line: "Connection refused" },
+  ],
 };
-const NOT_A_MEMBER: EntryState = { kind: "not-a-member" };
+const NOT_A_MEMBER: EntryState<{ reason: string }> = { kind: "not-a-member" };
 
 describe("entryStatusTone", () => {
   it("greens only the connected dot", () => {
@@ -59,6 +66,23 @@ describe("entryStatusTone", () => {
 
   it("surfaces the failure reason in the title, never invented text", () => {
     expect(statusTitle(FAILED)).toBe("failed: connection refused");
+  });
+
+  // kolu#2022 — the failure page reads its reason AND its evidence through the SAME
+  // seam the dot reads, so the two can't disagree about whether a host is failed, and
+  // the tail it renders is the pinned post-mortem record (which survives the liveness
+  // floor) rather than the live `connection.log` (which does not).
+  it("hands the failure page the reason WITH its evidence, and nothing for an up host", () => {
+    expect(failureRecord(FAILED)).toEqual({
+      reason: "connection refused",
+      evidence: [
+        { source: "local", line: "ssh: connect to host box port 22" },
+        { source: "remote", line: "Connection refused" },
+      ],
+    });
+    expect(failureRecord(CONNECTED)).toBeNull();
+    expect(failureRecord(WARMING)).toBeNull();
+    expect(failureRecord(NOT_A_MEMBER)).toBeNull();
   });
 
   it("covers every EntryState kind with a label", () => {

--- a/packages/app/src/client/entryStatusTone.ts
+++ b/packages/app/src/client/entryStatusTone.ts
@@ -9,7 +9,8 @@
  * across every component that paints a dot. PR4 landed exactly such a change:
  * the `failed` arm now carries a schema-valid domain `failure` value
  * (`EntryStatus<Failure>`), read here as `status.failure.reason` — drishti's
- * `HostFailure` is just `{ reason }`, since it paints a cause-blind dot.
+ * `HostFailure` is just `{ reason }`, since it paints a cause-blind dot. kolu#2022
+ * added that reason's `evidence` on the same arm, read here by `failureRecord`.
  *
  * `EntryStatus` is the map's FACT, floored on real transport liveness by
  * `connectSurfaceMap` (see its README) — it replaces the old per-host
@@ -18,7 +19,7 @@
  * data rides the ONE admin transport instead of its own socket).
  */
 
-import type { EntryState } from "@kolu/surface-map";
+import type { EntryState, FailureEvidence } from "@kolu/surface-map";
 import type { ConnectionInfo } from "drishti-common/browser";
 
 // A pure kind→tone lookup as a `Record` keyed on the full `EntryState["kind"]`
@@ -76,6 +77,26 @@ export function statusTitle(status: EntryState<{ reason: string }>): string {
     default:
       return "not a member";
   }
+}
+
+/** The failed entry's POST-MORTEM record — the domain `reason` together with the
+ *  `evidence` the framework staples to it (kolu#2022), `null` when the entry is not
+ *  failed. Read through this seam, beside the dot, so the failure page and the dot's
+ *  tooltip can't disagree about whether a host is failed.
+ *
+ *  Evidence is the retained output tail (`{source, line}`), pinned by `serveHostMap`
+ *  at the SAME classification seam that produced the reason — it is not the live
+ *  `connection.log` this page used to read. That distinction is the whole point:
+ *  `connectSurfaceMap`'s liveness floor DROPS `connection` over a dead admin link but
+ *  KEEPS the failure record, so reading the tail off the live payload lost the actual
+ *  error output at exactly the moment a user was staring at a broken host. Off the
+ *  failure record, the reason and its evidence arrive or vanish together. */
+export function failureRecord(
+  status: EntryState<{ reason: string }>,
+): { reason: string; evidence: FailureEvidence } | null {
+  return status.kind === "failed"
+    ? { reason: status.failure.reason, evidence: status.evidence }
+    : null;
 }
 
 /** Whether this status should pulse (work in progress). A terminally-failed

--- a/packages/app/src/client/entryStatusTone.ts
+++ b/packages/app/src/client/entryStatusTone.ts
@@ -20,7 +20,11 @@
  */
 
 import type { EntryState, FailureEvidence } from "@kolu/surface-map";
-import type { ConnectionInfo } from "drishti-common/browser";
+import {
+  type ConnectionInfo,
+  type ConnectionState,
+  DEFAULT_CONNECTION,
+} from "drishti-common/browser";
 
 // A pure kind→tone lookup as a `Record` keyed on the full `EntryState["kind"]`
 // union — so adding a fourth displayed kind is a compile error here
@@ -117,9 +121,39 @@ export function statusPending(status: EntryState): boolean {
  * `serveHostMap` resolve. Deriving the word HERE — the sole `entry.state()` seam,
  * beside `dotClass` — means the dot and the word cannot disagree: there is one
  * source. A `not-a-member` entry (never reached) carries no connection.
+ *
+ * Neither does a FAILED one, since kolu#2022: a live word is work-in-flight and a
+ * failed entry has none — its post-mortem is the `failureRecord` instead. So this
+ * returns the payload only for the two LIVE arms, and callers that paint a word
+ * must go through `connectionPhaseOf` rather than defaulting the absence.
  */
 export function connectionOf<F>(
   status: EntryState<F, ConnectionInfo>,
 ): ConnectionInfo | undefined {
-  return status.kind === "not-a-member" ? undefined : status.connection;
+  return status.kind === "not-a-member" || status.kind === "failed"
+    ? undefined
+    : status.connection;
+}
+
+/** The connection PHASE to PAINT beside the dot — the one word authority, total over
+ *  every `EntryState` arm.
+ *
+ *  This exists because `connectionOf(...) ?? DEFAULT_CONNECTION` is a TRAP on a failed
+ *  entry. `DEFAULT_CONNECTION` is the gate-closed placeholder for "no frame has arrived
+ *  yet", and its phase is `connecting` — so defaulting a failed entry's absent payload
+ *  painted an amber "connecting…" word beside the red dot, with the real reason sitting
+ *  right there on the entry. That was drishti#102's split reopened on the other side:
+ *  one frame, two disagreeing renders. Before kolu#2022 it only bit when the liveness
+ *  floor dropped `connection` off a failed entry (a dead admin link — exactly
+ *  juspay/kolu#2007); now the failed arm carries no payload at ALL, so the default
+ *  would fire on every failed host.
+ *
+ *  A failed entry's word is `failed`, read off the coarse arm the dot reads. Only the
+ *  live arms fall back to `DEFAULT_CONNECTION`'s phase, which is what that value means. */
+export function connectionPhaseOf(
+  status: EntryState<{ reason: string }, ConnectionInfo>,
+): ConnectionState {
+  return status.kind === "failed"
+    ? "failed"
+    : (connectionOf(status)?.phase ?? DEFAULT_CONNECTION.phase);
 }


### PR DESCRIPTION
Pairs **[juspay/kolu#2022](https://github.com/juspay/kolu/pull/2022)**, pinned at kolu `c432080fae4433f660eb4e84e415b6772d288f05` (branch `surface-failure-evidence`).

## What moved upstream

Failure **evidence** became a framework-minted co-product of the failure record in `@kolu/surface-map` / `@kolu/surface-remote`:

- `EntryStatus.failed` now requires `evidence: FailureEvidence` (`readonly {source: "local" | "remote"; line: string}[]`) beside its domain `failure`, and `entryStatusSchema` refuses a failed status without it — reason-without-evidence is unspellable in the type *and* on the wire.
- `serveHostMap` staples the session's retained log tail on at the same seam it classifies the reason.
- `floorOnLiveness` is unchanged: it keeps `failure` (now carrying evidence) and drops only `connection`, so the evidence survives a dead link by construction.

## What compiled unchanged

Everything on the server, and every existing read of the failure. `admin-router.ts`'s `serveHostMap` call publishes evidence with **zero** code changes — the stapling happens inside the framework — and `entryStatusTone.ts`'s `status.failure.reason` reads are untouched. The single compile break in the whole repo was one test fixture that constructed a `failed` arm without `evidence`, which is exactly the error the tightened type is for.

## What we adopted, and why it is not cosmetic

`FailedCard` took its "Connection log" from the **live** `connection.log`, and `ConnectingOverlay` narrowed the failed arm out of `connection.phase`. Both are the wrong source, for the same reason: `connectSurfaceMap`'s liveness floor **drops** `connection` over a dead admin link while **keeping** the failure. So a host that failed while our link to the browser was down rendered as "connecting…", with the actual ssh / `nix copy` output floored away — [juspay/kolu#2007](https://github.com/juspay/kolu/issues/2007)'s defect, reproduced on drishti's side.

Both now read the entry's failure record through one new seam:

- `packages/app/src/client/entryStatusTone.ts:94` — `failureRecord(status)` returns `{reason, evidence}` or `null`, beside the `dotClass`/`statusTitle` the chip already reads, so the failure page and the dot cannot disagree about whether a host is failed.
- `packages/app/src/client/App.tsx:1247` — `HostView` derives the standing failure off `entryState()` and passes it to `ConnectingOverlay`, which renders `FailedCard` from it instead of from the live payload.
- `packages/app/src/client/App.tsx:1682` — `FailedCard` renders the last 8 evidence lines, monospace, only when non-empty, each keeping its `source` tag. Whether drishti's own parent said a line or the far end did is often the diagnosis, and the field carries that rather than an in-band prefix. Its `reason` prop tightened from `string | null` to `string` on the way through: the framework has no fabricated fallback cause, so a failed entry always carries a real one.

The dot's `title` tooltip is unchanged — one line is right for a tooltip, and a log does not belong in one.

One small pin covers the new seam (`entryStatusTone.test.ts` — the reason arrives *with* its evidence, and an up host yields nothing).

## Verification

Typecheck, 191 unit tests, and full odu CI — `nix`, `typecheck`, `fmt-check`, `bun-nix-fresh`, `home-manager`, `drv-stability`, `agent-boots` — **20/20 green on both `x86_64-linux` and `aarch64-darwin`**.

## ODU-IMPACT VERDICT: `none`

Grounded by a grep of [`juspay/odu`](https://github.com/juspay/odu) at its pinned kolu SHA (`3ff256f0`): odu hydrates `@kolu/surface-map` in nix (`nix/overlay.nix`, `nix/env.nix`) but imports **nothing** from it in TypeScript — no `EntryStatus`, no `EntryState`, no `serveHostMap`, no `EntryFault`. Its `@kolu/surface-remote` use is `makeSession` / `sshConnector` / `SessionState` (`src/coordinator/lane.ts`, `lease.ts`, `runnerFlake.ts`), and kolu#2022 does not touch `session.ts` or `SessionState` — evidence is the *existing* `SessionState.log` passed through at the map seam. Nothing to break and nothing to adopt at odu's next bump.

## Re-pin to follow

kolu#2022's review gauntlet is deliberately held right now, so this pin is a **branch** SHA. Per kolu's `.claude/rules/surface.md`, a drishti green pinned to a pre-gauntlet SHA is stale: **this PR will be re-pinned to kolu's final post-gauntlet HEAD, re-merged with `origin/master`, and re-validated green before merge.**