### PR TITLE
The rooted bundle — the pair PR for juspay/kolu#2222

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "9f18b38880534f23dcfe43284a82362abcb78427",
-      "url": "https://github.com/juspay/kolu/archive/9f18b38880534f23dcfe43284a82362abcb78427.tar.gz",
-      "hash": "sha256-58usevyLDkASrVXCixHGPoUYaGMKoG7DEd8cNLlvQTk="
+      "revision": "4de72349061cc3aee414a52df91f72a4b33d9882",
+      "url": "https://github.com/juspay/kolu/archive/4de72349061cc3aee414a52df91f72a4b33d9882.tar.gz",
+      "hash": "sha256-oeYJEQ5o2kkiaknWS88OaTvwk3N3rrbbkpmN5IaatmI="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "014b93be514428b203ea7d43eef0eb22390a1b74",
-      "url": "https://github.com/juspay/kolu/archive/014b93be514428b203ea7d43eef0eb22390a1b74.tar.gz",
-      "hash": "sha256-UcePO/qgdBkZ/cCR10393Xfkamtf3toKp8sZhWQI5gU="
+      "revision": "9f18b38880534f23dcfe43284a82362abcb78427",
+      "url": "https://github.com/juspay/kolu/archive/9f18b38880534f23dcfe43284a82362abcb78427.tar.gz",
+      "hash": "sha256-58usevyLDkASrVXCixHGPoUYaGMKoG7DEd8cNLlvQTk="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "475815cb677360bdea92852271cc1c6e8452c6c3",
-      "url": "https://github.com/juspay/kolu/archive/475815cb677360bdea92852271cc1c6e8452c6c3.tar.gz",
-      "hash": "sha256-ZFc4H1EjVUb4bCTH7kq/KCNzto+lGzBiONoYqnx0PNc="
+      "revision": "014b93be514428b203ea7d43eef0eb22390a1b74",
+      "url": "https://github.com/juspay/kolu/archive/014b93be514428b203ea7d43eef0eb22390a1b74.tar.gz",
+      "hash": "sha256-UcePO/qgdBkZ/cCR10393Xfkamtf3toKp8sZhWQI5gU="
     },
     "nixpkgs": {
       "type": "Git",

--- a/packages/app/src/server/admin-router.ts
+++ b/packages/app/src/server/admin-router.ts
@@ -36,6 +36,7 @@
  * by hand after every mutation).
  */
 
+import { mergeDisjointGroups } from "@kolu/surface/define";
 import { directDispatch } from "@kolu/surface/links/direct";
 import {
   implementSurfaces,
@@ -263,7 +264,10 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
   // prefix baked in (`hostSurfaceMap.name`), and `implementSurfaces` does the
   // same for the two siblings — so the host merges two `{group, handlers}`
   // pairs and there is nothing left to widen, re-adapt, or cast.
-  const group = surfaces.group.merge(hostsMap.group);
+  const group = mergeDisjointGroups({
+    adminSiblings: surfaces.group,
+    hostMap: hostsMap.group,
+  });
   const handlers: SurfaceHandlers = Object.create(null);
   for (const [tag, handler] of [
     ...Object.entries(surfaces.handlers),
@@ -277,21 +281,14 @@ export function buildAdminRouter(opts: AdminRouterOptions) {
     }
     handlers[tag] = handler;
   }
-  // `RpcGroup.merge` is a last-writer-wins `Map.set` with no collision
-  // detection, so the size check is the collision detector — the same
-  // assertion `defineSurface` makes about the walk it owns. It is also the
-  // successor to the deleted matcher-tree reasoning: route-set identity, in
-  // both directions, is what "the map is actually served" means now.
-  const expected = surfaces.group.requests.size + hostsMap.group.requests.size;
-  if (group.requests.size !== expected) {
-    const collisions = [...hostsMap.group.requests.keys()].filter((tag) =>
-      surfaces.group.requests.has(tag),
-    );
-    throw new Error(
-      `buildAdminRouter: merging the admin siblings with the host map dropped ` +
-        `${expected - group.requests.size} tag(s) — colliding: ${collisions.join(", ")}.`,
-    );
-  }
+  // The group half of that disjointness is the FRAMEWORK's proof now
+  // (`mergeDisjointGroups`, juspay/kolu#2222): `RpcGroup.merge` is a
+  // last-writer-wins `Map.set` with no collision detection, and the counted
+  // merge above throws naming the tag and both halves rather than leaving a
+  // swallowed tag to answer under the other's schema. It replaces the hand-rolled
+  // size check this file used to carry, and it is the successor to the deleted
+  // matcher-tree reasoning: route-set identity, in both directions, is what "the
+  // map is actually served" means now.
   if (Object.keys(handlers).length !== group.requests.size) {
     throw new Error(
       `buildAdminRouter: ${Object.keys(handlers).length} handler(s) bound for ` +


### PR DESCRIPTION
Pairs with **[juspay/kolu#2222](https://github.com/juspay/kolu/pull/2222)**, where `@kolu/surface`'s composed wire learns to carry an **unprefixed root** beside its sibling bundle: `connectSurfaces` grows a `core: { surface, name }` slot, `exposeRootedFaces` joins the expose family, and one genuinely new export — `mergeDisjointGroups`, the counted, disjointness-proving group merge — replaces five private spellings upstream.

**Nothing here had to change to keep compiling.** The whole seam is additive, and drishti's own `connectSurfaces` call (`admin` + `surfaceApp`, no root) is untouched — the reserved probes still address the first sibling's tags, `conn.core` is simply typed `undefined`. That is what this pair is *for*: it is the proof that "additive or it does not ship" held.

### The one adoption

`buildAdminRouter` merged the admin siblings with the host map and then hand-rolled the collision detector beside it — a size check plus a `filter` over one side's tags. That was the fifth spelling of a proof that is now exported, so it calls the framework's:

```ts
const group = mergeDisjointGroups({
  adminSiblings: surfaces.group,
  hostMap: hostsMap.group,
});
```

Because the halves arrive **labelled**, a collision now names the tag *and* which two halves claimed it, instead of reporting a total that came up short. *The handler-record check right below it stays* — that one is about handlers, not groups, and the framework proves nothing about a record this file assembles by hand.

### Verified at kolu `014b93be`

- `bun run typecheck` — clean across `common` / `agent` / `app`
- `just test` — 387 pass, 7 skip, **0 fail** (1064 assertions, 57 files)

> The pin will be re-bumped to kolu#2222's **final** head after its review gauntlet and CI, per `.claude/rules/surface.md` — a green pinned to a pre-gauntlet SHA is stale.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._