### PR TITLE
Pair with juspay/kolu#2133: the framework owns the pid handshake, and the store merge stops guessing keys

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-typed-lifecycle",
       "submodules": false,
-      "revision": "eed68c77d31c361e1442362569ed31483dab6698",
-      "url": "https://github.com/juspay/kolu/archive/eed68c77d31c361e1442362569ed31483dab6698.tar.gz",
-      "hash": "sha256-aDoOsOpGGQ8dx4TS67u/zV3IgnDJ7L2p5yGLO5eTf0A="
+      "revision": "6922c1be8f5cdb895fad0602376ef96c528494f0",
+      "url": "https://github.com/juspay/kolu/archive/6922c1be8f5cdb895fad0602376ef96c528494f0.tar.gz",
+      "hash": "sha256-dNx9lkH9IAmHzD7vWsTpYoq6yawZkeT57drwpTnrbRQ="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-typed-lifecycle",
       "submodules": false,
-      "revision": "4d8a668f65a2071d7e0d9e92e0187c30a557f507",
-      "url": "https://github.com/juspay/kolu/archive/4d8a668f65a2071d7e0d9e92e0187c30a557f507.tar.gz",
-      "hash": "sha256-9Gf7/DQCH6iSHYkrThfiqWiRp7QtPmwoWcZkDz0y6zk="
+      "revision": "eed68c77d31c361e1442362569ed31483dab6698",
+      "url": "https://github.com/juspay/kolu/archive/eed68c77d31c361e1442362569ed31483dab6698.tar.gz",
+      "hash": "sha256-aDoOsOpGGQ8dx4TS67u/zV3IgnDJ7L2p5yGLO5eTf0A="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-typed-lifecycle",
       "submodules": false,
-      "revision": "6922c1be8f5cdb895fad0602376ef96c528494f0",
-      "url": "https://github.com/juspay/kolu/archive/6922c1be8f5cdb895fad0602376ef96c528494f0.tar.gz",
-      "hash": "sha256-dNx9lkH9IAmHzD7vWsTpYoq6yawZkeT57drwpTnrbRQ="
+      "revision": "5a47d7f94f5ccfa079ac3670761474bddbb70ce1",
+      "url": "https://github.com/juspay/kolu/archive/5a47d7f94f5ccfa079ac3670761474bddbb70ce1.tar.gz",
+      "hash": "sha256-kKhlIFpaBo3Y30Jltfw4mDCS1bLqjmLm6QweRHWRdA8="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -16,9 +16,10 @@
 
 import type { EntryState } from "@kolu/surface-map";
 import { unenrolledStreamCall } from "@kolu/surface/client";
+import { probeSurfaceIdentity } from "@kolu/surface/identity";
 import { createSubscription, surfaceClientsHealth } from "@kolu/surface/solid";
 import { shellCommit } from "@kolu/surface-app/lifecycle";
