### PR TITLE
Pin kolu to juspay/kolu#2170 (per-face `expose`) — the surface-rule pair PR

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-per-face-expose",
       "submodules": false,
-      "revision": "dad81604eaaf66ec5ff59942973865f62bcddefd",
-      "url": "https://github.com/juspay/kolu/archive/dad81604eaaf66ec5ff59942973865f62bcddefd.tar.gz",
-      "hash": "sha256-gIM4+eC6CTze9hHVAR7oEI2zyJXvd+h8+bUVQgtpweQ="
+      "revision": "6180b07441510907e98584a4288fa15a68aacb27",
+      "url": "https://github.com/juspay/kolu/archive/6180b07441510907e98584a4288fa15a68aacb27.tar.gz",
+      "hash": "sha256-sLHq5gE6FR57GmYHc6me9SL1Qs3yNbH+IE/rgtAofBw="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-per-face-expose",
+      "branch": "master",
       "submodules": false,
-      "revision": "3a2d86099763b0e3ab630163bd6a6d83ba60d8f7",
-      "url": "https://github.com/juspay/kolu/archive/3a2d86099763b0e3ab630163bd6a6d83ba60d8f7.tar.gz",
+      "revision": "bfb4eb563cd08ab84b8b45387150203234b3f0a1",
+      "url": "https://github.com/juspay/kolu/archive/bfb4eb563cd08ab84b8b45387150203234b3f0a1.tar.gz",
       "hash": "sha256-1c+kxWuzSlkI0nM7knQ2obTwxs5rwyt5uAXgxfxgsTU="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-per-face-expose",
       "submodules": false,
-      "revision": "6180b07441510907e98584a4288fa15a68aacb27",
-      "url": "https://github.com/juspay/kolu/archive/6180b07441510907e98584a4288fa15a68aacb27.tar.gz",
-      "hash": "sha256-sLHq5gE6FR57GmYHc6me9SL1Qs3yNbH+IE/rgtAofBw="
+      "revision": "3a2d86099763b0e3ab630163bd6a6d83ba60d8f7",
+      "url": "https://github.com/juspay/kolu/archive/3a2d86099763b0e3ab630163bd6a6d83ba60d8f7.tar.gz",
+      "hash": "sha256-1c+kxWuzSlkI0nM7knQ2obTwxs5rwyt5uAXgxfxgsTU="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
The pair PR [`.claude/rules/surface.md`](https://github.com/juspay/kolu/blob/master/.claude/rules/surface.md) requires for an API-facing change to `@kolu/surface` / `@kolu/surface-app`. Pairs with **juspay/kolu#2170**.

kolu#2170 gives each serving face its own default-deny `expose` allowlist — the same `ExposeMap` shape `serveSurfaceAsMcp` already took, so a verb can be reachable over a trusted unix socket and refused to browsers. `serveSurfaceApp` and `serveOverUnixSocket` gain an optional `expose?: FaceExposure`, and a new `@kolu/surface/expose` subpath exports the shape (`ExposeMap` / `ToolExposure`, moved there from `@kolu/surface-mcp`), the single key grammar every face reads a map through (`classifyExpose`), the binders (`exposeFace` / `exposeFaces`) and the filter (`restrictHandlers`).

**Nothing drishti imports changed shape.** The addition is a new subpath plus a new *optional* option; drishti imports none of the moved names, and its listener takes the granular `serveSurfaceSocket` seam, which is unchanged and deliberately takes no map (a hand-built serve path that wanted a gate would call `restrictHandlers` itself — drishti does not today).

So this is the gate rather than a migration: it exists to prove drishti still builds and passes CI against the new surface API. Pinned to kolu#2170's **final** HEAD (`6180b074`), after its review gauntlet and CI fix-commits — the rule is explicit that a green pinned to a pre-gauntlet SHA is stale.

`just typecheck` is green against this pin locally (common + agent + app).

**Awaiting srid** — do not merge; the kolu side is reviewed and merged by srid personally, and this should follow it.