### PR TITLE
Pair with juspay/kolu#2129: "we cannot see it" gets its own EntryState arm

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.103",
         "drishti-common": "workspace:*",
-        "effect": "4.0.0-beta.103",
+        "effect": "4.0.0-beta.106",
         "ts-pattern": "^5.9.0",
       },
     },
@@ -35,7 +35,7 @@
         "cleye": "^2.3.0",
         "dequal": "^2.0.3",
         "drishti-common": "workspace:*",
-        "effect": "4.0.0-beta.103",
+        "effect": "4.0.0-beta.106",
         "neverthrow": "^8.2.0",
         "quick-lru": "^7.3.0",
         "solid-js": "^1.9.0",
@@ -59,14 +59,14 @@
       "name": "drishti-common",
       "version": "0.1.0",
       "dependencies": {
-        "effect": "4.0.0-beta.103",
+        "effect": "4.0.0-beta.106",
       },
     },
   },
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
     "@effect/platform-node": "4.0.0-beta.103",
-    "effect": "4.0.0-beta.103",
+    "effect": "4.0.0-beta.106",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -301,7 +301,7 @@
 
     "drishti-common": ["drishti-common@workspace:packages/common"],
 
-    "effect": ["effect@4.0.0-beta.103", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pE8TxF4m2tQzVI+77dIlm3s+81TACV1AiX1JEkvY+zVuxgQQ8aGSkqXNJF6b/ST+coCSk5cUdbULpQ7sm4oHyw=="],
+    "effect": ["effect@4.0.0-beta.106", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-Sb1eNPYP8UdkE6xDOEEnrrOh/Vu2ocdRTPSeZTjZXukUrEYT2NtuQpbS90sEWaa7b6qLt8dfEYPpa6IVe5giHw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.363", "", {}, "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA=="],
 
@@ -313,8 +313,6 @@
 
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -322,8 +320,6 @@
     "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
-
-    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
 
@@ -381,8 +377,6 @@
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
-    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
-
     "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
@@ -429,8 +423,6 @@
 
     "terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
 
-    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
-
     "ts-pattern": ["ts-pattern@5.9.0", "", {}, "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg=="],
 
     "type-flag": ["type-flag@4.3.0", "", {}, "sha512-XwZWK+SOWleva2EjynfJT6tXHUkS+/TZAIc5fTJXVMArNf/5jBEt7Y/yBtGcxLFThtQCQ9v6nxXon0QZ86ZJhA=="],
@@ -450,8 +442,6 @@
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "drishti-agent",
       "version": "0.1.0",
       "dependencies": {
-        "@effect/platform-node": "4.0.0-beta.106",
+        "@effect/platform-node": "4.0.0-beta.103",
         "drishti-common": "workspace:*",
         "effect": "4.0.0-beta.106",
         "ts-pattern": "^5.9.0",

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "drishti-agent",
       "version": "0.1.0",
       "dependencies": {
-        "@effect/platform-node": "4.0.0-beta.103",
+        "@effect/platform-node": "4.0.0-beta.106",
         "drishti-common": "workspace:*",
         "effect": "4.0.0-beta.106",
         "ts-pattern": "^5.9.0",
@@ -25,7 +25,7 @@
       "dependencies": {
         "@babel/core": "^7.25.0",
         "@babel/preset-typescript": "^7.25.0",
-        "@effect/platform-node": "4.0.0-beta.103",
+        "@effect/platform-node": "4.0.0-beta.106",
         "@solid-primitives/keyed": "^1.5.3",
         "@solid-primitives/page-visibility": "^2.1.5",
         "@solid-primitives/scheduled": "^1.5.3",
@@ -65,7 +65,7 @@
   },
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.103",
+    "@effect/platform-node": "4.0.0-beta.106",
     "effect": "4.0.0-beta.106",
   },
   "packages": {
@@ -127,9 +127,9 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.103", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.103", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103", "ioredis": "^5.7.0" } }, "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.106", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.106", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106", "ioredis": ">=5.7.0 <6.0.0" } }, "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.103", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103" } }, "sha512-0aCZMBid5ifqmY55TkfCDLaGTIM8qu3bNFUW7qL9vh/7jFOkaIAMX2MA8muG4deqW17XWxawddWu4v0fK+UW3g=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.106", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106" } }, "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -487,9 +487,9 @@
   "drishti-agent" = copyPathToStore ./packages/agent;
   "drishti-app" = copyPathToStore ./packages/app;
   "drishti-common" = copyPathToStore ./packages/common;
-  "effect@4.0.0-beta.103" = fetchurl {
-    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.103.tgz";
-    hash = "sha512-pE8TxF4m2tQzVI+77dIlm3s+81TACV1AiX1JEkvY+zVuxgQQ8aGSkqXNJF6b/ST+coCSk5cUdbULpQ7sm4oHyw==";
+  "effect@4.0.0-beta.106" = fetchurl {
+    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.106.tgz";
+    hash = "sha512-Sb1eNPYP8UdkE6xDOEEnrrOh/Vu2ocdRTPSeZTjZXukUrEYT2NtuQpbS90sEWaa7b6qLt8dfEYPpa6IVe5giHw==";
   };
   "electron-to-chromium@1.5.363" = fetchurl {
     url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz";
@@ -515,10 +515,6 @@
     url = "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz";
     hash = "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==";
   };
-  "find-my-way-ts@0.1.6" = fetchurl {
-    url = "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz";
-    hash = "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==";
-  };
   "gensync@1.0.0-beta.2" = fetchurl {
     url = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
     hash = "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
@@ -534,10 +530,6 @@
   "html-entities@2.3.3" = fetchurl {
     url = "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz";
     hash = "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==";
-  };
-  "ini@7.0.0" = fetchurl {
-    url = "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz";
-    hash = "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==";
   };
   "ioredis@5.11.1" = fetchurl {
     url = "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz";
@@ -651,10 +643,6 @@
     url = "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz";
     hash = "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==";
   };
-  "multipasta@0.2.8" = fetchurl {
-    url = "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz";
-    hash = "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==";
-  };
   "neverthrow@8.2.0" = fetchurl {
     url = "https://registry.npmjs.org/neverthrow/-/neverthrow-8.2.0.tgz";
     hash = "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==";
@@ -747,10 +735,6 @@
     url = "https://registry.npmjs.org/terminal-columns/-/terminal-columns-2.0.0.tgz";
     hash = "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ==";
   };
-  "toml@4.3.0" = fetchurl {
-    url = "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz";
-    hash = "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==";
-  };
   "ts-pattern@5.9.0" = fetchurl {
     url = "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz";
     hash = "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==";
@@ -794,9 +778,5 @@
   "yallist@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
     hash = "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
-  };
-  "yaml@2.9.0" = fetchurl {
-    url = "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz";
-    hash = "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==";
   };
 }

--- a/bun.nix
+++ b/bun.nix
@@ -128,13 +128,13 @@
     url = "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz";
     hash = "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==";
   };
-  "@effect/platform-node-shared@4.0.0-beta.103" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.103.tgz";
-    hash = "sha512-0aCZMBid5ifqmY55TkfCDLaGTIM8qu3bNFUW7qL9vh/7jFOkaIAMX2MA8muG4deqW17XWxawddWu4v0fK+UW3g==";
+  "@effect/platform-node-shared@4.0.0-beta.106" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.106.tgz";
+    hash = "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw==";
   };
-  "@effect/platform-node@4.0.0-beta.103" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.103.tgz";
-    hash = "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA==";
+  "@effect/platform-node@4.0.0-beta.106" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.106.tgz";
+    hash = "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg==";
   };
   "@emnapi/core@1.10.0" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "787321305f003ed97153b2e44d757201b6de4305",
