### PR TITLE
Pin kolu to juspay/kolu#2217 (daemon leaf entries) — the surface-rule pair PR

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,10 +7,10 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "dock-row-export",
+      "branch": "master",
       "submodules": false,
-      "revision": "de8fcad8d56a445c8a71d7fa65b7c565c1fa4299",
-      "url": "https://github.com/juspay/kolu/archive/de8fcad8d56a445c8a71d7fa65b7c565c1fa4299.tar.gz",
+      "revision": "f9ace75e6dc25a2bbada31bd1daacf0c28405934",
+      "url": "https://github.com/juspay/kolu/archive/f9ace75e6dc25a2bbada31bd1daacf0c28405934.tar.gz",
       "hash": "sha256-+vIxBhOFvbMNgaLOBzQKGizc8QU7cm76I0+MoWL5I48="
     },
     "nixpkgs": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "dock-row-export",
       "submodules": false,
-      "revision": "49db20651caafec6b2f00d727e1c55260ef76371",
-      "url": "https://github.com/juspay/kolu/archive/49db20651caafec6b2f00d727e1c55260ef76371.tar.gz",
-      "hash": "sha256-VDesZpcKCsXDHQ05HGrjh0RpjFEDgj3ITW+wyTGYMBM="
+      "revision": "de8fcad8d56a445c8a71d7fa65b7c565c1fa4299",
+      "url": "https://github.com/juspay/kolu/archive/de8fcad8d56a445c8a71d7fa65b7c565c1fa4299.tar.gz",
+      "hash": "sha256-+vIxBhOFvbMNgaLOBzQKGizc8QU7cm76I0+MoWL5I48="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "dock-row-export",
       "submodules": false,
-      "revision": "aa19a11061ffe3cfac1281b210ab5fac8bb38f43",
-      "url": "https://github.com/juspay/kolu/archive/aa19a11061ffe3cfac1281b210ab5fac8bb38f43.tar.gz",
-      "hash": "sha256-0zxHsF8jGNyFj9Tyfw6OXa61i/TifFdU1iAx5XYP4g4="
+      "revision": "49db20651caafec6b2f00d727e1c55260ef76371",
+      "url": "https://github.com/juspay/kolu/archive/49db20651caafec6b2f00d727e1c55260ef76371.tar.gz",
+      "hash": "sha256-VDesZpcKCsXDHQ05HGrjh0RpjFEDgj3ITW+wyTGYMBM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "dock-row-export",
       "submodules": false,
-      "revision": "c46699631fd526d735b24e7dd2e9cbcfe1f6aa46",
-      "url": "https://github.com/juspay/kolu/archive/c46699631fd526d735b24e7dd2e9cbcfe1f6aa46.tar.gz",
-      "hash": "sha256-yfRaMCMYOa5GY5/VUMBZ6Fa8ozURaQ7yrFBDKYbMMzo="
+      "revision": "aa19a11061ffe3cfac1281b210ab5fac8bb38f43",
+      "url": "https://github.com/juspay/kolu/archive/aa19a11061ffe3cfac1281b210ab5fac8bb38f43.tar.gz",
+      "hash": "sha256-0zxHsF8jGNyFj9Tyfw6OXa61i/TifFdU1iAx5XYP4g4="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
The pair PR [`.claude/rules/surface.md`](https://github.com/juspay/kolu/blob/master/packages/AGENTS.md) requires for an API-facing change to `@kolu/surface-daemon` and `@kolu/surface-daemon-supervisor`.

Pairs with **[juspay/kolu#2217](https://github.com/juspay/kolu/pull/2217)**, pinned at its HEAD `aa19a1106`.

## What changed upstream

Each daemon package grew a narrow entry beside its barrel:

| leaf | carries | no longer compiles |
| --- | --- | --- |
| `@kolu/surface-daemon-supervisor/dial` | `dialSocket`, `DaemonContractSkewError`, `isContractSkewError`, `DaemonConnection` | `endpoint.ts` — the drivers, the convergence probe, and `osfacts-client` |
| `@kolu/surface-daemon/home` | `resolveDaemonHome` + the home path algebra | `daemonMain`, `daemonProcessMain`, the process-signal tier |
| `@kolu/surface-daemon/lifetime` | `DaemonLifetime`, `DaemonLifetimeInfo`, `lifetimeInfo` | the same |

The point is a browser-safe consumer of `connectPadi` that stops compiling a daemon runtime — kolu's own hydrate guard now asserts that **no bare daemon barrel** is in `@kolu/padi-client`'s import closure, where it previously recorded both as a known cost.

## Why this is the gate, not a migration

**Nothing drishti imports changed shape.** Both barrels' exported-symbol lists are byte-identical: the moved symbols are imported by their old homes and re-exported from them, so `endpoint.ts` and `daemonMain.ts` still export everything they did. The only public delta is three **added** `exports` entries.

Drishti reaches the barrels and one testlib, and names no deep path into either split module:

```
17  from "@kolu/surface-daemon"
 4  from "@kolu/surface-daemon-supervisor"
 3  from "@kolu/surface-daemon/upgrade-window.testlib"
```

So this PR exists to prove drishti still builds and passes CI against the new API — which is exactly what the rule asks for when the change is additive.

One thing worth stating rather than leaving implied: **drishti still hydrates `osfacts-client`, and still should.** kolu#2217 retires that second pin for consumers that reach `@kolu/padi-client/dial`; drishti is a direct supervisor-**barrel** consumer, so `endpoint.ts` — and with it the osfacts process-identity vocabulary — is still legitimately in its program.

## Evidence

- `just typecheck` — green across `common`, `agent`, `app`.
- `just test` — **387 pass / 7 skip / 0 fail**, 1064 assertions, 394 tests across 57 files.

The pin will be re-pointed at kolu master once #2217 merges. Per the rule, it will also be bumped to #2217's final post-gauntlet HEAD and re-validated before either side is called done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWaE2b2irwGkqt54XV7Dzd
