### PR TITLE
The websocket frame cap is the framework's number, not ours

### DIFF
--- a/packages/app/src/server/main.ts
+++ b/packages/app/src/server/main.ts
@@ -58,6 +58,7 @@ import {
 import { loadHosts, resolveHostsFile, saveHosts } from "./hostsStore";
 import { installStderrTimestamps, makeLogger } from "./log";
 import { startWakeMonitor } from "./wakeMonitor";
+import { WS_MAX_PAYLOAD_BYTES } from "./wsFrameCap";
 
 // Stamp every stderr line (drishti's, kolu's, and the forwarded remote
 // agent's) with a timestamp before anything logs — the connection
@@ -331,9 +332,12 @@ async function main(): Promise<void> {
   // go. The `host` query param is kept as the ONE remaining routing
   // sentinel (`ADMIN_HOST_SENTINEL`) so the upgrade handler still rejects
   // any other value rather than silently accepting an unrouted socket.
+  // maxPayload is the FRAMEWORK's frame cap, sourced (`wsFrameCap.ts`) rather
+  // than restated: a smaller number here would refuse frames `@kolu/surface`
+  // is willing to carry, one layer below the one that can classify them.
   const wss = new WebSocketServer({
     noServer: true,
-    maxPayload: 8 * 1024 * 1024,
+    maxPayload: WS_MAX_PAYLOAD_BYTES,
   });
 
   // Liveness heartbeat (@kolu/surface-app): ping accepted sockets and terminate

--- a/packages/app/src/server/wsFrameCap.test.ts
+++ b/packages/app/src/server/wsFrameCap.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The frame cap, at the layer that is allowed to refuse.
+ *
+ * The bug: `main.ts` capped websocket messages at 8 MiB while
+ * `@kolu/surface`'s `frameLimit` classifies oversize at 16 MiB. Everything in
+ * between — a large process census on a busy host is the realistic one — was
+ * refused by the raw `ws` layer, which has no classifier and no vocabulary for
+ * it. Since every configured host's telemetry is key-folded onto ONE socket,
+ * that refusal kills the whole fleet view instead of running the framework's
+ * handled oversize path.
+ *
+ * These are tests of the NUMBER, on purpose. Bun's built-in `ws` — what this
+ * server actually runs on — ignores `maxPayload` entirely and enforces 16 MiB
+ * of its own, so the disagreement between the two layers was invisible from
+ * the outside here and a behavioural assertion would have passed against the
+ * bug. What was wrong was the configuration, so that is what is pinned: this
+ * fails against `8 * 1024 * 1024` and against any future edit that lets the
+ * layers drift apart again.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  exceedsFrameLimit,
+  RPC_MAX_FRAME_BYTES,
+} from "@kolu/surface/frame-limit";
+
+import { WS_MAX_PAYLOAD_BYTES } from "./wsFrameCap";
+
+/** A frame the framework carries and the old cap did not: bigger than the
+ *  8 MiB `main.ts` used to pass to `ws`, smaller than the 16 MiB the framework
+ *  refuses at. */
+const DISPUTED_BYTES = 9 * 1024 * 1024;
+
+/** What `main.ts` said before this fix. Named so the fence reads as the
+ *  regression it is rather than as an arbitrary inequality. */
+const OLD_CAP_BYTES = 8 * 1024 * 1024;
+
+describe("the websocket frame cap", () => {
+  it("does not refuse a frame the framework would carry", () => {
+    // The framework's own predicate, not a re-statement of its number: this is
+    // the half of the claim that says 9 MiB is the framework's business.
+    expect(exceedsFrameLimit(DISPUTED_BYTES)).toBe(false);
+    // ...and this is the half that was false. 9 MiB > the old 8 MiB cap.
+    expect(DISPUTED_BYTES).toBeGreaterThan(OLD_CAP_BYTES);
+    expect(DISPUTED_BYTES).toBeLessThanOrEqual(WS_MAX_PAYLOAD_BYTES);
+  });
+
+  it("is never the layer that says no first", () => {
+    // Generalised, so a re-pin of either number cannot re-open the gap.
+    expect(WS_MAX_PAYLOAD_BYTES).toBeGreaterThanOrEqual(RPC_MAX_FRAME_BYTES);
+    // And the delimiter, as the property rather than as the expression: the
+    // BIGGEST frame the decoder accepts is `RPC_MAX_FRAME_BYTES` of content
+    // arriving in a message that also carries its newline, and that message
+    // has to fit. A cap of exactly the framework's number passes the line
+    // above and fails this one.
+    expect(RPC_MAX_FRAME_BYTES + 1).toBeLessThanOrEqual(WS_MAX_PAYLOAD_BYTES);
+  });
+
+  it("is what main.ts hands the WebSocketServer", () => {
+    // The constant is only worth pinning if it is the one on the wire, and
+    // `main.ts` self-executes on import (it boots the server), so the call
+    // site is read rather than exercised. Comments are stripped first, per
+    // this repo's source-scan idiom: the prose explaining the cap naturally
+    // quotes it, and a raw scan would pass on the explanation alone.
+    // Line comments go FIRST: one of main.ts's own says `/assets/*`, and
+    // stripping block comments ahead of it would read that as an opening
+    // delimiter and swallow everything up to the next `*/` — the call site
+    // included, which is how this assertion would pass on a file that no
+    // longer contains it.
+    const main = readFileSync(join(import.meta.dir, "main.ts"), "utf-8")
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(main).toContain("maxPayload: WS_MAX_PAYLOAD_BYTES");
+  });
+});

--- a/packages/app/src/server/wsFrameCap.ts
+++ b/packages/app/src/server/wsFrameCap.ts
@@ -1,0 +1,49 @@
+/**
+ * The largest websocket message the parent server will take — the framework's
+ * own frame cap, and not a number of ours.
+ *
+ * `@kolu/surface` owns the wire's frame size (`RPC_MAX_FRAME_BYTES`, 16 MiB)
+ * AND owns what happens to a frame that busts it: the ndjson decoder
+ * classifies the overflow and closes with the documented 1009 its
+ * `frame-limit` module names, which the client recognises as a RECOVERABLE
+ * transport death — reconnect, re-subscribe, and the per-subscription retry
+ * fence restores what was lost.
+ *
+ * A lower cap here does not make the wire safer. It moves the refusal one
+ * layer DOWN, to a place with no classifier, no documented close and no client
+ * that knows what happened — just a socket that died. And in drishti that is
+ * expensive out of proportion to the one bad frame: since the `@kolu/surface-map`
+ * adoption a browser tab multiplexes the admin control plane AND every
+ * configured host's telemetry onto ONE socket, so a raw-layer death takes the
+ * whole fleet view down, not one host's stream.
+ *
+ * `main.ts` used to say `8 * 1024 * 1024`, half the framework's number, so
+ * every frame in between died at the wrong layer. Sourcing the constant means
+ * the two layers can no longer disagree, whatever either of them is re-pinned
+ * to; `wsFrameCap.test.ts` fails if they do.
+ *
+ * It is a DECLARATION more than a setting under the runtime we ship. Bun's
+ * built-in `ws` is what `import { WebSocketServer } from "ws"` resolves to,
+ * and it ignores `maxPayload` in favour of a 16 MiB ceiling of its own
+ * (measured 2026-08-10 in this worktree: a server capped at 1024 was handed
+ * 4096 bytes and delivered them; 16777216 delivered, one byte more closed 1006
+ * "Received too big message"). Two consequences worth stating rather than
+ * discovering: no `maxPayload` we pass moves that ceiling, and while it stands
+ * the framework's handled INBOUND oversize path is unreachable here at all — a
+ * frame the decoder would refuse is already past bun's limit, and even one at
+ * exactly the cap arrives a delimiter byte over it and dies at 1006 rather
+ * than 1009. A node host obeys the option, and a bun that implements it would
+ * too, which is why the number still has to be right — and why the test pins
+ * the number rather than the behaviour.
+ */
+
+import { RPC_MAX_FRAME_BYTES } from "@kolu/surface/frame-limit";
+
+/** The newline an ndjson frame ends with. The encoder writes
+ *  `JSON.stringify(…) + "\n"` as one message, so it is on the wire — but the
+ *  decoder measures the line WITHOUT it (`nlIndex - position`). One byte, and
+ *  it is the difference between the two caps meeting and missing. */
+const NDJSON_DELIMITER_BYTES = 1;
+
+export const WS_MAX_PAYLOAD_BYTES =
+  RPC_MAX_FRAME_BYTES + NDJSON_DELIMITER_BYTES;


### PR DESCRIPTION
**The parent server capped websocket messages at 8 MiB while `@kolu/surface`'s `RPC_MAX_FRAME_BYTES` classifies oversize at 16 MiB** — so every frame in between was refused by the raw `ws` layer instead of the one that owns the decision. Same bug, same fix shape as [juspay/olai#71](https://github.com/juspay/olai/pull/71).

That layer has no classifier, no documented close, and no client written to recover from it. The framework's path does: its ndjson decoder closes with a 1009 the client treats as a *recoverable* transport death — reconnect, re-subscribe, per-subscription retry restores what was lost. And in drishti the cost of landing on the wrong layer is out of proportion to the one bad frame: since the `@kolu/surface-map` adoption a tab multiplexes the admin control plane **and** every configured host's telemetry onto one socket, so a raw-layer death takes the whole fleet view down rather than one host's stream.

### The fix

`maxPayload` is now sourced rather than restated (`packages/app/src/server/wsFrameCap.ts`):

```
RPC_MAX_FRAME_BYTES  +  1
   (framework, 16 MiB)    the newline an ndjson frame ends with — on the
                          wire, but outside what the decoder measures
                          (`nlIndex - position`)
```

The two layers now cannot disagree, whatever either of them is re-pinned to. It lives in its own module because `main.ts` self-executes on import (it boots the server), so a test cannot reach a constant declared there.

### The fence pins the number, not the behaviour

Measured in this worktree while fixing it, and it corrects the audit's account of the symptom:

| Claim | Measured under bun 1.3.10 |
| --- | --- |
| `maxPayload` is enforced | **No** — a server capped at 1024 was handed 4096 bytes and delivered them |
| bun has a ceiling of its own | **16 MiB** — 16777216 delivered, one byte more closed 1006 `Received too big message` |

So the misconfiguration was real but its symptom — the raw 1009 death — was a node host's, not one reachable here. A behavioural assertion would have passed against the bug; what was wrong was the *configuration*, so that is what is pinned. All three tests in `wsFrameCap.test.ts` fail against `8 * 1024 * 1024`: the framework's own `exceedsFrameLimit` predicate says a 9 MiB frame is its business, the cap must never be the layer that says no first, and the call site in `main.ts` must actually hand over the constant.

> *Newly known, and stated rather than left to be rediscovered:* while bun's ceiling stands, the framework's handled **inbound** oversize path is unreachable here at all — a frame the decoder would refuse is already past bun's limit, and even one at exactly the cap arrives a delimiter byte over it and dies at 1006 rather than 1009. A node host obeys the option, and a bun that implements it would too, which is why the number still has to be right.

drishti's per-host listener can't adopt kolu's `serveSurfaceApp` primitive, so this stays a surgical standalone fix rather than a migration.

### Try it locally

```sh
nix run github:srid/drishti/frame-cap
```

_Generated by Claude Code (model `claude-opus-5`)._