### PR TITLE
Take kolu#2187: the process table reads the framework's own deltas store

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-deltas-frame",
       "submodules": false,
-      "revision": "bfb4eb563cd08ab84b8b45387150203234b3f0a1",
-      "url": "https://github.com/juspay/kolu/archive/bfb4eb563cd08ab84b8b45387150203234b3f0a1.tar.gz",
-      "hash": "sha256-1c+kxWuzSlkI0nM7knQ2obTwxs5rwyt5uAXgxfxgsTU="
+      "revision": "3d54d645f09bf707110f84e40b8d4961e781e42b",
+      "url": "https://github.com/juspay/kolu/archive/3d54d645f09bf707110f84e40b8d4961e781e42b.tar.gz",
+      "hash": "sha256-1Z6BuauUjH/+0+7L6599eFG13nc+0HtAScq9FwUEhEM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,8 +9,8 @@
       },
       "branch": "surface-deltas-frame",
       "submodules": false,
-      "revision": "3d54d645f09bf707110f84e40b8d4961e781e42b",
-      "url": "https://github.com/juspay/kolu/archive/3d54d645f09bf707110f84e40b8d4961e781e42b.tar.gz",
+      "revision": "6af01eebf007a4dda1e78439584f6ca7156aed35",
+      "url": "https://github.com/juspay/kolu/archive/6af01eebf007a4dda1e78439584f6ca7156aed35.tar.gz",
       "hash": "sha256-1Z6BuauUjH/+0+7L6599eFG13nc+0HtAScq9FwUEhEM="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-deltas-frame",
+      "branch": "master",
       "submodules": false,
-      "revision": "6af01eebf007a4dda1e78439584f6ca7156aed35",
-      "url": "https://github.com/juspay/kolu/archive/6af01eebf007a4dda1e78439584f6ca7156aed35.tar.gz",
-      "hash": "sha256-1Z6BuauUjH/+0+7L6599eFG13nc+0HtAScq9FwUEhEM="
+      "revision": "f648f0a2083f3abe05dee1cf29d4d49edfb00866",
+      "url": "https://github.com/juspay/kolu/archive/f648f0a2083f3abe05dee1cf29d4d49edfb00866.tar.gz",
+      "hash": "sha256-ZfDKHYSaylSG4Yx41NQ7gA0UMVG/sZdFpcBcciiDDpA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/client/App.tsx
+++ b/packages/app/src/client/App.tsx
@@ -17,7 +17,11 @@
 import type { EntryState } from "@kolu/surface-map";
 import { unenrolledStreamCall } from "@kolu/surface/client";
 import { probeSurfaceIdentity } from "@kolu/surface/identity";
-import { createSubscription, surfaceClientsHealth } from "@kolu/surface/solid";
+import {
+  createSubscription,
+  surfaceClientsHealth,
+  useCollectionDeltas,
+} from "@kolu/surface/solid";
 import { shellCommit } from "@kolu/surface-app/lifecycle";
 import { SurfaceAppProvider } from "@kolu/surface-app/solid";
 import { Meta, Title } from "@solidjs/meta";
