### PR TITLE
Pair with juspay/kolu#2159: take the finished dist socket

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "dist-socket",
       "submodules": false,
-      "revision": "5a21c2687e02c6b0d9a654099a162f96db9ba809",
-      "url": "https://github.com/juspay/kolu/archive/5a21c2687e02c6b0d9a654099a162f96db9ba809.tar.gz",
-      "hash": "sha256-HbS5NwZ93qkPeVws9m76GCj82MXLaU7BAEx9jTukEAo="
+      "revision": "9735fb658583aa9e65be4e0e89af2afa645f5989",
+      "url": "https://github.com/juspay/kolu/archive/9735fb658583aa9e65be4e0e89af2afa645f5989.tar.gz",
+      "hash": "sha256-KRIwddOERHcaba1ObBFemq050XUHPLtjQNFl8sfxoqk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-typed-lifecycle",
+      "branch": "dist-socket",
       "submodules": false,
-      "revision": "5a47d7f94f5ccfa079ac3670761474bddbb70ce1",
-      "url": "https://github.com/juspay/kolu/archive/5a47d7f94f5ccfa079ac3670761474bddbb70ce1.tar.gz",
-      "hash": "sha256-kKhlIFpaBo3Y30Jltfw4mDCS1bLqjmLm6QweRHWRdA8="
+      "revision": "5a21c2687e02c6b0d9a654099a162f96db9ba809",
+      "url": "https://github.com/juspay/kolu/archive/5a21c2687e02c6b0d9a654099a162f96db9ba809.tar.gz",
+      "hash": "sha256-HbS5NwZ93qkPeVws9m76GCj82MXLaU7BAEx9jTukEAo="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pairs with **[juspay/kolu#2159](https://github.com/juspay/kolu/pull/2159)** — the surface-rule gate for an API-facing `@kolu/surface-app` change. Pinned to that PR's HEAD `5a21c268`.

## The whole diff is the pin

kolu's `buildSurfaceClient` now finishes the dist its own `freshStaticLayer` was built to serve: it emits the `br`/`zstd`/`gzip` siblings the static layer has always negotiated, prunes the hashed dir down to what the build produced, skips recompressing a sibling beside an unchanged asset, and builds with `splitting` on.

drishti *composes* that helper (`packages/app/src/server/build.ts`) and precompressed **nothing** — so for as long as this has been wired up, drishti has shipped identity-only bytes to a server that would happily have negotiated brotli. There is no source change to make. The repin is the adoption.

## What the client dist gains

`nix build .#drishti-client`, before → after:

| file | identity | `.br` | `.zst` | `.gz` |
| --- | --- | --- | --- | --- |
| `main-yz1sy0cc.js` | 640,266 B | **173,165 B** (−73%) | 181,780 B | 203,575 B |
| `styles-86201518.css` | 54,414 B | **6,773 B** (−88%) | 7,505 B | 8,202 B |

Every one of those siblings was absent before this pin.

Two absences are the point as much as the presences:

- **no sibling beside `main-yz1sy0cc.js.map`** (5.5 MB) — sourcemaps are deliberately skipped upstream; they are not on the first-paint path, and brotli-q11 over a multi-megabyte map would dominate the build for bytes only an open DevTools asks for.
- **no sibling beside `index.html`** — the `no-store` shell is never compressed, and the layer will not negotiate outside `/assets/` even if one appeared (kolu#1319).

## Notes

- **No `bun.nix` regeneration**: the upstream change adds no runtime dependency. (Upstream deliberately used a `Record` keyed by the encoding union rather than adding `ts-pattern` to a shared library, specifically so this pair stayed a pure repin.)
- **Splitting is now on** for this build. drishti's client has no dynamic `import()` today, so the output is the single entry it always was — the setting costs nothing here and is ready if a heavy module ever wants deferring.
- Branch cut fresh off `origin/master` (`d010d95`) at open, per the pair-PR rule.
