### PR TITLE
Pin kolu: pair for juspay/kolu#2097 (daemon-identity pinnedSources / workspace-closure graduation)

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -77,9 +77,13 @@ typecheck: install
 drv-stability:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Shebang recipes on odu may lack bun on PATH. Re-enter the flake
-    # devShell once (outer tree only — never nest nix develop in a worktree).
-    if [ -z "${IN_NIX_SHELL:-}" ] && ! command -v bun >/dev/null 2>&1; then
+    # Shebang recipes on odu may lack this recipe's tools on PATH. Re-enter the
+    # flake devShell once (outer tree only — never nest nix develop in a
+    # worktree). Probe EVERY tool the recipe needs, not just bun: since odu
+    # itself runs on Bun (juspay/odu#72) the lane runner carries `bun`, so a
+    # bun-only probe skips the shell and probe (b) dies at `nixpkgs-fmt`
+    # (dev-shell-only) with exit 127.
+    if [ -z "${IN_NIX_SHELL:-}" ] && { ! command -v bun >/dev/null 2>&1 || ! command -v nixpkgs-fmt >/dev/null 2>&1; }; then
       exec nix develop --accept-flake-config -c bash "$0" "$@"
     fi
     extract_id() {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -16,6 +16,13 @@ let
   koluPkgs = import (kolu + "/nix/nixpkgs.nix") {
     system = final.stdenv.hostPlatform.system;
   };
+  # osfacts graduated out of the kolu tree into its own repo at OSF5
+  # (juspay/kolu#2093); `kolu + "/osfacts"` no longer exists. Read it from
+  # KOLU'S OWN npins pin rather than adding a second drishti pin, so the
+  # binary and its client can never be a revision kolu does not test against
+  # — the same one-revision invariant the in-tree directory used to give for
+  # free.
+  osfactsSrc = (import (kolu + "/npins")).osfacts;
 in
 {
   kolu-surface = mkKoluPackage "surface";
@@ -43,19 +50,19 @@ in
   # Both ride the same npins kolu pin so the fragment and the probe stay matched.
   kolu-surface-daemon = mkKoluPackage "surface-daemon";
   kolu-surface-daemon-supervisor = mkKoluPackage "surface-daemon-supervisor";
-  # osfacts incubates at the kolu repo root (juspay/kolu#2011), outside the
-  # `packages/` workspace. Keep its binary and dependency-free TypeScript
-  # client on the same npins revision so the client's `V 2` gate can never be
-  # paired with a binary from another source.
-  osfacts = import (kolu + "/osfacts") { pkgs = koluPkgs; };
+  # osfacts (juspay/osfacts, formerly the kolu repo root — see `osfactsSrc`).
+  # Binary and dependency-free TypeScript client come from one revision, so
+  # the client's `V 2` gate can never be paired with a binary from another
+  # source.
+  osfacts = import osfactsSrc { pkgs = koluPkgs; };
   osfacts-client = final.runCommand "osfacts-client"
     {
       meta = {
         description = "TypeScript client source for osfacts";
-        homepage = "https://github.com/juspay/kolu/tree/osfacts-improve/osfacts/client-ts";
+        homepage = "https://github.com/juspay/osfacts/tree/main/client-ts";
       };
     }
     ''
-      cp -r ${kolu}/osfacts/client-ts $out
+      cp -r ${osfactsSrc}/client-ts $out
     '';
 }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "graduate-identity",
       "submodules": false,
-      "revision": "dd22e5fc6cc1d9a5b5d87441c0eaf50ca2d62e71",
-      "url": "https://github.com/juspay/kolu/archive/dd22e5fc6cc1d9a5b5d87441c0eaf50ca2d62e71.tar.gz",
-      "hash": "sha256-lwFkO667iEaeqDM5N7Ax8lczEeeGfF9rJc7mAtPKjjo="
+      "revision": "2dbc6b10dad41a47a2214ecc35749585ae221910",
+      "url": "https://github.com/juspay/kolu/archive/2dbc6b10dad41a47a2214ecc35749585ae221910.tar.gz",
+      "hash": "sha256-xdkiZuArBHC0Vu5Ma5LbZOzyZaixpllx5Uho1eO64f8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "graduate-identity",
+      "branch": "master",
       "submodules": false,
-      "revision": "2dbc6b10dad41a47a2214ecc35749585ae221910",
-      "url": "https://github.com/juspay/kolu/archive/2dbc6b10dad41a47a2214ecc35749585ae221910.tar.gz",
-      "hash": "sha256-xdkiZuArBHC0Vu5Ma5LbZOzyZaixpllx5Uho1eO64f8="
+      "revision": "ee58793b6826fcc2c87120aae0fd034cb657716b",
+      "url": "https://github.com/juspay/kolu/archive/ee58793b6826fcc2c87120aae0fd034cb657716b.tar.gz",
+      "hash": "sha256-KxwDTLXnSJCvXbhddEzgdSsEjae7G2fyce0tzvXTlYM="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pair PR for **juspay/kolu#2097** (daemon-identity `pinnedSources` / workspace-closure graduation). **Drishti calls neither `mkDaemonIdentity` nor the new `workspace-closure.nix`** — it consumes `@kolu/surface-daemon`'s TS sources and bakes its own store-path identity — so the pin bump plus green CI is the no-breakage evidence.

Two real fixes rode along, both pre-existing breakages this pair surfaced (neither caused by #2097):

- **`nix/overlay.nix`**: kolu #2093 moved `osfacts` to its own repo, so `import (kolu + "/osfacts")` broke against every kolu ≥ `af296061` — drishti master was already red against kolu master. Now reads osfacts from **kolu's own npins pin**, keeping binary + TS client on one revision.
- **`ci/mod.just`**: since odu runs on Bun (juspay/odu#72) the lane runner carries `bun`, so `drv-stability`'s bun-only dev-shell probe skipped re-entry and died at `nixpkgs-fmt` (exit 127, both platforms, master too). The guard now probes every tool the recipe needs.

**CI: 24 ok · 0 failed on both platforms** (`a147e89`, kolu pinned at `2dbc6b10d`). Kolu's PR head has since gained a master merge commit with no surface-API delta; per the #130 precedent the pin gets its final bump to kolu master after #2097 merges.

_Generated by Claude Code (model `claude-fable-5`); implementation by Opus subagents._