### PR TITLE
chore: re-pin kolu to master after the OSF4 socket-holders verb (#2071)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "b3a687b448fd7055103af7e17b51f8f805928ca4",
-      "url": "https://github.com/juspay/kolu/archive/b3a687b448fd7055103af7e17b51f8f805928ca4.tar.gz",
-      "hash": "sha256-cWPA4KMwThLmY7l7HurPCXg2wfH/ME7WDYhV3ELwW3E="
+      "revision": "dd22e5fc6cc1d9a5b5d87441c0eaf50ca2d62e71",
+      "url": "https://github.com/juspay/kolu/archive/dd22e5fc6cc1d9a5b5d87441c0eaf50ca2d62e71.tar.gz",
+      "hash": "sha256-lwFkO667iEaeqDM5N7Ax8lczEeeGfF9rJc7mAtPKjjo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "bdaa2092d6d926a8086eb389f97bebbdc6740c53",
-      "url": "https://github.com/juspay/kolu/archive/bdaa2092d6d926a8086eb389f97bebbdc6740c53.tar.gz",
-      "hash": "sha256-1cP2t8iQHDqBOWpEvDJXfYu65//f2zvQHMdzXEK0L0s="
+      "revision": "2e36387f32ed62afc94c483555ccc1a33e6de700",
+      "url": "https://github.com/juspay/kolu/archive/2e36387f32ed62afc94c483555ccc1a33e6de700.tar.gz",
+      "hash": "sha256-VyUYv73TTwe4FXOmPlRuQVsu8zHMcK1QbW0YMxvmrTM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2e36387f32ed62afc94c483555ccc1a33e6de700",
-      "url": "https://github.com/juspay/kolu/archive/2e36387f32ed62afc94c483555ccc1a33e6de700.tar.gz",
-      "hash": "sha256-VyUYv73TTwe4FXOmPlRuQVsu8zHMcK1QbW0YMxvmrTM="
+      "revision": "c7fce670d918339df394f2031083d125926ee5d7",
+      "url": "https://github.com/juspay/kolu/archive/c7fce670d918339df394f2031083d125926ee5d7.tar.gz",
+      "hash": "sha256-aN97YuFTw9X3+SdUr3ZFqb5u18/Rz2nz6ogdA8cVWaM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c7fce670d918339df394f2031083d125926ee5d7",
-      "url": "https://github.com/juspay/kolu/archive/c7fce670d918339df394f2031083d125926ee5d7.tar.gz",
-      "hash": "sha256-aN97YuFTw9X3+SdUr3ZFqb5u18/Rz2nz6ogdA8cVWaM="
+      "revision": "b3a687b448fd7055103af7e17b51f8f805928ca4",
+      "url": "https://github.com/juspay/kolu/archive/b3a687b448fd7055103af7e17b51f8f805928ca4.tar.gz",
+      "hash": "sha256-cWPA4KMwThLmY7l7HurPCXg2wfH/ME7WDYhV3ELwW3E="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pairs with [juspay/kolu#2071](https://github.com/juspay/kolu/pull/2071) (OSF4), **now merged**. The pin tracks kolu `master` at `dd22e5fc6`.

## What changed upstream

`@kolu/surface-daemon-supervisor`:

- `EndpointSpec` gained a **required** `readSocketHolders` inject, beside `readProcessIdentity`.
- The hand-rolled `socketHolders(socketPath)` export is gone. The socket-holder answer types (`SocketHolder`, `SocketOccupancy`) now live in `osfacts-client` and are re-exported from the supervisor; the reader and the fold (`osfactsSocketHolders`, `foldSocketOccupancy`) live in `osfacts-client` beside `processIdentityAsync`.
- The supervisor's holder lookup is one `osfacts socket-holders` call instead of a `/proc/net/unix` parse plus a darwin `lsof` shell-out.

`osfacts-client`:

- new: `socketHolders`, `parseSocketHoldersOutput`, `osfactsSocketHolders`, `foldSocketOccupancy`, `SOCKET_HOLDERS_SOURCE_FACETS`.
- removed: `processIdentityFromEnvAsync` (zero callers repo-wide at the time of removal; the **sync** `processIdentityFromEnv` is untouched and still has callers).
- `OsfactsClientError` moved to an internal leaf module and is re-exported, so the package surface is unchanged.

## Why this is a pin bump and nothing else

Drishti consumes `convergeAdmit`, `probeDaemonIdentityFrom`, `drainAndAwaitExit`, `createConnectorDrainBudget`, `instanceKeyFromStartedAt` and `drainRejectionSuffix` from the supervisor — none of which take an `EndpointSpec` — and `processIdentity` (sync), `host`, `snapshotHost`, `parseHostOutput` and `parseSnapshotOutput` from `osfacts-client`, none of which moved. It never called `socketHolders`. `osfacts-client` is already hydrated into `node_modules` beside the `@kolu/*` packages (`justfile` → `hydrate-kolu-packages.sh`), so the supervisor's new import resolves as-is.

That reasoning is a claim; **CI green on this pin is the evidence for it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)