### PR TITLE
Pair with juspay/kolu#2160: the connectSurface readout that cannot lie

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-typed-lifecycle",
+      "branch": "readout",
       "submodules": false,
-      "revision": "5a47d7f94f5ccfa079ac3670761474bddbb70ce1",
-      "url": "https://github.com/juspay/kolu/archive/5a47d7f94f5ccfa079ac3670761474bddbb70ce1.tar.gz",
-      "hash": "sha256-kKhlIFpaBo3Y30Jltfw4mDCS1bLqjmLm6QweRHWRdA8="
+      "revision": "b88d20f7f653fec9248821f397a09bf1904c8644",
+      "url": "https://github.com/juspay/kolu/archive/b88d20f7f653fec9248821f397a09bf1904c8644.tar.gz",
+      "hash": "sha256-3bRHWmUzhdYZSHvBwgL7LPDzh3XhxyU/KTxxpnx78X8="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pair for [juspay/kolu#2160](https://github.com/juspay/kolu/pull/2160). **A pure repin — drishti needs no source change.**

Upstream, `connectSurface` / `connectSurfaces` stop handing back a transport-only `status` beside a `client.health()` an app may never call. They now hand back one **`readout`** — `connecting | live | degraded | reconnecting | retired`, with `needsReload` and, on the degraded arm, the non-empty list of subscriptions that stopped. `live` becomes the conjunction of the wire's state and the subscription-health fact, so an indicator's green is a claim about what reaches the page rather than about a socket.

### Why nothing here moves

| drishti site | binds | affected |
| --- | --- | --- |
| `packages/app/src/client/wire.ts` | `conn.link`, `conn.transport`, `conn.clients` | no — never `conn.status` / `conn.health` |
| `packages/app/src/client/StatusFooter.tsx` | `SurfaceHealth` as a prop type, `<HostStatusPip>` | no — the health fact and `gateStatus` are unchanged |
| `packages/app/src/client/App.tsx` | `surfaceClientsHealth`, `createSubscription` | no |

`<HostStatusPip>` deliberately stays on `gateStatus` upstream: the gate verdict and the readout answer different questions — a pending first frame legitimately blocks a body gate, and must *not* amber a connection light. The footer's `ready={(h) => h.live && pwa.status() === "live"}` refinement is untouched.

The removed `status` field was type-level only for this repo; `just typecheck` passes against the new pin, and CI below is the gate proper.

Pinned at kolu `b88d20f7f653fec9248821f397a09bf1904c8644` — that PR's final HEAD, itself CI-green on both platforms.