### PR TITLE
Repair the kolu pin: it names a commit the squash orphaned, on a branch that's gone

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-failure-evidence",
+      "branch": "master",
       "submodules": false,
-      "revision": "928d9bced1002c4f77c8986e05ce508a3f50e8cc",
-      "url": "https://github.com/juspay/kolu/archive/928d9bced1002c4f77c8986e05ce508a3f50e8cc.tar.gz",
-      "hash": "sha256-k6HC2Y1ny2gjBC8Tkuqn4kQG1sA+7Boc+8uYuLoqT6g="
+      "revision": "0964acb3a744b7cf2e89c70cdd94dfe06033de5d",
+      "url": "https://github.com/juspay/kolu/archive/0964acb3a744b7cf2e89c70cdd94dfe06033de5d.tar.gz",
+      "hash": "sha256-+2dy9qQ5PO/QRL8iNm55a6PKe9LB0pnXRpE0j3+44I0="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
#125 merged carrying a kolu pin at `928d9bced1002c4f77c8986e05ce508a3f50e8cc` — the head of kolu's `surface-failure-evidence` branch, which was the right pin while that PR was open. [juspay/kolu#2022](https://github.com/juspay/kolu/pull/2022) was then **squash**-merged, so that commit is **not an ancestor of kolu master**, and the branch has since been **deleted** from the kolu remote (`git ls-remote --heads origin surface-failure-evidence` comes back empty). Our pin names a commit no ref reaches, on a branch that no longer exists.

**Nothing is broken today.** GitHub still serves the archive tarball for an unreferenced commit — `https://github.com/juspay/kolu/archive/928d9bce….tar.gz` returns `200`, npins fetches it, the build is green. But an unreferenced commit is GC-able at GitHub's discretion, and the pin's `branch` field points at something that can no longer be resolved. What this repairs is a confusing 404 at some unpredictable future build, not a red check now.

## The repair

Repointed at **`0964acb3a744b7cf2e89c70cdd94dfe06033de5d`** — the #2022 merge commit on kolu `master` — with the pin's `branch` field moved from `surface-failure-evidence` to `master`, so a future `npins update kolu` follows a branch that exists.

That SHA, specifically, because it is both **on master** and **exactly the content our CI already validated**:

```
git diff 928d9bced 0964acb3a -- packages/surface packages/surface-map packages/surface-remote packages/surface-app
```

is **empty**. The squash carries byte-identical surface sources, which is why this is a pure pin repair.

## What it deliberately does not do

It does **not** advance to current kolu master (`810f8c4ab`). That also carries [juspay/kolu#2018](https://github.com/juspay/kolu/pull/2018) — "Provisioning carries cache binaries to the host" — which drishti has never built or tested. Adopting it is its own deliberate bump with its own validation, not a side effect of repairing a pin.

## Verification

`npins/sources.json` is the **only** file this PR touches — zero code changes. Typecheck clean, **193 unit tests pass**, and full odu CI (`nix`, `typecheck`, `fmt-check`, `bun-nix-fresh`, `home-manager`, `drv-stability`, `agent-boots`) green on both `x86_64-linux` and `aarch64-darwin`.