-import { SurfaceAppProvider, surfaceAppProbe } from "@kolu/surface-app/solid";
+import { SurfaceAppProvider } from "@kolu/surface-app/solid";
 import { Meta, Title } from "@solidjs/meta";
 import {
   type Accessor,
@@ -199,7 +200,6 @@ import {
   hostRpc,
   hostStreams,
   notify,
-  rememberServerProcessId,
   runCall,
   surfaceAppClient,
 } from "./wire";
@@ -440,36 +440,34 @@ function projectHistory(
 //
 //  - controlPlane = the surface-app client over the admin transport: surface-app
 //    rides drishti's one global, always-open connection as a SIBLING surface
-//    (kolu#1197/#1201). It carries the `buildInfo` cell + the `identity.info`
-//    probe; the admin surface (host set) is its sibling on the same wire.
+//    (kolu#1197/#1201). It carries the `buildInfo` cell; the admin surface (host
+//    set) is its sibling on the same wire.
 //  - clientCommit = the commit this client was built at, read off the no-store
 //    HTML shell via `shellCommit()` (the global `surfaceApp()`/`buildSurfaceClient`
 //    injects as `window.__SURFACE_APP_COMMIT__`, NOT a bundler define inside a
 //    content-hashed asset — kolu#1319). The same value `surfaceAppServer()` reads
 //    server-side, so skew is a real comparison.
-//  - ws + probe = the admin socket's open/close paired with the shared
-//    `surfaceAppProbe` helper (the scoped `surface.identity.info` probe), so a
-//    reconnect to a *restarted* parent reads as a restart, not a transient drop.
-//  - onProcessId = the turnkey `{ ws, probe }` source now publishes each observed
-//    server `processId` (kolu#1231); we stash it in the `wire.ts` mutable the
-//    admin/per-host URL thunks echo as the `pid` handshake param. The provider
-//    also retires the admin socket itself on a stale-restart, so drishti no
-//    longer hand-rolls either the probe-wrapper echo or the admin retirement —
-//    the per-host sockets, which have no provider lifecycle, keep their own
-//    close-listener retirement in `wire.ts`.
+//  - ws + probe = the admin socket's open/close paired with the FRAMEWORK-RESERVED
+//    `system/identity` round-trip (`probeSurfaceIdentity`, scoped by the
+//    `surfaceApp` sibling key), so a reconnect to a *restarted* parent reads as a
+//    restart, not a transient drop. surface-app declares no identity member of its
+//    own any more — every surface answers this one, with the same per-process id
+//    the parent's stale-tab gate compares against (juspay/kolu#2133).
+//  - there is no `onProcessId`. The `pid` echo was drishti's to feed from here and
+//    is now `connectSurfaces`' own (it probes the same reserved member on every
+//    open), so the handshake holds with no app step to omit.
 export default function App() {
   return (
     <SurfaceAppProvider
       controlPlane={surfaceAppClient()}
       clientCommit={shellCommit()}
       wire={adminSocket()}
-      probe={() => surfaceAppProbe(surfaceAppClient())}
+      probe={() => probeSurfaceIdentity(surfaceAppClient().rpc)}
       // `wire.ts`'s `connectSurfaces` already wires the half-open watchdog over
       // this admin wire (minting the branded `{ live }` the clients require), so
       // the lifecycle opts ITS watchdog out — one watchdog on the wire, not two.
       // (The lifecycle mints no brand, so this is ownership coordination only.)
       heartbeat={false}
-      onProcessId={rememberServerProcessId}
       // No `restartCloseCode`: the stale-close vocabulary lives in the LINK now
       // (surface-app hands it `isStaleProcessClose`), which halts its own retry
       // schedule and reports the terminal `WireStatus` `"retired"`. There is no

--- a/packages/app/src/client/wire.ts
+++ b/packages/app/src/client/wire.ts
@@ -34,7 +34,6 @@
 
 import { Effect } from "effect";
 import type { WatchableWire } from "@kolu/surface/link";
-import { createProcessIdEcho } from "@kolu/surface-app/connect";
 import { createNotify } from "@kolu/surface-app/notify";
 import { connectSurfaces } from "@kolu/surface-app/solid";
 import { connectSurfaceMap } from "@kolu/surface-map/client";
@@ -43,15 +42,14 @@ import { adminSurfaces } from "../common/admin-surface";
 import { ADMIN_HOST_SENTINEL } from "../common/host";
 import { hostSurfaceMap } from "../common/hostMap";
 
-// ONE `pid` echo for the ONE socket. The parent mints a fresh `processId`
-// per boot; the echo threads the last-known one back as the `pid` query
-// param on every (re)connect so the parent recognizes a stale tab after a
-// restart and rejects it at the handshake. `App.tsx` feeds this via the
-// provider's `onProcessId` callback (the turnkey `{ ws, probe }` source
-// publishes each observed id); it's null until the first probe, so the
-// first connect omits the param.
-const echo = createProcessIdEcho();
-export const rememberServerProcessId = echo.remember;
+// There is no `pid` echo to declare or feed here any more. `connectSurfaces`
+// owns the whole stale-tab handshake now: it probes the framework-reserved
+// `system/identity` member on every wire OPEN and threads the parent's
+// `processId` back as the `pid` query param on the next (re)dial, so the parent
+// recognizes a stale tab after a restart and rejects it at the handshake. drishti
+// used to declare the echo here and feed it from `<SurfaceAppProvider onProcessId>`
+// — an app-side step which, omitted, leaves the parent's gate unable to reject
+// anything at all (juspay/kolu#2133).
 
 // The ONE WS URL — WITHOUT the `pid` (the echo appends it). `host=` is kept
 // as the routing sentinel `main.ts`'s upgrade handler still checks, though
@@ -77,7 +75,7 @@ function wsBase(): string {
 
 // The admin transport multiplexes TWO sibling surfaces (kolu#1197/#1201):
 // drishti's own `admin` surface (host-lifecycle procedures) and
-// surface-app's complete surface (`buildInfo` + the `identity.info` probe).
+// surface-app's complete surface (the `buildInfo` cell).
 // `connectSurfaces` splits the one link into a per-key client bundle and
 // folds them into ONE `health()` fact (`live` AND-reduced across siblings
 // off the one socket). It ALWAYS wires the half-open watchdog (it mints the
@@ -85,8 +83,8 @@ function wsBase(): string {
 // requires). The `<SurfaceAppProvider>` lifecycle over the SAME socket
 // (`App.tsx`) opts ITS own watchdog out (`heartbeat={false}`) so the socket
 // isn't double-watched; the lifecycle still retires the socket on a
-// stale-restart, so this opts out of self-retire (`retireOnStaleClose:
-// false`).
+// stale-restart. The `retired` handler below is this seam's own required
+// answer to the terminal state.
 /** The ONE drishti client-error interpreter (SR11, fork-A) — the single place drishti's
  *  app-owned {@link ClientErrorPolicy} arm is rendered. drishti has no Toaster, so it
  *  LOGS: `console.error(label, err)` where `label` is the member's declared message. It
@@ -105,7 +103,6 @@ export function interpretClientError(p: ClientErrorPolicy, err: Error): void {
 const conn = await connectSurfaces({
   surfaces: adminSurfaces,
   url: wsBase,
-  echo,
   // The host map's tags ride THIS wire but are not reached through
   // `clients.<key>` — they are dialled over `conn.transport` below. Effect
   // RPC's flat client resolves a call's payload/success SCHEMAS by looking its
@@ -119,6 +116,16 @@ const conn = await connectSurfaces({
   // seam symmetric with `connectSurfaceMap` below (and honest the day a root member ever
   // declares a policy). See design §A: the app spells ONE interpreter.
   onClientError: (p, e) => interpretClientError(p as ClientErrorPolicy, e),
+  // REQUIRED, and deliberately so — this is the one state a wire never recovers
+  // from: the parent retired this tab, the link has stopped dialling for good, and
+  // every call on it now fails. The user-facing recovery already rides the same
+  // wire (`<SurfaceAppProvider>`'s lifecycle reads the terminal status as a
+  // definitive `restarted`, and `<TransportOverlay>` offers the Reload), so what
+  // this adds is the RECORD, in drishti's idiom — it has no Toaster; it logs.
+  retired: () =>
+    console.error(
+      "the parent retired this tab — it was bound to a process that no longer exists; reload to recover",
+    ),
 });
 
 /** The watchable wire under every client here — status observability plus the
@@ -225,11 +232,11 @@ export function adminRpc() {
 }
 
 /** The surface-app client over the admin transport — the global
- *  build-identity `buildInfo` cell + the `identity.info` restart probe.
- *  Handed to `<SurfaceAppProvider controlPlane=...>` and
- *  `surfaceAppProbe(...)`. The `surfaceApp` key is consumed by the scope,
- *  so the probe's wire path is `/surface/surfaceApp/identity/info` (the key
- *  does NOT reappear). */
+ *  build-identity `buildInfo` cell, and (through its tag-scoped face) the
+ *  FRAMEWORK-RESERVED `system/identity` restart probe. Handed to
+ *  `<SurfaceAppProvider controlPlane=...>` and `probeSurfaceIdentity(...)`. The
+ *  `surfaceApp` key is consumed by the scope, so the probe's wire path is
+ *  `/surface/surfaceApp/system/identity` (the key does NOT reappear). */
 export function surfaceAppClient() {
   return conn.clients.surfaceApp;
 }

--- a/packages/app/src/common/admin-surface.ts
+++ b/packages/app/src/common/admin-surface.ts
@@ -24,7 +24,7 @@
  *
  * The admin connection is also drishti's CONTROL PLANE: the one
  * always-open, global connection. surface-app's build-identity surface
- * (the `buildInfo` cell + the `identity.info` restart probe) rides this
+ * (the `buildInfo` cell) rides this
  * same transport — but as a SIBLING surface, NOT merged into the admin
  * surface (kolu#1197/#1201). `composeSurfaceContracts` multiplexes the
  * two: drishti's own `admin` surface under the `admin` key, surface-app's

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -7,8 +7,9 @@
  *   - `admin`      — drishti's own host-lifecycle PROCEDURES
  *                     (add/remove/reconnect/recheck). No collection of its
  *                     own any more (see `admin-surface.ts`'s docstring).
- *   - `surfaceApp` — the global build-identity `buildInfo` cell + the
- *                     `identity.info` restart probe (kolu#1197/#1201).
+ *   - `surfaceApp` — the global build-identity `buildInfo`
+ *                     cell (kolu#1197/#1201); the restart axis is the
+ *                     framework-reserved `system/identity` member.
  *   - `hosts`      — the `@kolu/surface-map` HOST MAP (`hostMap.ts`):
  *                     `serveHostMap` folds the warm session pool's
  *                     membership + each session's connection state into the
@@ -65,7 +66,7 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // Two SIBLING surfaces over the one admin transport (kolu#1197/#1201):
   // drishti's OWN `admin` surface (the host-lifecycle procedures) under the
   // `admin` key, and surface-app's COMPLETE surface (the build-identity
-  // `buildInfo` cell + the `identity.info` restart probe) under the
+  // `buildInfo` cell) under the
   // `surfaceApp` key. They are NOT merged — `implementSurfaces` keys each
   // surface, serving them at `/surface/admin/…` and `/surface/surfaceApp/…`
   // with a key-namespaced channel per surface.
@@ -74,7 +75,8 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // the build-identity cell store (commit resolved once: SURFACE_APP_COMMIT env
   // → git → "dev"; the same commit is baked into the client bundle via
   // build.ts's Bun.build define, so client and server stamp one value and skew
-  // is detectable across deploys) AND the `identity.info` probe impl (one
+  // is detectable across deploys). The restart axis is NOT here: it is the
+  // framework-reserved `system/identity` member every surface answers (one
   // processId per process — restart the parent → new id → the control-plane
   // status flips to "restarted"). The buildInfo cell's async republish is fired
   // by the surface runtime — no app-visible connect.
@@ -83,10 +85,11 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // here we add only the server-only per-surface deps, keyed the same way.
   // Per-key deps are typed against each surface's own spec now (kolu#1201), so
   // the concretely-typed admin / surface-app deps bind directly — no cast.
-  // `surfaceAppServer()` mints this process's `processId` (no override passed),
-  // and now EXPOSES it — so the stale-tab handshake gate in `main.ts` compares a
-  // reconnecting tab's `pid` against the SAME id `identity.info` reports, rather
-  // than minting a second one that would never match.
+  // `surfaceAppServer()` no longer mints or exposes a `processId`, and the gate in
+  // `main.ts` no longer takes one: a process has ONE identity —
+  // `surfaceProcessId()` (`@kolu/surface/identity`) — which the framework-reserved
+  // `system/identity` member answers with and which the gate compares against, so
+  // there is nothing left for a consumer to keep in step (juspay/kolu#2133).
   const surfaceApp = surfaceAppServer();
   const surfaces = implementSurfaces(
     adminSurfaces,
@@ -297,13 +300,13 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
     );
   }
 
-  // `processId` is this parent process's live id — `main.ts`'s WS-upgrade gate
-  // feeds it to `rejectStaleProcess` so a tab that reconnects after a parent
-  // restart is rejected at the handshake.
+  // No `processId` is handed out any more. `main.ts`'s WS-upgrade gate reads this
+  // process's own `surfaceProcessId()` — the same value the framework-reserved
+  // `system/identity` member answers with, and so the same one a reconnecting tab
+  // echoes back — leaving nothing to thread from here (juspay/kolu#2133).
   return {
     group,
     handlers,
-    processId: surfaceApp.processId,
     /** Tear down the map's own machinery — `serveHostMap.dispose()` tears down
      *  `serveSurfaceMap`'s membership republish sub PLUS the adapter's fused
      *  per-member `onState` subs and cached links in one call. Called from

--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -385,12 +385,14 @@ async function main(): Promise<void> {
         // closes with STALE_PROCESS_CLOSE_CODE before the RPC server attaches —
         // so its live subscriptions never replay against a process that never had
         // them. An absent `pid` (the first-ever connect) always passes.
-        // `admin.processId` is the live id the `identity.info` probe reports, so
-        // the gate and the probe single-source. The installed `error` listener
+        // It takes no live id: it compares the claim against this process's own
+        // `surfaceProcessId()`, which is exactly what the reserved `system/identity`
+        // member answers and so exactly what a tab echoes back — the two sides
+        // cannot be pointed at different strings. The installed `error` listener
         // persists for the connection lifetime — so the per-branch handlers below
         // no longer re-install one.
         if (
-          gateStaleSocket(ws, url, admin.processId, {
+          gateStaleSocket(ws, url, {
             onError: (err) =>
               log(`browser ws error (host=${host}): ${err.message}`),
             onReject: () =>


### PR DESCRIPTION
Pairs with **[juspay/kolu#2133](https://github.com/juspay/kolu/pull/2133)**, pinned
to its final HEAD (`5a47d7f` — the commit kolu CI settled green on for both
platforms). Two changes land in that PR; both touch drishti.

## The stale-tab handshake stops being drishti's to wire

`@kolu/surface`'s reserved `system/identity` member carries a `processId` now
(`surfaceProcessId()`, one per process), and `createSurfaceSocket` probes it on
every wire open and feeds the `pid` echo itself. So the three app-side steps
drishti was carrying are gone:

- `createProcessIdEcho()` + `rememberServerProcessId` in `client/wire.ts`, and the
  `<SurfaceAppProvider onProcessId>` that fed it. That feed was a single line, and
  a single line is exactly what a third consumer dropped
  ([juspay/olai#61](https://github.com/juspay/olai/pull/61)) — leaving reconnects
  with no `pid`, the server's gate unable to reject anything, and the wire's
  `retired` state unreachable.
- `admin.processId` off `buildAdminRouter`'s return, and the argument
  `gateStaleSocket(ws, url, admin.processId, …)` took. The gate reads this
  process's own `surfaceProcessId()` — the same value the reserved member answers
  with, so the two sides cannot be pointed at different strings.
- `surfaceAppProbe(...)` → `probeSurfaceIdentity(surfaceAppClient().rpc)`.
  surface-app declares no identity member of its own any more; the framework's
  reserved one answers for every surface.

What drishti gains is one **required** option: `retired`, on the `connectSurfaces`
call. It has no default and cannot be omitted — that is the point of it. drishti's
user-facing recovery already rides the same wire (`<SurfaceAppProvider>`'s
lifecycle reads the terminal status as a definitive `restarted`, and
`<TransportOverlay>` offers the Reload), so the handler here is the record, in
drishti's own idiom: it has no Toaster, so it logs.

## The store merge no longer infers an element key

Every merge in `@kolu/surface/solid` passes `reconcile(..., { key: null })`
instead of inheriting Solid's `key: "id"` default. No drishti call site changes;
the behaviour change is that a bound store replaces array elements rather than
recycling the previous row objects into them, so a row object never comes to hold
a record it never described. Worth knowing when reading drishti's host cards: rows
delivered by `.use()` are fresh objects per frame now, so anything keyed on row
identity is keyed on the frame, not on a recycled carrier.

## Verification

- `bun run typecheck` — clean across `common`, `agent`, `app`.
- `KOLU_DAEMON_TESTS=1 bun test --conditions=browser --preload ./packages/app/src/client/test-setup.ts` — **391 pass, 0 fail** at the pinned SHA (re-run after the repin to kolu's final HEAD, per the pair-gate rule that a green pinned to a pre-gauntlet SHA is stale).

Branch cut from current `origin/master` (`323fbb0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