-      "url": "https://github.com/juspay/kolu/archive/787321305f003ed97153b2e44d757201b6de4305.tar.gz",
-      "hash": "sha256-Qcv5Z8bxAY/zrxhj9ifssDpptd0fMRaSIw9Eih3JaXM="
+      "revision": "48b2c6a778def55d848f89f12a9d3b9da67710a3",
+      "url": "https://github.com/juspay/kolu/archive/48b2c6a778def55d848f89f12a9d3b9da67710a3.tar.gz",
+      "hash": "sha256-9Gf7/DQCH6iSHYkrThfiqWiRp7QtPmwoWcZkDz0y6zk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2104ddea97b431c759d782d380559b0e523e3734",
-      "url": "https://github.com/juspay/kolu/archive/2104ddea97b431c759d782d380559b0e523e3734.tar.gz",
-      "hash": "sha256-aFTBedTFjZEg/MhtN77ErXThx9UBm92v/rb3yjdPfSs="
+      "revision": "787321305f003ed97153b2e44d757201b6de4305",
+      "url": "https://github.com/juspay/kolu/archive/787321305f003ed97153b2e44d757201b6de4305.tar.gz",
+      "hash": "sha256-Qcv5Z8bxAY/zrxhj9ifssDpptd0fMRaSIw9Eih3JaXM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,8 +9,8 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "48b2c6a778def55d848f89f12a9d3b9da67710a3",
-      "url": "https://github.com/juspay/kolu/archive/48b2c6a778def55d848f89f12a9d3b9da67710a3.tar.gz",
+      "revision": "4d8a668f65a2071d7e0d9e92e0187c30a557f507",
+      "url": "https://github.com/juspay/kolu/archive/4d8a668f65a2071d7e0d9e92e0187c30a557f507.tar.gz",
       "hash": "sha256-9Gf7/DQCH6iSHYkrThfiqWiRp7QtPmwoWcZkDz0y6zk="
     },
     "nixpkgs": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "//overrides": "ONE effect copy fleet-wide. The hydrated @kolu/* sources resolve `effect` from THIS node_modules (bunfig linker=hoisted), and Effect's tagged-error narrowing is `_tag`-structural precisely because two module instances would otherwise stop recognising each other's classes — but `instanceof`, Context keys and Schema identity are not. Pinning here means a transitive bump cannot smuggle in a second copy. Mirrored verbatim in packages/agent/agent.package.json and scripts/regenerate-agent-deps.sh's heredoc — all three must move together.",
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.103",
+    "@effect/platform-node": "4.0.0-beta.106",
     "effect": "4.0.0-beta.106"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
     "@effect/platform-node": "4.0.0-beta.103",
-    "effect": "4.0.0-beta.103"
+    "effect": "4.0.0-beta.106"
   }
 }

--- a/packages/agent/agent.bun.nix
+++ b/packages/agent/agent.bun.nix
@@ -16,9 +16,9 @@
     url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.106.tgz";
     hash = "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw==";
   };
-  "@effect/platform-node@4.0.0-beta.103" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.103.tgz";
-    hash = "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA==";
+  "@effect/platform-node@4.0.0-beta.106" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.106.tgz";
+    hash = "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg==";
   };
   "@ioredis/commands@1.10.0" = fetchurl {
     url = "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz";
@@ -78,21 +78,13 @@
   };
   "drishti-agent" = copyPathToStore ./.;
   "drishti-common" = copyPathToStore ../common;
