### PR TITLE
Gate kolu#2188 (the last-reader `holders` seam) — pin only, nothing to adopt

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-holders",
+      "branch": "master",
       "submodules": false,
-      "revision": "4b665c9a94a51faf632787612a3681da3acae3ee",
-      "url": "https://github.com/juspay/kolu/archive/4b665c9a94a51faf632787612a3681da3acae3ee.tar.gz",
-      "hash": "sha256-oT5wbxHrMDdAHBwVKAYRa9k0KJw+VHQIBDITkVXHun8="
+      "revision": "f648f0a2083f3abe05dee1cf29d4d49edfb00866",
+      "url": "https://github.com/juspay/kolu/archive/f648f0a2083f3abe05dee1cf29d4d49edfb00866.tar.gz",
+      "hash": "sha256-ZfDKHYSaylSG4Yx41NQ7gA0UMVG/sZdFpcBcciiDDpA="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-holders",
       "submodules": false,
-      "revision": "bfb4eb563cd08ab84b8b45387150203234b3f0a1",
-      "url": "https://github.com/juspay/kolu/archive/bfb4eb563cd08ab84b8b45387150203234b3f0a1.tar.gz",
-      "hash": "sha256-1c+kxWuzSlkI0nM7knQ2obTwxs5rwyt5uAXgxfxgsTU="
+      "revision": "4b665c9a94a51faf632787612a3681da3acae3ee",
+      "url": "https://github.com/juspay/kolu/archive/4b665c9a94a51faf632787612a3681da3acae3ee.tar.gz",
+      "hash": "sha256-oT5wbxHrMDdAHBwVKAYRa9k0KJw+VHQIBDITkVXHun8="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
The pair PR [`.claude/rules/surface.md`](https://github.com/juspay/kolu/blob/master/.claude/rules/surface.md) requires for an API-facing change to `@kolu/surface`. **This one is the gate, not a migration** — there is nothing for drishti to adopt, and the PR exists to prove that against CI rather than in a paragraph.

## What kolu#2188 changes

A collection's deps take one OPTIONAL member:

```ts
holders?: CollectionHolders<K>   // (key: K) => Effect<unknown, never, Scope>
```

A per-key `get` IS a subscription, and the framework has always known when one ENDS — fiber interruption is the unsubscribe — it just never said so. `holders` hands that scope to whoever is answering, so a server keeping something expensive alive per key (a file body held for whoever has that page open, a live log followed for whoever is watching that node) stops guessing with an LRU. Pull order is contract: hold → channel subscribe → `readOne`.

## Why drishti has nothing to do

Its five collections are derived poll-reconciler views over in-memory maps. Every one is `{ readAll, upsert, remove }` — `packages/app/src/server/router.ts:133-178` — with no `readOne` and nothing loaded per reader, so there is nothing a last-reader signal could release.

And absent `holders`, the `get` arm is the exact expression it was: the change routes the hold through `subscribeBeforeSnapshot`'s existing acquire, and a collection that passes no pre-acquire gets the identical stream with no wrapper and no extra channel layer.

So: `just typecheck` clean across `common`/`agent`/`app`, `just test` 387 pass / 7 skip / 0 fail. No drishti source changes.

## Pin

`npins/sources.json` → kolu `4b665c9a` (juspay/kolu#2188's final HEAD), branch `surface-holders`. Cut from current `origin/master` (`fb8526b`). Re-pinned if that PR moves after review, per the rule.

Pairs with **juspay/kolu#2188**. Independent of [#143](https://github.com/srid/drishti/pull/143) (the pair for kolu#2187) — the two kolu changes merge independently, so these two do too.
