### PR TITLE
Pin kolu to juspay/kolu#2190 (`arrayKey` + `changed`) — the surface-rule pair PR

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "reactivity-kolu-upstream",
       "submodules": false,
-      "revision": "f648f0a2083f3abe05dee1cf29d4d49edfb00866",
-      "url": "https://github.com/juspay/kolu/archive/f648f0a2083f3abe05dee1cf29d4d49edfb00866.tar.gz",
-      "hash": "sha256-ZfDKHYSaylSG4Yx41NQ7gA0UMVG/sZdFpcBcciiDDpA="
+      "revision": "b9a4da61db7cc98300a0aa59955b79df4f2b5fa0",
+      "url": "https://github.com/juspay/kolu/archive/b9a4da61db7cc98300a0aa59955b79df4f2b5fa0.tar.gz",
+      "hash": "sha256-1iiMrLLPo8rxUdlUmlbuphVZ1+vtQA+Ny8Q5FiosjfE="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "reactivity-kolu-upstream",
+      "branch": "master",
       "submodules": false,
-      "revision": "b9a4da61db7cc98300a0aa59955b79df4f2b5fa0",
-      "url": "https://github.com/juspay/kolu/archive/b9a4da61db7cc98300a0aa59955b79df4f2b5fa0.tar.gz",
+      "revision": "b6378c57624d476a89bcd0cd21af37de34a4ded9",
+      "url": "https://github.com/juspay/kolu/archive/b6378c57624d476a89bcd0cd21af37de34a4ded9.tar.gz",
       "hash": "sha256-1iiMrLLPo8rxUdlUmlbuphVZ1+vtQA+Ny8Q5FiosjfE="
     },
     "nixpkgs": {


### PR DESCRIPTION
The pair PR [`.claude/rules/surface.md`](https://github.com/juspay/kolu/blob/master/.claude/rules/surface.md) requires for an API-facing change to `@kolu/surface`. Pairs with **[juspay/kolu#2190](https://github.com/juspay/kolu/pull/2190)** (merged).

kolu#2190 gives a member definition **`arrayKey?: string`** — the field that identifies a row inside that member's value, declared at the spec so every merge of that member is keyed the same way — and a **`changed(handler)`** verb on `Subscription` that fires on the same frames as `updated` without cloning `{prev, next}`. Undeclared members still merge with `{ key: null }`; `updated` still pays for the snapshot it hands out.

**Nothing drishti imports changed shape.** Both additions are optional. Drishti names neither `arrayKey` nor `changed` / `updated` (`grep` across `packages/*/src` is empty). So this is the gate rather than a migration: it exists to prove drishti still builds and passes CI against the new surface API.

Pinned to kolu master `b6378c576` — the squash of #2190. The tarball hash is byte-identical to the reviewed PR-head `b9a4da61` the first CI run went green against, so this is the same tree, now reachable from master.

### Local verification

`just typecheck` (common + agent + app):

```
$ bun --cwd packages/common typecheck && bun --cwd packages/agent typecheck && bun --cwd packages/app typecheck
$ tsc --noEmit
$ tsc --noEmit
$ tsc --noEmit
```

exit 0, ~28s including hydrate of the new `@kolu/*` store paths.

`just test`:

```
 387 pass
 7 skip
 0 fail
 1064 expect() calls
Ran 394 tests across 57 files. [11.12s]
```

## Deferrals

No deferrals.

_Generated by Grok (model `grok-4.6`)._