-  "effect@4.0.0-beta.103" = fetchurl {
-    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.103.tgz";
-    hash = "sha512-pE8TxF4m2tQzVI+77dIlm3s+81TACV1AiX1JEkvY+zVuxgQQ8aGSkqXNJF6b/ST+coCSk5cUdbULpQ7sm4oHyw==";
+  "effect@4.0.0-beta.106" = fetchurl {
+    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.106.tgz";
+    hash = "sha512-Sb1eNPYP8UdkE6xDOEEnrrOh/Vu2ocdRTPSeZTjZXukUrEYT2NtuQpbS90sEWaa7b6qLt8dfEYPpa6IVe5giHw==";
   };
   "fast-check@4.9.0" = fetchurl {
     url = "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz";
     hash = "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==";
-  };
-  "find-my-way-ts@0.1.6" = fetchurl {
-    url = "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz";
-    hash = "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==";
-  };
-  "ini@7.0.0" = fetchurl {
-    url = "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz";
-    hash = "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==";
   };
   "ioredis@5.11.1" = fetchurl {
     url = "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz";
@@ -118,10 +110,6 @@
     url = "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz";
     hash = "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==";
   };
-  "multipasta@0.2.8" = fetchurl {
-    url = "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz";
-    hash = "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==";
-  };
   "node-gyp-build-optional-packages@5.2.2" = fetchurl {
     url = "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz";
     hash = "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==";
@@ -142,10 +130,6 @@
     url = "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz";
     hash = "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==";
   };
-  "toml@4.3.0" = fetchurl {
-    url = "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz";
-    hash = "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==";
-  };
   "ts-pattern@5.9.0" = fetchurl {
     url = "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz";
     hash = "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==";
@@ -165,9 +149,5 @@
   "ws@8.21.3" = fetchurl {
     url = "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz";
     hash = "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==";
-  };
-  "yaml@2.9.0" = fetchurl {
-    url = "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz";
-    hash = "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==";
   };
 }

--- a/packages/agent/agent.bun.nix
+++ b/packages/agent/agent.bun.nix
@@ -16,9 +16,9 @@
     url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.106.tgz";
     hash = "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw==";
   };
-  "@effect/platform-node@4.0.0-beta.106" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.106.tgz";
-    hash = "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg==";
+  "@effect/platform-node@4.0.0-beta.103" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.103.tgz";
+    hash = "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA==";
   };
   "@ioredis/commands@1.10.0" = fetchurl {
     url = "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz";

--- a/packages/agent/agent.bun.nix
+++ b/packages/agent/agent.bun.nix
@@ -12,9 +12,9 @@
 , ...
 }:
 {
-  "@effect/platform-node-shared@4.0.0-beta.103" = fetchurl {
-    url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.103.tgz";
-    hash = "sha512-0aCZMBid5ifqmY55TkfCDLaGTIM8qu3bNFUW7qL9vh/7jFOkaIAMX2MA8muG4deqW17XWxawddWu4v0fK+UW3g==";
+  "@effect/platform-node-shared@4.0.0-beta.106" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.106.tgz";
+    hash = "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw==";
   };
   "@effect/platform-node@4.0.0-beta.103" = fetchurl {
     url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.103.tgz";
@@ -52,9 +52,9 @@
     url = "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz";
     hash = "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==";
   };
-  "@types/node@26.1.2" = fetchurl {
-    url = "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz";
-    hash = "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==";
+  "@types/node@26.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz";
+    hash = "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==";
   };
   "@types/ws@8.18.1" = fetchurl {
     url = "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz";
@@ -162,9 +162,9 @@
     url = "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz";
     hash = "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==";
   };
-  "ws@8.21.2" = fetchurl {
-    url = "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz";
-    hash = "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==";
+  "ws@8.21.3" = fetchurl {
+    url = "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz";
+    hash = "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==";
   };
   "yaml@2.9.0" = fetchurl {
     url = "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz";

--- a/packages/agent/agent.lock
+++ b/packages/agent/agent.lock
@@ -9,7 +9,7 @@
       "name": "drishti-agent",
       "version": "0.1.0",
       "dependencies": {
-        "@effect/platform-node": "4.0.0-beta.103",
+        "@effect/platform-node": "4.0.0-beta.106",
         "drishti-common": "workspace:*",
         "effect": "4.0.0-beta.106",
         "ts-pattern": "^5.9.0",
@@ -25,11 +25,11 @@
   },
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.103",
-    "effect": "4.0.0-beta.103",
+    "@effect/platform-node": "4.0.0-beta.106",
+    "effect": "4.0.0-beta.106",
   },
   "packages": {
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.103", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.103", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103", "ioredis": "^5.7.0" } }, "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.106", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.106", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106", "ioredis": ">=5.7.0 <6.0.0" } }, "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.106", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106" } }, "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw=="],
 
@@ -65,13 +65,9 @@
 
     "drishti-common": ["drishti-common@workspace:packages/common"],
 
-    "effect": ["effect@4.0.0-beta.103", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pE8TxF4m2tQzVI+77dIlm3s+81TACV1AiX1JEkvY+zVuxgQQ8aGSkqXNJF6b/ST+coCSk5cUdbULpQ7sm4oHyw=="],
+    "effect": ["effect@4.0.0-beta.106", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "uuid": "^14.0.1" } }, "sha512-Sb1eNPYP8UdkE6xDOEEnrrOh/Vu2ocdRTPSeZTjZXukUrEYT2NtuQpbS90sEWaa7b6qLt8dfEYPpa6IVe5giHw=="],
 
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
-
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
-    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
 
@@ -85,8 +81,6 @@
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
-    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
-
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
@@ -97,8 +91,6 @@
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
-    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
-
     "ts-pattern": ["ts-pattern@5.9.0", "", {}, "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg=="],
 
     "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
@@ -108,7 +100,5 @@
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
-
-    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
   }
 }

--- a/packages/agent/agent.lock
+++ b/packages/agent/agent.lock
@@ -11,7 +11,7 @@
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.103",
         "drishti-common": "workspace:*",
