### PR TITLE
feat(agent): adopt the Effect-native osfacts client

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "effect",
+      "branch": "osfacts-effect",
       "submodules": false,
-      "revision": "41d517754737ad2b97e72719e276739102d749b9",
-      "url": "https://github.com/juspay/kolu/archive/41d517754737ad2b97e72719e276739102d749b9.tar.gz",
-      "hash": "sha256-nZPp6CF7ZHR9Ev+Fjy2tRi6kwhae+jHJUqJVo0NLvQE="
+      "revision": "c72da36cd80b1abb016209792708ccd5b02d5bf9",
+      "url": "https://github.com/juspay/kolu/archive/c72da36cd80b1abb016209792708ccd5b02d5bf9.tar.gz",
+      "hash": "sha256-3Gpv4Gd2R9dp1XQLh/EUOUJlwVfhDg9mkyNRmg67Rnk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,8 +9,8 @@
       },
       "branch": "osfacts-effect",
       "submodules": false,
-      "revision": "c72da36cd80b1abb016209792708ccd5b02d5bf9",
-      "url": "https://github.com/juspay/kolu/archive/c72da36cd80b1abb016209792708ccd5b02d5bf9.tar.gz",
+      "revision": "7d58e57f08a2b8a3c33c230b5f518ee05a928a76",
+      "url": "https://github.com/juspay/kolu/archive/7d58e57f08a2b8a3c33c230b5f518ee05a928a76.tar.gz",
       "hash": "sha256-3Gpv4Gd2R9dp1XQLh/EUOUJlwVfhDg9mkyNRmg67Rnk="
     },
     "nixpkgs": {

--- a/packages/agent/src/proc.test.ts
+++ b/packages/agent/src/proc.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
 import { osfactsSourceStatus } from "drishti-common/source-errors";
-import { parseHostOutput, parseSnapshotOutput } from "osfacts-client";
+import {
+  OsfactsSpawnError,
+  parseHostOutput,
+  parseSnapshotOutput,
+} from "osfacts-client";
 import {
   computeCpuUsage,
   computeNetThroughput,
@@ -101,8 +106,8 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "linux",
       "test",
-      async () => readings[index++]!,
-      async () => parseHostOutput(hostFixture),
+      () => Effect.sync(() => readings[index++]!),
+      () => Effect.succeed(parseHostOutput(hostFixture)),
       () => clock,
     );
     expect((await reader.readProcesses()).get(42)?.cpuPct).toBe(0);
@@ -120,8 +125,8 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "darwin",
       "mac",
-      async () => reading,
-      async () => parseHostOutput(hostFixture),
+      () => Effect.succeed(reading),
+      () => Effect.succeed(parseHostOutput(hostFixture)),
       () => clock,
       async () => {
         psCalls++;
@@ -149,8 +154,8 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "linux",
       "linux",
-      async () => parseSnapshotOutput(snapshotFixture),
-      async () => parseHostOutput(hostFixture),
+      () => Effect.succeed(parseSnapshotOutput(snapshotFixture)),
+      () => Effect.succeed(parseHostOutput(hostFixture)),
       () => 1_000,
       async () => {
         psCalls++;
@@ -170,8 +175,8 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "darwin",
       "mac",
-      async () => reading,
-      async () => parseHostOutput(hostFixture),
+      () => Effect.succeed(reading),
+      () => Effect.succeed(parseHostOutput(hostFixture)),
       () => 1_000,
       async () => {
         throw Object.assign(new Error("ps unavailable"), { code: "ENOENT" });
@@ -212,8 +217,8 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "darwin",
       "mac",
-      async () => reading,
-      async () => parseHostOutput(hostFixture),
+      () => Effect.succeed(reading),
+      () => Effect.succeed(parseHostOutput(hostFixture)),
       () => 1_000,
       async () =>
         new Map([[42, { cpuPct: 11.5, rssBytes: 16_777_216 }]]),
@@ -244,11 +249,15 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "linux",
       "test",
-      async (bin, facets) => {
-        calls.push({ bin, facets });
-        return reading;
-      },
-      async () => hostReading,
+      // `Effect.sync`, not a plain closure returning `Effect.succeed`: the
+      // record now happens when the reader RUNS the description, so this
+      // counts spawns rather than descriptions built.
+      (bin, facets) =>
+        Effect.sync(() => {
+          calls.push({ bin, facets });
+          return reading;
+        }),
+      () => Effect.succeed(hostReading),
       () => 10,
     );
     await Promise.all([
@@ -332,8 +341,8 @@ describe("osfacts V2 process observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "linux",
       "test",
-      async () => reading,
-      async () => parseHostOutput(hostFixture),
+      () => Effect.succeed(reading),
+      () => Effect.succeed(parseHostOutput(hostFixture)),
       () => 10,
     );
     expect((await reader.readProcesses()).has(42)).toBe(true);
@@ -343,6 +352,58 @@ describe("osfacts V2 process observation", () => {
         source: "darwin_tcp_pcblist",
         facet: "ports_unclaimed",
         code: "BLIND_OR_EMPTY",
+      },
+    ]);
+  });
+
+  /**
+   * THE run edge, pinned by its one observable consequence.
+   *
+   * osfacts-client's spawning verbs are Effects (juspay/osfacts#5), and
+   * `proc.ts` runs them with `Effect.runPromise` so `ProcReader` can stay the
+   * Promise-shaped reader the reactor's `source({ read })` requires. That run
+   * is only safe if it hands the client's failure through UNCHANGED: an Effect
+   * runner that wrapped the failure (in a fiber-failure envelope, or in
+   * anything carrying a synthesised message) would silently break
+   * `readSourceErrors`, whose recovery reads a marker out of the error's own
+   * message. Identity — `toBe`, not `toBeInstanceOf` — is what says the
+   * rejection IS the value the verb failed with.
+   *
+   * And the other arm keeps answering: a snapshot read that fails must not
+   * take the host aggregate's source errors down with it, which is the whole
+   * reason `readSourceErrors` settles the two frames rather than awaiting them.
+   */
+  it("hands a failed osfacts read through the run edge as the client's own tagged error", async () => {
+    const failure = new OsfactsSpawnError({
+      message: "osfacts `/nix/store/osfacts/bin/osfacts` failed (ENOENT)",
+    });
+    const reader = createOsfactsReader(
+      "/nix/store/osfacts/bin/osfacts",
+      "linux",
+      "test",
+      () => Effect.fail(failure),
+      () =>
+        Effect.succeed(
+          parseHostOutput(`${hostFixture}E\tthermal\tcpu\tUNSUPPORTED\n`),
+        ),
+      () => 10,
+    );
+
+    const rejection = await reader.readProcesses().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBe(failure);
+
+    // Not an osfacts SOURCE error (no marker in its message), so it publishes
+    // no fact — and the host arm's E row still arrives.
+    expect(osfactsSourceStatus(rejection)).toBeNull();
+    expect([...(await reader.readSourceErrors()).values()]).toEqual([
+      {
+        operation: "host",
+        source: "thermal",
+        facet: "cpu",
+        code: "UNSUPPORTED",
       },
     ]);
   });
@@ -442,18 +503,19 @@ describe("osfacts V2 host observation", () => {
       "/nix/store/osfacts/bin/osfacts",
       "linux",
       "test",
-      async () => parseSnapshotOutput(snapshotFixture),
-      async (_bin, facets) => {
-        calls++;
-        expect(facets).toEqual({
-          load: true,
-          mem: true,
-          cpu: true,
-          net: true,
-          disk: true,
-        });
-        return parseHostOutput(hostFixture);
-      },
+      () => Effect.succeed(parseSnapshotOutput(snapshotFixture)),
+      (_bin, facets) =>
+        Effect.sync(() => {
+          calls++;
+          expect(facets).toEqual({
+            load: true,
+            mem: true,
+            cpu: true,
+            net: true,
+            disk: true,
+          });
+          return parseHostOutput(hostFixture);
+        }),
       () => 10,
     );
     await Promise.all([

--- a/packages/agent/src/proc.ts
+++ b/packages/agent/src/proc.ts
@@ -4,8 +4,16 @@
  * On Darwin, Apple's privileged ps recovers only per-process CPU/RSS facts
  * osfacts explicitly marks unreadable; it never overwrites readable facts.
  * Node's os module is used only for host identity and OS selection.
+ *
+ * osfacts-client's spawning verbs are Effects (juspay/osfacts#5), so this module
+ * carries the agent's TWO osfacts run edges — one per fact family, in
+ * `processFrame` and `hostFrame` below. They are here and not higher because
+ * `ProcReader` feeds the reactor's `source({ read })`, whose `read` is
+ * `() => Promise<T>` by design; pushing the Effects up would only relocate the
+ * run, not remove it, and would put two Promise faces on the same reader.
  */
 
+import { Effect } from "effect";
 import { hostname, platform } from "node:os";
 import {
   host as readOsfactsHost,
@@ -346,6 +354,11 @@ export function hostFromOsfacts(
   return { frame, baseline: { takenMs, cpus, networks } };
 }
 
+/** The two injectable osfacts seams, stated as `typeof` the verbs they stand in
+ *  for so a client API change lands here as a type error rather than as a
+ *  double that has quietly drifted from the thing it doubles. Both are
+ *  Effect-returning since juspay/osfacts#5: a double must hand back an Effect,
+ *  and a Promise-returning one no longer compiles. */
 export type SnapshotHost = typeof snapshotHost;
 export type ReadHost = typeof readOsfactsHost;
 export type ReadDarwinProcessUsage = typeof readDarwinProcessUsage;
@@ -454,18 +467,26 @@ export function createOsfactsReader(
               };
             })
         : Promise.resolve({ usage: new Map(), errors: [] });
+    // RUN EDGE (snapshot). `readSnapshot` describes a spawn; nothing forks
+    // until this runs it, and running it HERE — inside the cache-window guard,
+    // once — is what keeps "one osfacts subprocess per fact family per window"
+    // true. `runPromise` rejects with the client's failure VALUE, so the
+    // tagged `OsfactsClientError` reaches `readSourceErrors` below exactly as
+    // the old rejection did, unwrapped.
     const promise = Promise.all([
-      readSnapshot(bin, {
-        procs: true,
-        ports: true,
-        mem: true,
-        startTime: true,
-        cpuTime: true,
-        uid: true,
-        cwd: true,
-        status: true,
-        argv: true,
-      }),
+      Effect.runPromise(
+        readSnapshot(bin, {
+          procs: true,
+          ports: true,
+          mem: true,
+          startTime: true,
+          cpuTime: true,
+          uid: true,
+          cwd: true,
+          status: true,
+          argv: true,
+        }),
+      ),
       nativeCensus,
     ]).then(([reading, census]) => {
       const current = new Map<Pid, number>(
@@ -509,13 +530,20 @@ export function createOsfactsReader(
     const takenMs = now();
     if (hostCache && takenMs - hostCache.takenMs < maxAgeMs)
       return hostCache.promise;
-    const promise = readHost(bin, {
-      load: true,
-      mem: true,
-      cpu: true,
-      net: true,
-      disk: true,
-    }).then((reading) => {
+    // RUN EDGE (host) — the snapshot edge's twin, for the same reason.
+    // `hostFromOsfacts` stays OUTSIDE the Effect deliberately: it throws
+    // `OsfactsSourceError`, which `readSourceErrors` recovers by reading the
+    // message marker. Folded in as an `Effect.map` that throw would become a
+    // DEFECT and reach the caller wrapped, and the marker read would go blind.
+    const promise = Effect.runPromise(
+      readHost(bin, {
+        load: true,
+        mem: true,
+        cpu: true,
+        net: true,
+        disk: true,
+      }),
+    ).then((reading) => {
       const mapped = hostFromOsfacts(
         reading,
         hostBaseline,


### PR DESCRIPTION
osfacts' TypeScript client went Effect-native in [juspay/osfacts#5](https://github.com/juspay/osfacts/pull/5): every spawning verb now hands back an `Effect.Effect<_, OsfactsClientError>` instead of a Promise, and `OsfactsClientError` became a union of three tagged classes rather than one class with a `kind` string. drishti consumes exactly **two** of those verbs — `snapshotHost` and `host`, both in `packages/agent/src/proc.ts` — so this adoption is two run edges, their test doubles, and the pin that brings the new client in.

## What changed

**`proc.ts` — two run edges, and where they are.** `readSnapshot(...)` and `readHost(...)` are now descriptions; `Effect.runPromise` runs them inside the existing cache-window guard, which is what keeps "one osfacts subprocess per fact family per window" true. The edges live *in* `proc.ts` rather than higher up because `ProcReader` feeds the reactor's `source({ read })`, whose `read` is `() => Promise<T>` by design — pushing the Effects up would only relocate the run, not remove it, and would leave two Promise faces on one reader. That is the same call kolu made for padi's port sampler in the paired PR, and the same one `hostRegistry.ts` already documents at the `Admit` seam it doesn't own.

**`hostFromOsfacts` stays *outside* the host Effect, deliberately.** It throws `OsfactsSourceError`, and `readSourceErrors` recovers that by reading a marker out of the error's own message. Folded in as an `Effect.map`, the throw would become a **defect**, reach the caller wrapped, and the marker read would go blind. The comment at the edge says so.

**The seam types needed no edit — which is the point.** `SnapshotHost` / `ReadHost` are `typeof snapshotHost` / `typeof host`, so the upstream API change arrived as a type error at every call site rather than as doubles that had quietly drifted from the thing they double. The doubles are now `Effect.sync`, which upgrades the two counting tests from counting *descriptions built* to counting *spawns*.

**One falsified pin.** `hands a failed osfacts read through the run edge as the client's own tagged error` asserts **identity** (`toBe`, not `toBeInstanceOf`): a runner that wrapped the failure in a fiber-failure envelope would silently break `readSourceErrors`' marker recovery, and the rest of the suite would stay green. Made red by wrapping the rejection at the edge, then green again.

## What did *not* change, and why that was checked rather than assumed

| Touchpoint | Verdict |
|---|---|
| `processIdentity.ts` | The port kept `processIdentity` on the sync island. Compiles as-is. |
| `parseHostOutput` / `parseSnapshotOutput` in `proc.test.ts` | Still sync-throwing. Call shapes unchanged. |
| Supervisor seam | drishti uses `convergeAdmit` and `probeDaemonIdentityFrom` — neither takes an osfacts reader. drishti never calls `createEndpoint`, so the two flipped seams (`ReadSocketHolders`, `ReadProcessIdentityAsync`) have no drishti consumer. |
| Error vocabulary | No `instanceof OsfactsClientError` and no `.kind` read existed anywhere in drishti. |
| `@kolu/surface-daemon`'s pid gate | Untouched upstream — it takes the *sync* `ProcessIdentity`, which is exactly what `processIdentity.ts` supplies. |

## The pin

kolu at `7d58e57f0` (branch `osfacts-effect`, the head of juspay/kolu#2103), which pins osfacts at `86091cf6`. drishti reads osfacts through **kolu's own** npins pin (`nix/overlay.nix`), so one bump moves both the binary and its client together.

The `branch` field moves to `osfacts-effect` alongside the revision. Left at `effect` it would be a lie that a future `npins update` would "fix" by silently yanking the pin back off the adoption.

## Pair relationships and merge order

This is one of four PRs that only typecheck together:

1. [juspay/kolu#2101](https://github.com/juspay/kolu/pull/2101) — the Effect 4 migration these all stand on
2. [juspay/osfacts#5](https://github.com/juspay/osfacts/pull/5) — the client port itself (`86091cf6`, green)
3. [juspay/kolu#2103](https://github.com/juspay/kolu/pull/2103) — kolu's adoption: bumps its osfacts pin and flips the supervisor's last two Promise seams
4. **this PR**, stacked on [#132](https://github.com/srid/drishti/pull/132) (base `effect`)

Merge in that order, each step re-pinning to the previous one's **merge commit** rather than its branch head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
