### PR TITLE
Follow kolu to master (c46699631) — #2200's transport-death additions, and eleven commits riding with them

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "7181c3a8314b47f63274b665691213ba4b14f5c2",
-      "url": "https://github.com/juspay/kolu/archive/7181c3a8314b47f63274b665691213ba4b14f5c2.tar.gz",
-      "hash": "sha256-ShkIDqlg0pNGpZ85RPb7xyc4EA1reCPjlAPbcisaIqU="
+      "revision": "c46699631fd526d735b24e7dd2e9cbcfe1f6aa46",
+      "url": "https://github.com/juspay/kolu/archive/c46699631fd526d735b24e7dd2e9cbcfe1f6aa46.tar.gz",
+      "hash": "sha256-yfRaMCMYOa5GY5/VUMBZ6Fa8ozURaQ7yrFBDKYbMMzo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "b6378c57624d476a89bcd0cd21af37de34a4ded9",
-      "url": "https://github.com/juspay/kolu/archive/b6378c57624d476a89bcd0cd21af37de34a4ded9.tar.gz",
-      "hash": "sha256-1iiMrLLPo8rxUdlUmlbuphVZ1+vtQA+Ny8Q5FiosjfE="
+      "revision": "c468ec6aab11b6d17c2e46bd2ca2f3cf58f7be64",
+      "url": "https://github.com/juspay/kolu/archive/c468ec6aab11b6d17c2e46bd2ca2f3cf58f7be64.tar.gz",
+      "hash": "sha256-D9IAXyOU/kngqbruHEBb0dpw9e6fj8U2Fp5q3NU8aoo="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c468ec6aab11b6d17c2e46bd2ca2f3cf58f7be64",
-      "url": "https://github.com/juspay/kolu/archive/c468ec6aab11b6d17c2e46bd2ca2f3cf58f7be64.tar.gz",
-      "hash": "sha256-D9IAXyOU/kngqbruHEBb0dpw9e6fj8U2Fp5q3NU8aoo="
+      "revision": "7181c3a8314b47f63274b665691213ba4b14f5c2",
+      "url": "https://github.com/juspay/kolu/archive/7181c3a8314b47f63274b665691213ba4b14f5c2.tar.gz",
+      "hash": "sha256-ShkIDqlg0pNGpZ85RPb7xyc4EA1reCPjlAPbcisaIqU="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
This started life as the paired gate PR that `.claude/rules/surface.md` requires for an API-facing change to `@kolu/surface`, opened against **[juspay/kolu#2200](https://github.com/juspay/kolu/pull/2200)** and pinned to that PR's branch HEAD. **#2200 has merged**, so the gate is closed and this is now a routine kolu pin bump — the link above is kept for provenance.

#2200 was **squash-merged**, so the SHA this was pinned to (`7181c3a83`) is not an ancestor of kolu master and never will be; it only resolves while GitHub still serves the orphan archive. `npins update kolu` follows the pin's own `branch: master` and landed on **`c46699631fd526d735b24e7dd2e9cbcfe1f6aa46`** — "A link death that says what actually died, and one kill per close (#2200)".

## What the bump actually carries

Read the diff against **drishti master's** pin, `b6378c576`, not against this branch's earlier one: merging this advances kolu by **twelve commits**, not one.

| kolu PR | What it is | Touches `packages/surface*` |
| --- | --- | --- |
| [#2200](https://github.com/juspay/kolu/pull/2200) | Transport-death reasons + one kill per close | yes |
| [#2202](https://github.com/juspay/kolu/pull/2202) | A round trip carries the backlog, in a bounded buffer | yes |
| [#2201](https://github.com/juspay/kolu/pull/2201) | Revert of #2199 | yes |
| [#2199](https://github.com/juspay/kolu/pull/2199) | First attempt at the backlog fix (reverted above) | yes |
| [#2198](https://github.com/juspay/kolu/pull/2198) | A repeated upgrade header is the folded string node | yes |
| [#2196](https://github.com/juspay/kolu/pull/2196) | A surface app names the upgrade headers its connections carry | yes |
| [#2197](https://github.com/juspay/kolu/pull/2197) | The surface-app Bun build takes an asset prefix | yes |
| [#2194](https://github.com/juspay/kolu/pull/2194) | `kolu watch` can mute, flush, heartbeat | no |
| [#2195](https://github.com/juspay/kolu/pull/2195), [#2193](https://github.com/juspay/kolu/pull/2193) | Docs | no |
| [#2184](https://github.com/juspay/kolu/pull/2184) | A lost kaval link heals itself | no |
| [#2191](https://github.com/juspay/kolu/pull/2191) | xterm.js beta.302, Pierre Diffs 1.3.5 | no |

### #2200 — the change this PR was opened for

Purely additive, and drishti consumes none of it:

- `@kolu/surface/errors` gains `StdioTransportDeath` and `RetiredTransportDeath` (a `Schema.Literals` const + a type each), plus an **optional** `death` field on `SurfaceStdioTransportClosed` (`keepAliveUnanswered` / `streamEnded` / `disposed`) and on `SurfaceTransportRetired` (`retiredByServer` / `disposed`). Both are `Schema.optionalKey`, so a payload minted without them still decodes.
- `@kolu/surface/loopback` gains `stallLoopback`, and `greetLoopback` gains a second parameter `describe` **defaulted** to `"loopback"`, so existing one-argument calls compile unchanged.
- `WireTransportFailure` was deleted from `packages/surface/src/links/wire.ts`, but that module is package-internal — no `@kolu/surface/*` `exports` subpath reaches it — so it is not public API.
- `@kolu/surface-remote`'s two touched files changed only log wording and comments; no signature moved.

I re-derived by grep that drishti names none of `StdioTransportDeath`, `RetiredTransportDeath`, `death`, `stallLoopback`, `greetLoopback`, or `WireTransportFailure`.

### #2202 — the one that landed after the gate run, and the one to look at

`packages/surface/src/server.ts` now pipes both stream bridges through `Stream.buffer({ capacity: 512, strategy: "suspend" })`, so a subscription chunk carries everything published since the last one went out instead of one publish per round trip. No exported signature moved — the constant is private and the change is behavioural — and `suspend` leaves the producer's own bound the one that decides what happens to a backlog nobody is reading. A drishti subscription therefore sees the same values in the same order, just batched.

## Verification

- `just typecheck` green across common/agent/app.
- `just test` — 387 pass / 7 skip / 0 fail.
- Full odu pipeline green on both platforms (see the checks below).
- Branch cut off `origin/master` and re-merged at every repin, per the surface rule's stale-base clause.

Because the venue pool (`kolu-ci-*`) is currently unreachable, the `x86_64-linux` lane ran on localhost rather than a pool box; `aarch64-darwin` ran on `petit` as usual.