-        "effect": "4.0.0-beta.103",
+        "effect": "4.0.0-beta.106",
         "ts-pattern": "^5.9.0",
       },
     },
@@ -19,7 +19,7 @@
       "name": "drishti-common",
       "version": "0.1.0",
       "dependencies": {
-        "effect": "4.0.0-beta.103",
+        "effect": "4.0.0-beta.106",
       },
     },
   },
@@ -31,7 +31,7 @@
   "packages": {
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.103", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.103", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103", "ioredis": "^5.7.0" } }, "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.103", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103" } }, "sha512-0aCZMBid5ifqmY55TkfCDLaGTIM8qu3bNFUW7qL9vh/7jFOkaIAMX2MA8muG4deqW17XWxawddWu4v0fK+UW3g=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.106", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106" } }, "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
@@ -49,7 +49,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -107,7 +107,7 @@
 
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
-    "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
   }

--- a/packages/agent/agent.lock
+++ b/packages/agent/agent.lock
@@ -9,7 +9,7 @@
       "name": "drishti-agent",
       "version": "0.1.0",
       "dependencies": {
-        "@effect/platform-node": "4.0.0-beta.106",
+        "@effect/platform-node": "4.0.0-beta.103",
         "drishti-common": "workspace:*",
         "effect": "4.0.0-beta.106",
         "ts-pattern": "^5.9.0",
@@ -25,11 +25,11 @@
   },
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.106",
+    "@effect/platform-node": "4.0.0-beta.103",
     "effect": "4.0.0-beta.106",
   },
   "packages": {
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.106", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.106", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106", "ioredis": ">=5.7.0 <6.0.0" } }, "sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.103", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.103", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103", "ioredis": "^5.7.0" } }, "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.106", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.106" } }, "sha512-TRTzLmhCwVM8G7dXz16lI3wE2vZFSs1jNs/+3WhnuOZgOUeJz9vzBK/KKlGRbbi0QbtEqmW4rAy1y9Fj4MZfsw=="],
 

--- a/packages/agent/agent.package.json
+++ b/packages/agent/agent.package.json
@@ -3,9 +3,10 @@
   "private": true,
   "type": "module",
   "workspaces": ["packages/agent", "packages/common"],
+  "//": "THE agent projection's manifest — the one `nix/packages/drishti-agent` copies to package.json, and (since it stopped being duplicated in a shell heredoc) the one `scripts/regenerate-agent-deps.sh` resolves agent.lock/agent.bun.nix against. `effect` is overridden because the agent runs kolu's hydrated @kolu/surface sources, which must see the SAME effect kolu built them against; @effect/platform-node stays at .103 deliberately — its peer range accepts effect ^4.0.0-beta.103 (which .106 satisfies), while .106 widens an optional `ioredis` peer that makes bun mint a peer-specialized cache key the nix-provided read-only bun cache cannot be written into.",
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
     "@effect/platform-node": "4.0.0-beta.103",
-    "effect": "4.0.0-beta.103"
+    "effect": "4.0.0-beta.106"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.103",
+    "@effect/platform-node": "4.0.0-beta.106",
     "drishti-common": "workspace:*",
     "effect": "4.0.0-beta.106",
     "ts-pattern": "^5.9.0"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.106",
+    "@effect/platform-node": "4.0.0-beta.103",
     "drishti-common": "workspace:*",
     "effect": "4.0.0-beta.106",
     "ts-pattern": "^5.9.0"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@effect/platform-node": "4.0.0-beta.103",
     "drishti-common": "workspace:*",
-    "effect": "4.0.0-beta.103",
+    "effect": "4.0.0-beta.106",
     "ts-pattern": "^5.9.0"
   },
   "exports": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "cleye": "^2.3.0",
     "dequal": "^2.0.3",
     "drishti-common": "workspace:*",
-    "effect": "4.0.0-beta.103",
+    "effect": "4.0.0-beta.106",
     "neverthrow": "^8.2.0",
     "quick-lru": "^7.3.0",
     "solid-js": "^1.9.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.25.0",
     "@babel/preset-typescript": "^7.25.0",
-    "@effect/platform-node": "4.0.0-beta.103",
+    "@effect/platform-node": "4.0.0-beta.106",
     "@solid-primitives/keyed": "^1.5.3",
     "@solid-primitives/page-visibility": "^2.1.5",
     "@solid-primitives/scheduled": "^1.5.3",

--- a/packages/app/src/client/daemonHostGlance.tsx
+++ b/packages/app/src/client/daemonHostGlance.tsx
@@ -10,6 +10,7 @@ import { Show } from "solid-js";
 import type { EntryState } from "@kolu/surface-map";
 import type { ConnectionInfo, ConnectionState } from "drishti-common/browser";
 import { STATE } from "./connectionColors";
+import { labelForKind } from "./entryStatusTone";
 import { FleetDaemonStatusChip } from "./DaemonStatusChip";
 import { HostDot } from "./HostDot";
 
