### PR TITLE
Pin kolu to juspay/kolu#2223 — the live rooted bundle

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "live-bundle",
       "submodules": false,
-      "revision": "4de72349061cc3aee414a52df91f72a4b33d9882",
-      "url": "https://github.com/juspay/kolu/archive/4de72349061cc3aee414a52df91f72a4b33d9882.tar.gz",
-      "hash": "sha256-oeYJEQ5o2kkiaknWS88OaTvwk3N3rrbbkpmN5IaatmI="
+      "revision": "b2e8be0d27772bd82a7d5320f373952ac3f89ce7",
+      "url": "https://github.com/juspay/kolu/archive/b2e8be0d27772bd82a7d5320f373952ac3f89ce7.tar.gz",
+      "hash": "sha256-4VRVHWYDIRU01y6GupUNfRKOrmamjQRuyWmfXMq/iBI="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
The paired repin for **[juspay/kolu#2223](https://github.com/juspay/kolu/pull/2223)**, which adds `implementRootedSurfaces` — a rooted surface bundle whose sibling set changes while it serves — and `SurfacesConnection.redial` to `@kolu/surface` / `@kolu/surface-app`.

**Drishti needs no source change, and this PR is the proof.** It consumes `implementSurfaces` (`packages/agent/src/runtime.ts`) and `connectSurfaces` (`packages/app/src/client/wire.ts`), neither of whose signatures moved, and it constructs no `SurfacesConnection` of its own — so the one shape change (a new required `redial` member on the value the seam *returns*) reaches nothing drishti writes.

### What moved in kolu

| | |
| --- | --- |
| **New** | `implementRootedSurfaces`, `MountedSurface`, `RootedSurfacesRuntime`, `SurfaceSiblingDropped`, `ImplementRootedSurfacesBase`, `MountSurfaceOptions`, `refusingHandler`, `bindSibling` (`@kolu/surface/server`); `isStandaloneRoot`, `notStandaloneRootDetail` (`@kolu/surface/define`); `SurfacesConnection.redial`, `ConnectAllocations.supersede` (`@kolu/surface-app`) |
| **Changed behaviour a consumer could see** | `trackConnectAllocations`: the release walk is memoized and the **first exit owns the verdict** — a second `dispose()` is now a true no-op rather than a second walk that re-disposes every resource. Strictly safer for drishti, which disposes once. |
| **Unchanged** | `implementSurface`, `implementSurfaces`, `composeSurfaceContracts`, `mergeDisjointGroups`, `exposeFace(s)`, `connectSurface(s)`' own signatures, and every wire tag |

### Verification

`just typecheck` green against the new pin (`packages/common`, `packages/agent`, `packages/app`). Full CI below.

Pinned to `b2e8be0d` — kolu#2223 at the head of its review gauntlet (architecture-first-principles → lowy ∥ hickey → grok debate to consensus → /simplify → code-police). Per `.claude/rules/surface.md` this gate is only satisfied against the **final** kolu HEAD, so if that PR moves again this pin is bumped and CI re-confirmed before either merges.