@@ -66,6 +70,7 @@ import {
   type UnclaimedListener,
 } from "drishti-common";
 import {
+  browserSurface,
   type ConnectionInfo,
   type ConnectionState,
   DEFAULT_CONNECTION,
@@ -120,6 +125,7 @@ import {
   processInspectionNotes,
   processMatches,
   processRowCell,
+  type ProcessLookup,
   processRowUptime,
   PROCESS_SORT_KEYS,
   type ProcessTableCellPresentation,
@@ -134,27 +140,6 @@ import {
   mergeSourceErrorFacts,
   sourceErrorFacts,
 } from "./sourceErrorPresentation";
-import type { CollectionDeltasMsg } from "@kolu/surface/define";
-
-/** Fold one `processes` collection `deltas` frame into the accumulated process map
- *  (SR5 — the collection's `deltas` verb replaced the hand-rolled `processesSnapshot`
- *  stream; `CollectionDeltasMsg<Pid, Process>` is the same snapshot/delta shape the
- *  old `foldProcessesMessage` folded, so the accumulator is byte-identical). A
- *  `snapshot` replaces the whole set; a `delta` applies upserts then removes. */
-function foldProcessDeltas(
-  prev: Record<Pid, Process>,
-  msg: CollectionDeltasMsg<Pid, Process>,
-): Record<Pid, Process> {
-  if (msg.kind === "snapshot") {
-    const next: Record<Pid, Process> = {};
-    for (const [pid, value] of msg.entries) next[pid] = value;
-    return next;
-  }
-  const next = { ...prev };
-  for (const [pid, value] of msg.upserts) next[pid] = value;
-  for (const pid of msg.removes) delete next[pid];
-  return next;
-}
 import {
   coreUsageColor,
   processPctColor,
@@ -1261,39 +1246,35 @@ function HostView(props: {
     daemonStore.renew(props.host);
   };
 
-  // The live process table, consumed as a declarative value-bearing reactive
-  // subscription: `createSubscription` folds every snapshot|delta frame in-loop
-  // (via `foldProcessesMessage`) into the full process map, replacing the
-  // hand-rolled `unenrolledStreamCall` + `for await` loop this used to be. The
-  // table renders FINE-GRAINED off `processes()` below (`processes()[pid].cpuPct`),
-  // so an in-place `reconcile` leaf update re-notifies just that cell — reading
-  // the whole map coarsely and copying it into a store would drop same-shape
-  // deltas (the R8b lesson). `.streams.use()` exposes no `reduce`, so this
-  // drops one level to `createSubscription` (same reactive family). The
-  // AbortController that used to abort the underlying stream on unmount is
-  // GONE — the subscription's teardown is a fiber interrupt now.
-  const processesSub = createSubscription<
-    CollectionDeltasMsg<Pid, Process>,
-    Record<Pid, Process>
-  >(
-    // The bare `unenrolledStreamCall` is the right primitive HERE — the raw
-    // batched-deltas `Stream` feeding `createSubscription`, which owns its own
-    // pending/error. `processes` is a `deltas`-declaring collection
-    // (SR5 — one protocol across the wire, replacing the old `processesSnapshot`
-    // stream), and `unenrolledDeltas` is its DELIBERATELY un-enrolled reach: there
-    // is no per-host `health()` fact to join it to — every host's data rides the
-    // ONE admin transport now — so a dead process feed surfaces via this
-    // subscription's own reactive `error()`, read below (never a gate flicker).
-    unenrolledStreamCall(
-      hostCollections(props.host).processes.unenrolledDeltas,
-      undefined,
-    ),
+  // The live process table, over the framework's OWN batched-deltas store. The
+  // `processes` collection declares the `deltas` verb, so the wire sends ONE
+  // coalesced {upserts, removes} frame per poll tick, and `useCollectionDeltas`
+  // applies it by NAMED-KEY writes — the keys the frame mentions, nobody else. The
+  // table renders FINE-GRAINED off `process(pid)` below (`process(pid)?.cpuPct`),
+  // which is exactly that store's per-key contract (the R8b lesson: reading the
+  // whole map coarsely and copying it into a store drops same-shape deltas).
+  //
+  // `unenrolledDeltas` is the collection's DELIBERATELY un-enrolled reach: there is
+  // no per-host `health()` fact to join it to — every host's data rides the ONE
+  // admin transport — so a dead process feed surfaces via this view's own reactive
+  // `stream.error()`, read below, never as a gate flicker (kolu #1591). That reach
+  // is why the hook is exported at all; before it was, this file carried its own
+  // copy of the framework's fold, which re-copied the whole pid map per frame and
+  // then had `createSubscription`'s reconcile walk it again to rediscover the pids
+  // the frame had already named.
+  const processesView = useCollectionDeltas(
+    browserSurface.descriptors.collections.processes,
     {
-      reduce: foldProcessDeltas,
-      initial: {},
+      source: unenrolledStreamCall(
+        hostCollections(props.host).processes.unenrolledDeltas,
+        undefined,
+      ),
     },
   );
-  const processes = (): Record<Pid, Process> => processesSub() ?? {};
+  /** One pid's row, or `undefined` if it has left the set. A per-key read: only
+   *  the rows a frame named re-render. */
+  const process = (pid: Pid): Process | undefined =>
+    processesView.byKey(pid)?.();
   const unclaimedListeners = entry.collections.unclaimedListeners.use();
   const unclaimedListenerValues = createMemo(() =>
     [...unclaimedListeners.keys()]
@@ -1329,10 +1310,10 @@ function HostView(props: {
   // later-reused pid from silently re-opening the panel. Tracks only the
   // selected pid's slot (not its fields), so a cpu/mem tick doesn't re-run it.
   //
-  // Gate on the subscription having yielded its FIRST frame (`!processesSub
-  // .pending()`) — mirroring kolu's `pending()`-gated hydration in
-  // `useSessionRestore.ts`. `processesSub` REMOUNTS on a host switch and starts
-  // at its `initial: {}` (empty) with `pending() === true`; without this gate,
+  // Gate on the subscription having yielded its FIRST frame
+  // (`!processesView.stream.pending()`) — mirroring kolu's `pending()`-gated
+  // hydration in `useSessionRestore.ts`. The view REMOUNTS on a host switch and
+  // starts empty with `pending() === true`; without this gate,
   // switching back would read the RETAINED per-host `selectedPid` against that
   // empty first frame and clear it BEFORE the first real snapshot arrives —
   // silently defeating the scopedByEntry adoption (the expanded PID surviving
@@ -1340,7 +1321,11 @@ function HostView(props: {
   // genuinely-exited pid still clears against the LOADED table.
   createEffect(() => {
     const pid = selectedPid();
-    if (pid !== null && !processesSub.pending() && processes()[pid] === undefined)
+    if (
+      pid !== null &&
+      !processesView.stream.pending() &&
+      process(pid) === undefined
+    )
       setSelectedPid(null);
   });
 
@@ -1388,9 +1373,10 @@ function HostView(props: {
     />
   );
 
-  const allPids = createMemo<Pid[]>(() =>
-    Object.keys(processes()).map((k) => Number(k)),
-  );
+  // Arrival order, straight off the store's own key set — the same array by
+  // REFERENCE while membership is unchanged, so a values-only tick does not wake
+  // anything reading it.
+  const allPids = processesView.keys;
 
   // `cpuCores`/`networkInterfaces` ride the collection `deltas` verb, which
   // is ALSO void-input at the entry-router fold — the same omitted-`input`
@@ -1422,20 +1408,18 @@ function HostView(props: {
     const pids = allPids();
     const key = sortKey();
     const filtered: Pid[] = [];
-    const procs = processes();
     if (q.length === 0) {
       for (const pid of pids) {
-        if (procs[pid] !== undefined) filtered.push(pid);
+        if (process(pid) !== undefined) filtered.push(pid);
       }
     } else {
       for (const pid of pids) {
-        const proc = procs[pid];
+        const proc = process(pid);
         if (proc === undefined) continue;
-        if (processMatches(pid, proc, q))
-          filtered.push(pid);
+        if (processMatches(pid, proc, q)) filtered.push(pid);
       }
     }
-    filtered.sort(processComparator(key, procs));
+    filtered.sort(processComparator(key, process));
     return filtered;
   });
 
@@ -1470,7 +1454,7 @@ function HostView(props: {
   const selected = createMemo<{ pid: Pid; proc: Process } | null>(() => {
     const pid = selectedPid();
     if (pid === null) return null;
-    const proc = processes()[pid];
+    const proc = process(pid);
     return proc === undefined ? null : { pid, proc };
   });
 
@@ -1540,7 +1524,7 @@ function HostView(props: {
         <SourceErrorNotice
           facts={mergeSourceErrorFacts(
             partialSourceFacts(),
-            sourceErrorFacts([system.error(), processesSub.error()]),
+            sourceErrorFacts([system.error(), processesView.stream.error()]),
           )}
         />
         <div class="grid xl:grid-cols-[minmax(24rem,2fr)_minmax(0,3fr)]">
@@ -1577,7 +1561,7 @@ function HostView(props: {
               memTotal={currentSystem().memTotal}
               onClose={() => setSelectedPid(null)}
               onSelectParent={
-                processes()[s().proc.ppid] !== undefined
+                process(s().proc.ppid) !== undefined
                   ? () => setSelectedPid(s().proc.ppid)
                   : null
               }
@@ -1597,7 +1581,7 @@ function HostView(props: {
         >
           <ProcessTable
             pids={visiblePids()}
-            processes={processes}
+            process={process}
             toLocalTime={(remoteMs) => entry.clock.toLocal(remoteMs)}
             sortKey={sortKey()}
             onSort={setSortKey}
@@ -1978,7 +1962,7 @@ function SourceErrorNotice(props: { facts: readonly SourceErrorFact[] }) {
 
 function ProcessTable(props: {
   pids: readonly Pid[];
-  processes: Accessor<Record<Pid, Process>>;
+  process: ProcessLookup;
   toLocalTime: (remoteMs: number) => number | null;
   sortKey: ProcessSortKey;
   onSort: (k: ProcessSortKey) => void;
@@ -2044,7 +2028,7 @@ function ProcessTable(props: {
             {(pid) => (
               <ProcessRow
                 pid={pid}
-                processes={props.processes}
+                process={props.process}
                 nowMs={nowMs()}
                 toLocalTime={props.toLocalTime}
               />
@@ -2065,12 +2049,12 @@ function ProcessTable(props: {
 // per-field via Solid's store proxy.
 function ProcessRow(props: {
   pid: Pid;
-  processes: Accessor<Record<Pid, Process>>;
+  process: ProcessLookup;
   nowMs: number;
   toLocalTime: (remoteMs: number) => number | null;
 }) {
   const selection = useContext(SelectionContext);
-  const proc = () => props.processes()[props.pid];
+  const proc = () => props.process(props.pid);
   const uptime = () =>
     processRowUptime(
       proc()?.startedAtMs ?? null,

--- a/packages/app/src/client/processPresentation.test.ts
+++ b/packages/app/src/client/processPresentation.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROCESS_SORT_KEY,
   fallbackTableMarker,
   processComparator,
+  type ProcessLookup,
   processDetailMemoryText,
   processInspectionNotes,
   processMatches,
@@ -15,6 +16,13 @@ import {
   processThreadCell,
   unreadableTableMarker,
 } from "./processPresentation";
+
+/** The comparator takes a LOOKUP now (the process table reads a keyed store, not a
+ *  materialised record), so these fixtures hand it one over a plain object. */
+const look =
+  (procs: Record<number, Process>): ProcessLookup =>
+  (pid) =>
+    procs[pid];
 
 const process = (
   unreadable: Process["unreadable"],
@@ -186,8 +194,8 @@ describe("restored process sorting and search", () => {
       1: { ...process([]), cpuPct: 2, user: "root" },
       2: { ...process([]), cpuPct: 40, user: "1000" },
     };
-    expect([1, 2].sort(processComparator("cpu", procs))).toEqual([2, 1]);
-    expect([1, 2].sort(processComparator("user", procs))).toEqual([2, 1]);
+    expect([1, 2].sort(processComparator("cpu", look(procs)))).toEqual([2, 1]);
+    expect([1, 2].sort(processComparator("user", look(procs)))).toEqual([2, 1]);
   });
 
   it("sorts fully-blind rows below readable zero-CPU rows", () => {
@@ -196,7 +204,7 @@ describe("restored process sorting and search", () => {
       2: process([]),
     };
 
-    expect([1, 2].sort(processComparator("cpu", procs))).toEqual([2, 1]);
+    expect([1, 2].sort(processComparator("cpu", look(procs)))).toEqual([2, 1]);
   });
 
   it("searches uid presentation, cwd, and full argv", () => {

--- a/packages/app/src/client/processPresentation.ts
+++ b/packages/app/src/client/processPresentation.ts
@@ -112,30 +112,34 @@ export function processMatches(pid: Pid, process: Process, query: string): boole
   );
 }
 
+/** How a caller looks one pid's row up. A FUNCTION, not a `Record`: the process
+ *  table reads the surface framework's batched-deltas store, whose per-key contract
+ *  is exactly "ask for one key" — materialising a whole record to sort by would
+ *  re-copy per tick the very map the store exists to stop copying. */
+export type ProcessLookup = (pid: Pid) => Process | undefined;
+
 export function processComparator(
   key: ProcessSortKey,
-  procs: Record<Pid, Process>,
+  look: ProcessLookup,
 ): (a: Pid, b: Pid) => number {
-  if (key === "ppid")
-    return (a, b) => procs[a]!.ppid - procs[b]!.ppid || a - b;
+  if (key === "ppid") return (a, b) => look(a)!.ppid - look(b)!.ppid || a - b;
   if (key === "mem")
     return (a, b) =>
-      (procs[b]!.rssBytes ?? -1) - (procs[a]!.rssBytes ?? -1) || a - b;
+      (look(b)!.rssBytes ?? -1) - (look(a)!.rssBytes ?? -1) || a - b;
   if (key === "uptime")
     return (a, b) =>
-      (procs[a]!.startedAtMs ?? Number.POSITIVE_INFINITY) -
-        (procs[b]!.startedAtMs ?? Number.POSITIVE_INFINITY) || a - b;
+      (look(a)!.startedAtMs ?? Number.POSITIVE_INFINITY) -
+        (look(b)!.startedAtMs ?? Number.POSITIVE_INFINITY) || a - b;
   if (key === "command")
-    return (a, b) =>
-      procs[a]!.command.localeCompare(procs[b]!.command) || a - b;
+    return (a, b) => look(a)!.command.localeCompare(look(b)!.command) || a - b;
   if (key === "user")
-    return (a, b) => procs[a]!.user.localeCompare(procs[b]!.user) || a - b;
+    return (a, b) => look(a)!.user.localeCompare(look(b)!.user) || a - b;
   if (key === "cpu")
     return (a, b) => {
-      const aBlind = fullyBlindErrno(procs[a]!) !== null;
-      const bBlind = fullyBlindErrno(procs[b]!) !== null;
+      const aBlind = fullyBlindErrno(look(a)!) !== null;
+      const bBlind = fullyBlindErrno(look(b)!) !== null;
       if (aBlind !== bBlind) return aBlind ? 1 : -1;
-      return procs[b]!.cpuPct - procs[a]!.cpuPct || a - b;
+      return look(b)!.cpuPct - look(a)!.cpuPct || a - b;
     };
   return (a, b) => a - b;
 }


### PR DESCRIPTION
The pair PR [`.claude/rules/surface.md`](https://github.com/juspay/kolu/blob/master/.claude/rules/surface.md) requires for an API-facing change to `@kolu/surface` — and this one is also the adoption vehicle, not just a re-green.

## What kolu#2187 changes

A collection that declares the `deltas` verb is served by ONE coalesced `{upserts, removes}` frame per producer tick. The client half used to digest that frame into a keyed dictionary by copying the whole dictionary and reconciling the copy — two O(N) passes per O(|frame|) update. It now writes exactly the keys the frame names, exports the hook that does it, and adds `fold({ init, step })` for a consumer whose accumulator is not a keyed map.

Nothing drishti imports changed shape: the change is additive, and the deleted `foldCollectionDeltas` had no consumer outside its own test file. `.use({ keys })` is untouched (drishti calls it nowhere anyway — `grep -rn '\.use({ *keys' packages/*/src` is empty).

## What drishti does about it

`App.tsx` carried its own copy of the framework's fold. That was not carelessness — it was the only way in: the process table needs the deliberately un-enrolled reach (`processes.unenrolledDeltas`, the [#1591](https://github.com/juspay/kolu/issues/1591) carve-out — there is no per-host `health()` fact to join a process feed to, so a dead feed has to surface through the subscription's own `error()` rather than flicker a gate), and `useCollectionDeltas` was barrel-private. So `foldProcessDeltas` copied the whole `Record<Pid, Process>` per frame, and `createSubscription`'s reduce path reconciled the whole map again, per poll tick, over hundreds of pids that tick continuously.

Both are gone. The table reads the framework's store directly:

| before | after |
| --- | --- |
| `foldProcessDeltas` + a manual `createSubscription` | `useCollectionDeltas(browserSurface.descriptors.collections.processes, { source })` |
| `processes()[pid]` | `process(pid)` — one per-key read |
| `Object.keys(processes()).map(Number)` | the store's own `keys()` — the same array by reference while membership holds |
| `processesSub.pending()` / `.error()` | `processesView.stream.pending()` / `.error()` |

The fine-grained reads the table depends on (`processes()[pid].cpuPct`, the R8b requirement) are unchanged: per-key IS that store's contract, and the value behind it is still a Solid store proxy.

One signature moved with it. `processComparator` took a materialised `Record<Pid, Process>`; it takes a `ProcessLookup` function now, because building a record to sort by would re-copy per tick the very map this change stops copying.

## Cost

kolu's own bench (`just bench-collection-deltas`, 2000 keys, 200 rows on screen) puts the per-tick client cost of a `deltas` frame at **937x** cheaper when one key ticks, **90.9x** for 5 pids born and 5 dying, **22.2x** for a hundred, and **1.65x** when genuinely every key moves — the gain scales with how much of the collection a tick actually touches. A process table lives in the middle of that range.

## Pin

`npins/sources.json` → kolu `3d54d645` (juspay/kolu#2187's HEAD), branch `surface-deltas-frame`. Cut from current `origin/master` (`fb8526b`). Re-pinned to kolu's final HEAD if that PR moves after review, per the rule.

Pairs with **juspay/kolu#2187**.