@@ -24,7 +25,11 @@ const TAB_ACTIVE =
 export const TabHostGlance: Component<{
   host: string;
   active: boolean;
-  connectionKind: string;
+  /** The entry's arm, typed — NOT a widened `string`. A `string` here meant this prop
+   *  absorbed any change to the union, up to and including a rename, without the build
+   *  noticing; it also let the raw arm name land in a tooltip unreviewed. Typed, the
+   *  tooltip below goes through `labelForKind`, which is exhaustive over the union. */
+  connectionKind: EntryState["kind"];
   alertCount: number;
   onSelect: () => void;
   onClose: () => void;
@@ -40,7 +45,7 @@ export const TabHostGlance: Component<{
       data-testid={`tab-select-${props.host}`}
       class="flex items-center gap-2"
       onClick={() => props.onSelect()}
-      title={`${props.host} — ${props.connectionKind}`}
+      title={`${props.host} — ${labelForKind(props.connectionKind)}`}
     >
       <HostDot state={props.entryState} />
       <span class="font-semibold">{props.host}</span>

--- a/packages/app/src/client/entryStatusTone.test.ts
+++ b/packages/app/src/client/entryStatusTone.test.ts
@@ -1,7 +1,10 @@
 import type { EntryState } from "@kolu/surface-map";
 import { testMembershipId } from "@kolu/surface-map/testing";
+import { DEFAULT_CONNECTION } from "drishti-common/browser";
 import { describe, expect, it } from "bun:test";
 import {
+  connectionOf,
+  connectionPhaseOf,
   dotClass,
   failureRecord,
   statusLabel,
@@ -36,6 +39,15 @@ const FAILED: EntryState<{ reason: string }> = {
     { source: "remote", line: "Connection refused" },
   ],
 };
+// kolu#2129: the CLIENT-only arm the liveness floor mints when OUR link to the
+// publisher is dead. It replaces the floor's old lossy demotion to `warming`, which
+// made "the publisher says it is coming up" and "we cannot see the publisher" the same
+// value; `published` records the last word we actually heard.
+const UNOBSERVABLE: EntryState<{ reason: string }> = {
+  kind: "unobservable",
+  membershipId: testMembershipId(),
+  published: "connected",
+};
 const NOT_A_MEMBER: EntryState<{ reason: string }> = { kind: "not-a-member" };
 
 describe("entryStatusTone", () => {
@@ -57,11 +69,40 @@ describe("entryStatusTone", () => {
     expect(statusTextClass(WARMING)).toBe("text-amber-500");
   });
 
-  it("only warming pulses — connected and failed are steady", () => {
+  it("the two UNSETTLED arms pulse — connected and failed are steady", () => {
     expect(statusPending(WARMING)).toBe(true);
+    // Blind is unsettled too. A `kind === "warming"` test — which this used to be —
+    // would have frozen the pulse the moment the admin link dropped.
+    expect(statusPending(UNOBSERVABLE)).toBe(true);
     expect(statusPending(CONNECTED)).toBe(false);
     expect(statusPending(FAILED)).toBe(false);
     expect(statusPending(NOT_A_MEMBER)).toBe(false);
+  });
+
+  // kolu#2129 — the arm exists so a consumer can tell "it is coming up" from "we cannot
+  // see it". Every projection here has to keep them apart; the ones that must NOT is a
+  // shorter list (the pulse above, which is genuinely the same question).
+  it("says 'we cannot see it' rather than borrowing the word for 'coming up'", () => {
+    expect(dotClass(UNOBSERVABLE)).not.toBe(dotClass(WARMING));
+    expect(dotClass(UNOBSERVABLE)).not.toContain("emerald");
+    expect(dotClass(UNOBSERVABLE)).not.toContain("red");
+    expect(statusTextClass(UNOBSERVABLE)).not.toBe(statusTextClass(WARMING));
+    expect(statusLabel(UNOBSERVABLE)).not.toBe(statusLabel(WARMING));
+    // The tooltip names the last thing we heard — the most useful fact a stale tab has.
+    expect(statusTitle(UNOBSERVABLE)).toContain("connected");
+    // Not a failure: nothing here is a post-mortem.
+    expect(failureRecord(UNOBSERVABLE)).toBeNull();
+  });
+
+  // The DEFAULT_CONNECTION trap, reopened on the third side. A blind entry carries no
+  // `connection` payload, so `connectionOf(...) ?? DEFAULT_CONNECTION.phase` would have
+  // painted an amber "connecting…" word over a host we simply cannot hear.
+  it("paints a blind entry's word off its own arm, never the gate-closed default", () => {
+    expect(connectionOf(UNOBSERVABLE)).toBeUndefined();
+    expect(connectionPhaseOf(UNOBSERVABLE)).toBe("disconnected");
+    expect(connectionPhaseOf(UNOBSERVABLE)).not.toBe(
+      DEFAULT_CONNECTION.phase,
+    );
   });
 
   it("surfaces the failure reason in the title, never invented text", () => {
@@ -86,7 +127,7 @@ describe("entryStatusTone", () => {
   });
 
   it("covers every EntryState kind with a label", () => {
-    for (const s of [CONNECTED, WARMING, FAILED, NOT_A_MEMBER]) {
+    for (const s of [CONNECTED, WARMING, FAILED, UNOBSERVABLE, NOT_A_MEMBER]) {
       expect(statusLabel(s).length).toBeGreaterThan(0);
     }
   });

--- a/packages/app/src/client/entryStatusTone.ts
+++ b/packages/app/src/client/entryStatusTone.ts
@@ -19,7 +19,7 @@
  * data rides the ONE admin transport instead of its own socket).
  */
 
-import type { EntryState, FailureEvidence } from "@kolu/surface-map";
+import { type EntryState, type FailureEvidence, isSettling } from "@kolu/surface-map";
 import {
   type ConnectionInfo,
   type ConnectionState,
@@ -27,13 +27,15 @@ import {
 } from "drishti-common/browser";
 
 // A pure kind→tone lookup as a `Record` keyed on the full `EntryState["kind"]`
-// union — so adding a fourth displayed kind is a compile error here
-// (exhaustive by construction), not a silent fall-through a `switch` would
-// hide.
+// union — so adding a displayed kind is a compile error here (exhaustive by
+// construction), not a silent fall-through a `switch` would hide.
 const DOT_TONE: Record<EntryState["kind"], string> = {
   connected: "bg-emerald-500", // live — the map floors this on transport liveness
   warming: "bg-amber-500", // probing / provisioning / connecting — coming up
   failed: "bg-red-500", // provisioning or link failed
+  // We cannot see the publisher, so we say nothing about the host: grey, never
+  // the amber that means "coming up" and never the red that means "failed".
+  unobservable: "bg-gray-400 dark:bg-gray-600",
   "not-a-member": "bg-gray-400 dark:bg-gray-600", // unreached — we only render members
 };
 
@@ -42,30 +44,42 @@ export function dotClass(status: EntryState): string {
   return DOT_TONE[status.kind];
 }
 
+// The three lookups below were `switch (status.kind)` with a `default:`, which is
+// how a new arm gets silently painted as an existing one — `unobservable` would
+// have landed on amber "connecting…", the exact conflation kolu#2129 split apart.
+// They are `Record`s now, for the same reason `DOT_TONE` always was.
+
 /** The status-word text color class, following the same tone. */
+const TEXT_TONE: Record<EntryState["kind"], string> = {
+  connected: "text-emerald-500",
+  warming: "text-amber-500",
+  failed: "text-red-500",
+  unobservable: "text-gray-500",
+  "not-a-member": "text-amber-500",
+};
 export function statusTextClass(status: EntryState): string {
-  switch (status.kind) {
-    case "connected":
-      return "text-emerald-500";
-    case "failed":
-      return "text-red-500";
-    default:
-      return "text-amber-500";
-  }
+  return TEXT_TONE[status.kind];
 }
 
 /** A terse label — the fleet card / tab-chip tight fallback. */
+const LABEL: Record<EntryState["kind"], string> = {
+  connected: "connected",
+  warming: "connecting…",
+  failed: "failed",
+  // Not "connecting…": that word claims a campaign is under way, and this arm
+  // means we have lost the ability to see whether one is.
+  unobservable: "unknown",
+  "not-a-member": "not configured",
+};
 export function statusLabel(status: EntryState): string {
-  switch (status.kind) {
-    case "connected":
-      return "connected";
-    case "warming":
-      return "connecting…";
-    case "failed":
-      return "failed";
-    default:
-      return "not configured";
-  }
+  return labelForKind(status.kind);
+}
+/** The same label from a bare arm name — for the one caller (the tab chip's tooltip)
+ *  that holds the kind without the whole state. Exported rather than letting that
+ *  caller interpolate the raw arm into user-visible text, which is how `unobservable`
+ *  would have shown up in a tooltip as the word "unobservable". */
+export function labelForKind(kind: EntryState["kind"]): string {
+  return LABEL[kind];
 }
 
 /** A one-line human note for the dot's `title` — the failure reason when
@@ -78,7 +92,12 @@ export function statusTitle(status: EntryState<{ reason: string }>): string {
       return "connecting…";
     case "failed":
       return `failed: ${status.failure.reason}`;
-    default:
+    // The one arm whose tooltip is genuinely the most useful thing on screen: the
+    // host is probably fine and our admin link is not, so name the last word we
+    // actually heard rather than pretending to a current one.
+    case "unobservable":
+      return `status unknown — drishti can't reach this host's publisher (last seen: ${status.published})`;
+    case "not-a-member":
       return "not a member";
   }
 }
@@ -103,10 +122,16 @@ export function failureRecord(
     : null;
 }
 
-/** Whether this status should pulse (work in progress). A terminally-failed
- *  or fully-connected entry sits steady; only `warming` is "in flight". */
+/** Whether this status should pulse (unsettled). A terminally-failed or fully-connected
+ *  entry sits steady; `warming` and `unobservable` are both "not settled yet".
+ *
+ *  Delegates to the framework's `isSettling` rather than re-spelling `kind === "warming"`:
+ *  that test used to be right and stopped being right the moment the floor grew its own
+ *  arm — a dropped admin link would have frozen the pulse on a host that is still very
+ *  much in motion. This is the one call kolu#2129 added so the spin-only consumer pays
+ *  nothing for the split. */
 export function statusPending(status: EntryState): boolean {
-  return status.kind === "warming";
+  return isSettling(status);
 }
 
 /**
@@ -123,16 +148,23 @@ export function statusPending(status: EntryState): boolean {
  * source. A `not-a-member` entry (never reached) carries no connection.
  *
  * Neither does a FAILED one, since kolu#2022: a live word is work-in-flight and a
- * failed entry has none — its post-mortem is the `failureRecord` instead. So this
- * returns the payload only for the two LIVE arms, and callers that paint a word
- * must go through `connectionPhaseOf` rather than defaulting the absence.
+ * failed entry has none — its post-mortem is the `failureRecord` instead. Nor does
+ * an `unobservable` one (kolu#2129): our own link to the publisher is down, so the
+ * last word we heard is by definition frozen, and the arm carries no field for it.
+ * So this returns the payload only for the two LIVE arms, and callers that paint a
+ * word must go through `connectionPhaseOf` rather than defaulting the absence.
+ *
+ * Spelled as a POSITIVE test on the two arms that have the field, not a negative
+ * list of the ones that don't: a negative list silently admits every future arm
+ * into the "live" bucket, which is how the previous spelling would have read a
+ * blind entry as one carrying a current connection.
  */
 export function connectionOf<F>(
   status: EntryState<F, ConnectionInfo>,
 ): ConnectionInfo | undefined {
-  return status.kind === "not-a-member" || status.kind === "failed"
-    ? undefined
-    : status.connection;
+  return status.kind === "connected" || status.kind === "warming"
+    ? status.connection
+    : undefined;
 }
 
 /** The connection PHASE to PAINT beside the dot — the one word authority, total over
@@ -149,11 +181,16 @@ export function connectionOf<F>(
  *  would fire on every failed host.
  *
  *  A failed entry's word is `failed`, read off the coarse arm the dot reads. Only the
- *  live arms fall back to `DEFAULT_CONNECTION`'s phase, which is what that value means. */
+ *  live arms fall back to `DEFAULT_CONNECTION`'s phase, which is what that value means.
+ *
+ *  `unobservable` (kolu#2129) is the same trap wearing a different hat, and is caught the
+ *  same way: it has no payload either, so the default would have painted "connecting…"
+ *  over a host whose publisher we simply cannot hear. Its word is `disconnected` — a
+ *  statement about the link we lost, which is the only thing we actually know. */
 export function connectionPhaseOf(
   status: EntryState<{ reason: string }, ConnectionInfo>,
 ): ConnectionState {
-  return status.kind === "failed"
-    ? "failed"
-    : (connectionOf(status)?.phase ?? DEFAULT_CONNECTION.phase);
+  if (status.kind === "failed") return "failed";
+  if (status.kind === "unobservable") return "disconnected";
+  return connectionOf(status)?.phase ?? DEFAULT_CONNECTION.phase;
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,6 +20,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.103"
+    "effect": "4.0.0-beta.106"
   }
 }

--- a/scripts/regenerate-agent-deps.sh
+++ b/scripts/regenerate-agent-deps.sh
@@ -15,19 +15,14 @@ rm -f "$tmp/packages/agent/agent.lock" \
   "$tmp/packages/agent/agent.bunfig.toml" \
   "$tmp/packages/agent/agent.bun.nix"
 
-cat >"$tmp/package.json" <<'EOF'
-{
-  "name": "drishti-agent-workspace",
-  "private": true,
-  "type": "module",
-  "workspaces": ["packages/agent", "packages/common"],
-  "overrides": {
-    "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.103",
-    "effect": "4.0.0-beta.106"
-  }
-}
-EOF
+# The agent workspace's manifest is `packages/agent/agent.package.json` — the SAME file
+# `nix/packages/drishti-agent` copies to `package.json` at build time. Copy it; never
+# re-spell it. It used to be duplicated as a heredoc here, and the two copies drifted:
+# this one carried `effect: 4.0.0-beta.106` while the committed one still said `.103`, so
+# the regenerated lock claimed .106 and the BUILT agent installed .103 — which showed up
+# only as a boot crash (`Schema.TaggedError is not a function`), because nothing
+# typechecks the agent's runtime closure. One manifest, one place to bump.
+cp packages/agent/agent.package.json "$tmp/package.json"
 cat >"$tmp/bunfig.toml" <<'EOF'
 [install]
 linker = "hoisted"

--- a/scripts/regenerate-agent-deps.sh
+++ b/scripts/regenerate-agent-deps.sh
@@ -23,8 +23,8 @@ cat >"$tmp/package.json" <<'EOF'
   "workspaces": ["packages/agent", "packages/common"],
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.103",
-    "effect": "4.0.0-beta.103"
+    "@effect/platform-node": "4.0.0-beta.106",
+    "effect": "4.0.0-beta.106"
   }
 }
 EOF

--- a/scripts/regenerate-agent-deps.sh
+++ b/scripts/regenerate-agent-deps.sh
@@ -23,7 +23,7 @@ cat >"$tmp/package.json" <<'EOF'
   "workspaces": ["packages/agent", "packages/common"],
   "overrides": {
     "@babel/helper-module-imports": "^7.29.7",
-    "@effect/platform-node": "4.0.0-beta.106",
+    "@effect/platform-node": "4.0.0-beta.103",
     "effect": "4.0.0-beta.106"
   }
 }


### PR DESCRIPTION
Pair PR for [juspay/kolu#2129](https://github.com/juspay/kolu/pull/2129), which changes `@kolu/surface-map`'s client-facing `EntryState`.

## What moved upstream

kolu's liveness floor has always refused to render a stale `connected` as green once our link to the publisher dies (#1568). It did that by demoting the entry to `warming` — and that demotion was **lossy**. It made two facts with opposite consequences into one value:

- "the publisher says this host is coming up" — a real, self-healing campaign, worth putting a clock on;
- "we cannot see the publisher at all" — we know nothing, and may claim nothing.

A consumer that merely spins is fine either way. One that *times* the entry can certify a healthy thing dead, which is exactly what kolu#2129 was. Upstream now floors both live arms onto their own arm instead:

```ts
type UnobservableEntry = {
  kind: "unobservable";
  membershipId: MembershipId;
  published: "warming" | "connected";   // the last word we actually heard
};
type ObservedEntryStatus<F, C> = EntryStatus<F, C> | UnobservableEntry;
type EntryState<F, C> = ObservedEntryStatus<F, C> | { kind: "not-a-member" };
```

The published (wire) `EntryStatus` is **unchanged** — the arm is client-only, has no wire schema, and cannot be republished. It carries neither `clockOffset` nor `connection`, so "nothing green, no frozen live word" is a property of its shape. `failed` still passes the floor untouched.

## What that forced here, and what it did not

Exactly **one** site in drishti failed to compile: `DOT_TONE`, the single `Record<EntryState["kind"], …>` in the seam.

That is the finding rather than the fix. Eleven further sites would have compiled clean and rendered a blind host as an amber **connecting…** campaign, labelled **not configured**, with no pulse, no failure record, no metrics body and no alert pip — every one of them a claim we are in no position to make. So this PR absorbs the arm *and* closes the routes by which it could have arrived unnoticed.

| Site | Before | After |
| --- | --- | --- |
| `DOT_TONE` | compile error (working as intended) | grey — never amber ("coming up"), never red ("failed") |
| `statusTextClass` | `switch` + `default:` → amber | `Record`, exhaustive |
| `statusLabel` | `switch` + `default:` → "not configured" | `Record`, exhaustive; blind reads **unknown** |
| `statusTitle` | `default:` → "not a member" | names the last published word |
| `connectionOf` | negative list (`!== "not-a-member" && !== "failed"`) | positive test on the two arms that *have* a payload |
| `connectionPhaseOf` | `?? DEFAULT_CONNECTION.phase` → "connecting…" | `disconnected` — the one thing we do know |
| `statusPending` | `kind === "warming"` | the framework's new `isSettling`, so the pulse still covers both unsettled arms |
| `TabHostGlance.connectionKind` | typed `string` | `EntryState["kind"]`, tooltip via the exhaustive `labelForKind` |

`connectionPhaseOf` is worth calling out: that is the `?? DEFAULT_CONNECTION` trap opening for the **third** time (drishti#102, then kolu#2022's failed arm, now this one). Each time, an arm without a `connection` payload defaulted into the gate-closed placeholder whose phase happens to be `connecting`.

## The effect bump rides along

The new kolu pin brings kolu's own `osfacts` pin forward, and that `osfacts-client` needs `Schema.TaggedError` — 62 typecheck errors on `effect@4.0.0-beta.103`. So this also takes kolu's move to `4.0.0-beta.106` ([juspay/kolu#2126](https://github.com/juspay/kolu/pull/2126)), with `bun.nix` and the agent-scoped lock regenerated.

## Local proofs

- `bun run typecheck` — 0 errors (62 before the effect bump, all in `osfacts-client`)
- `bun test --conditions=browser` — 382 pass, 0 fail
- `nixpkgs-fmt --check .` clean

CI green on this pin is the no-breakage proof. The pin will be re-bumped to kolu#2129's final HEAD before either PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## The agent projection had two manifests, and CI is the only thing that could tell

Typecheck was clean and every unit test passed while the **built agent could not boot** — `TypeError: Schema.TaggedError is not a function`, kolu's `@kolu/surface` sources running against `effect@4.0.0-beta.103`. Three commits to find why, and the answer is worth writing down because it is a structural trap, not a version typo.

The agent's dependency closure is deliberately **not** the root `bun.lock` (U5.1's positive projection). It is resolved against a workspace manifest — and that manifest existed **twice**:

| copy | consumed by | said |
|---|---|---|
| `packages/agent/agent.package.json` | `nix/packages/drishti-agent` → `cp … package.json` at build time | `effect: 4.0.0-beta.103` |
| a heredoc inside `scripts/regenerate-agent-deps.sh` | the lock/`agent.bun.nix` regeneration | whatever you last edited |

Bumping the script moved `agent.lock` to `.106`; the build kept installing from the committed `.103`. **A lockfile that describes a workspace the build does not use is not a lockfile** — and nothing typechecks the agent's *runtime* closure, so the first honest signal is `ci::agent-boots`, which is exactly the node that caught it.

The fix is to delete the duplicate: the script now **copies** `agent.package.json`. One manifest, one place to bump.

Two smaller findings fell out on the way:

- `@effect/platform-node` stays at **.103 deliberately**. Its peer range accepts `effect ^4.0.0-beta.103`, which `.106` satisfies, so the bump was never needed — and `.106` widens an *optional* `ioredis` peer, which makes bun mint a peer-specialized cache key (`@effect/platform-node@4.0.0-<hash>@@@1`) that the nix-provided **read-only** bun cache cannot be written into: `EACCES … rename()`, on both platforms, on a clean box.
- One earlier red run was **box contamination**, not source — a previous run had left root-owned files under `node_modules/@kolu/surface-map`, so the hydrate script's `rm` failed and typecheck reported a missing `@kolu/surface-map/evidence`. It reproduced nowhere else and is gone on a fresh lease.

## CI

Green on **both platforms** at `1de6910`, pinned to kolu#2129's post-merge HEAD `48b2c6a77`:

```
24 ok · 0 failed · 0 errored · 0 skipped · 0 cancelled — OK
  ✔ ci::agent-boots@aarch64-darwin      ✔ ci::agent-boots@x86_64-linux
  ✔ ci::typecheck@…  ✔ ci::test-daemon@x86_64-linux  ✔ ci::nix@…  ✔ ci::home-manager@…
```


---

## Re-pinned to kolu **master**, and re-proven there

juspay/kolu#2129 was **squash-merged**, so the branch commit this was originally pinned to (`48b2c6a77`) is not an ancestor of kolu master and its branch is gone. Master carries the squash `4d8a668f65a2071d7e0d9e92e0187c30a557f507` instead. A green CI attesting to a SHA master does not contain is exactly the stale pin `.claude/rules/surface.md` exists to prevent, so the pin now points at the merged commit.

The re-pin is provably content-neutral: npins resolves **the same NAR hash** (`sha256-9Gf7/DQCH6iSHYkrThfiqWiRp7QtPmwoWcZkDz0y6zk=`) for both SHAs — the squash's tree is byte-identical to the branch head it replaced. Only where the pin *points* changed.

`origin/master` re-merged at the repin (already up to date); GitHub reports the branch **MERGEABLE**.

### CI at the re-pinned HEAD `9e37e45` — green on both platforms

```
24 ok · 0 failed · 0 errored · 0 skipped · 0 cancelled — OK
  ✔ ci::agent-boots@aarch64-darwin       ✔ ci::agent-boots@x86_64-linux
  ✔ ci::typecheck@both   ✔ ci::nix@both   ✔ ci::flake-check@both
  ✔ ci::drv-stability@both   ✔ ci::home-manager@both
  ✔ ci::test-daemon@x86_64-linux (skips on darwin by design)
```
