### PR TITLE
Roster in place — the pair PR for juspay/kolu#2228

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-app-roster-in-place",
       "submodules": false,
-      "revision": "8d78cf8579ae103fb223a3e1ce89f6b81f831bae",
-      "url": "https://github.com/juspay/kolu/archive/8d78cf8579ae103fb223a3e1ce89f6b81f831bae.tar.gz",
-      "hash": "sha256-xeqCCLY0Ywl/PaOsQ3ixba9l9NdQbw2gMm03kMK47fw="
+      "revision": "f7be52281cd586aca257f855fbe5c4b3cb44b2ab",
+      "url": "https://github.com/juspay/kolu/archive/f7be52281cd586aca257f855fbe5c4b3cb44b2ab.tar.gz",
+      "hash": "sha256-aVScbVgSvaL+coiv/CLnFbLGnRIfAPzG9mc+8xdZVkg="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-app-roster-in-place",
       "submodules": false,
-      "revision": "ff4c6f1521da5a1ca70cd9e86be9f33fbd740205",
-      "url": "https://github.com/juspay/kolu/archive/ff4c6f1521da5a1ca70cd9e86be9f33fbd740205.tar.gz",
-      "hash": "sha256-D6nKKA1uVroigi+FweIoCF84I8FPKbCatpSsNWgQ/sM="
+      "revision": "457a577bb153043f68dc0e4524710b7a411c8d9a",
+      "url": "https://github.com/juspay/kolu/archive/457a577bb153043f68dc0e4524710b7a411c8d9a.tar.gz",
+      "hash": "sha256-6xvDgPzBNoAaJrhTw8HQdNULMGxYItASCdFuU7kmH0o="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-app-roster-in-place",
       "submodules": false,
-      "revision": "4de72349061cc3aee414a52df91f72a4b33d9882",
-      "url": "https://github.com/juspay/kolu/archive/4de72349061cc3aee414a52df91f72a4b33d9882.tar.gz",
-      "hash": "sha256-oeYJEQ5o2kkiaknWS88OaTvwk3N3rrbbkpmN5IaatmI="
+      "revision": "ff4c6f1521da5a1ca70cd9e86be9f33fbd740205",
+      "url": "https://github.com/juspay/kolu/archive/ff4c6f1521da5a1ca70cd9e86be9f33fbd740205.tar.gz",
+      "hash": "sha256-D6nKKA1uVroigi+FweIoCF84I8FPKbCatpSsNWgQ/sM="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-app-roster-in-place",
       "submodules": false,
-      "revision": "457a577bb153043f68dc0e4524710b7a411c8d9a",
-      "url": "https://github.com/juspay/kolu/archive/457a577bb153043f68dc0e4524710b7a411c8d9a.tar.gz",
-      "hash": "sha256-6xvDgPzBNoAaJrhTw8HQdNULMGxYItASCdFuU7kmH0o="
+      "revision": "8d78cf8579ae103fb223a3e1ce89f6b81f831bae",
+      "url": "https://github.com/juspay/kolu/archive/8d78cf8579ae103fb223a3e1ce89f6b81f831bae.tar.gz",
+      "hash": "sha256-xeqCCLY0Ywl/PaOsQ3ixba9l9NdQbw2gMm03kMK47fw="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "surface-app-roster-in-place",
+      "branch": "master",
       "submodules": false,
-      "revision": "f7be52281cd586aca257f855fbe5c4b3cb44b2ab",
-      "url": "https://github.com/juspay/kolu/archive/f7be52281cd586aca257f855fbe5c4b3cb44b2ab.tar.gz",
-      "hash": "sha256-aVScbVgSvaL+coiv/CLnFbLGnRIfAPzG9mc+8xdZVkg="
+      "revision": "4b1758afad90b15624030e0fd00e1116586b4054",
+      "url": "https://github.com/juspay/kolu/archive/4b1758afad90b15624030e0fd00e1116586b4054.tar.gz",
+      "hash": "sha256-hQ+yq4GnYp7homn9iVXzyRpElGRSxoh52YAqO/lMp9E="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
Pairs with **[juspay/kolu#2228](https://github.com/juspay/kolu/pull/2228)** (`surface-app-roster-in-place`), the surface-rule gate for an API-facing change to `@kolu/surface` and `@kolu/surface-app`.

Pinned to kolu **`f7be52281cd586aca257f855fbe5c4b3cb44b2ab`** (`npins/sources.json`, branch `surface-app-roster-in-place`) — the branch's current head, and a long way past the first pin this PR carried (`ff4c6f1`). The pin bump is still the **whole diff**: drishti needed no source change.

The branch has since merged `origin/master`, so **this pin also carries [juspay/kolu#2229](https://github.com/juspay/kolu/pull/2229)** ("The upgrade's header allowlist can follow the live row") — the first thing in this pin that is *not* #2228's own work. See the section below for why drishti is inert to it too.

## What moved in kolu since `ff4c6f1`, and whether drishti felt it

The API **widened** after the first green. None of it reaches drishti.

| # | kolu change | drishti affected? |
|---|---|---|
| 1 | `SurfaceClientsBundle` grew from `{ clients, reroster, dispose }` to `{ clients, roster, health(), moves(), reroster, dispose }` — `roster` is the reactive read of `clients` (which `reroster` mutates in place, so Solid can't track it), `health()` is the bundle's own `surfaceClientsHealth` fold keyed off `roster`, and `moves(next)` asks whether a re-roster would change anything. | **No.** drishti never calls `surfaceClients` directly — the only two mentions in the tree are prose comments (`admin-router.ts:85`, `admin-surface.ts:133`). It reaches clients only through `connectSurfaces`' `conn.clients.admin` / `conn.clients.surfaceApp`, and nothing destructures the bundle as a bare record. |
| 2 | `conn.redial(surfaces)` is now **idempotent** — "a roster this connection is ALREADY on resolves without dialling anything." | **No.** drishti dials `connectSurfaces` exactly once (the top-level `await` in `client/wire.ts`) and never redials. |
| 3 | `conn.link.dispose` now releases the **whole connection**, not just the wire — it *is* `SurfacesConnection.dispose`. The connection's state machine gates the wire, so a second ungated door would leave it reading `live` over a dead wire. | **No.** drishti never disposes the connection: `conn` is a module-scope singleton for the page's lifetime, and there is no `conn.link.dispose()` (or `conn.dispose()`) call anywhere in the tree. |
| 4 | **New** `conn.connectionEpoch: Accessor<number>` on `SurfacesConnection` — a monotonic count of usable connections established. | **No** — purely additive. |
| 5 | **New** `followingWire.establishments()` / `.onEstablished(handler)` in `@kolu/surface/links/following`. | **No** — purely additive, and drishti imports no `links/following` path. |
| 6 | **New** `@kolu/surface` module `src/links/supersession.ts` — package-internal, no `exports` subpath, consumed by relative import. | **No** — not spellable from outside `@kolu/surface`. |
| 7 | `websocketLink`'s epoch wrap was refactored onto the shared supersession fence (`links/websocket.ts` −125 lines net churn). Behaviour now shared code; **no API change**. | **No.** drishti holds the link only as `export const wire: WatchableWire = conn.link.wire`; the `WatchableWire` shape is unchanged. |
| 8 | `ConnectAllocations.supersede` deleted. | **No** — package-internal, never exported (and already gone at `ff4c6f1`; the file keeps only the tombstone comment). drishti's own `supersede` hits are its agent-admit strings in `server/hostRegistry.ts`. |
| 9 | **New subpath export `@kolu/surface/teardown`** (`reportLeakedTeardown`), added in `d8d3be07`. It was package-internal at `457a577b` (it was row 6's other half); `@kolu/surface-app` now has the same exit and imports it across the package boundary instead of keeping a fourth copy. | **No** *for drishti's own source* — it imports no `@kolu/surface/teardown` path. But it **is** a genuine new resolution requirement for the hydration, and that was checked rather than assumed: see below. |
| 10 | **New export `policyBearingMember(spec)`** from `@kolu/surface/define` — returns the first member of a spec declaring a `client.onError` policy. It backs a new **pre-dial refusal** in `connectSurfaces`: a roster whose member declares `client.onError` while no `onClientError` interpreter was passed is now refused at *plan* time, before anything is dialled (it used to throw at client-build time on `redial`, which released the whole connection). | **No.** drishti passes `onClientError` at both seams (`client/wire.ts` — `interpretClientError` at `connectSurfaces` **and** `connectSurfaceMap`), so the interpreter is present and the scan short-circuits on its first line. The root admin/surfaceApp siblings carry no policy today anyway (`TPolicy = never`). |

### The one thing #9 actually required checking

drishti does not vendor `@kolu/surface` — `nix/overlay.nix` extracts each kolu workspace package as a nix-store path and `scripts/hydrate-kolu-packages.sh` `cp -rL`s it into `node_modules/@kolu/<name>`. A new `exports` subpath therefore only resolves if the hydrated `package.json` carries it. Verified on the hydrated tree at this pin:

```
$ grep '"./teardown"' node_modules/@kolu/surface/package.json
    "./teardown": "./src/teardown.ts",
$ grep -rn '@kolu/surface/teardown' node_modules/@kolu/surface-app/
src/connectAllocations.ts:68:import { reportLeakedTeardown } from "@kolu/surface/teardown";
src/solid/connectSurfaces.ts:93:import { reportLeakedTeardown } from "@kolu/surface/teardown";
```

It carries it, because the extraction is a whole-directory copy (`cp -r $kolu/packages/<name> $out`) rather than a filtered fileset — a new subpath rides along for free, and `typecheck` (which is what would have caught a miss) is green on both platforms.

### Why drishti is inert to the rest

Its entire contact surface with `connectSurfaces` is four reads in `packages/app/src/client/wire.ts`:

```ts
export const wire: WatchableWire = conn.link.wire;
export const hostMap = connectSurfaceMap(hostSurfaceMap, conn.transport, { … });
export function adminClient()      { return conn.clients.admin; }
export function surfaceAppClient() { return conn.clients.surfaceApp; }
```

All four keep their identity and their types. The one folding helper drishti *does* import, `surfaceClientsHealth({ admin, surfaceApp })` (`App.tsx`), still resolves from `@kolu/surface/solid` and still takes a hand-built `Record<string, Pick<SurfaceClient, "health">>` — the bundle's new `health()` is an *additional* door, not a replacement, so #1 does not reach it.

## The merged-in kolu#2229, and why it stops at the package boundary

The `origin/master` merge in this pin is the first change here that isn't #2228's own, and it is not a small one: it reworks `packages/surface-app/src/serve.ts` (+284/−…), **deletes** `pickUpgradeHeaders.{ts,test.ts}` and **adds** `upgradeHeaders.{ts,test.ts}` plus a new `./upgrade-headers` export subpath. A deleted module is the shape of change that breaks a downstream by name, so it was checked by name rather than assumed:

```
$ grep -rn "pickUpgradeHeaders\|upgradeHeaders\|serveSurfaceApp\|serveOverUnixSocket" packages/*/src
$ echo $?
1
```

Nothing. drishti never imported `pickUpgradeHeaders`, so its removal is not a break here, and drishti does not serve through `serveSurfaceApp` / `serveOverUnixSocket` either — it stands up its own `effect/unstable/http` server in `packages/app/src/server/main.ts` and reaches surface-app only through the **`/server`** subpath:

```ts
import {
  gateStaleSocket, serveSurfaceSocket, startWsHeartbeat, surfaceAppLayer,
} from "@kolu/surface-app/server";           // server/main.ts
import { surfaceAppServer } from "@kolu/surface-app/server";  // server/admin-router.ts
```

`src/server.ts` is **byte-identical** across the two pins — same git blob `02a9f8f`, and it does not appear in `git diff --stat 8d78cf8..f7be522 -- packages/surface-app/` at all. It also imports nothing from `./serve`. So `serve.ts` is reachable only via the `@kolu/surface-app/serve` subpath, which drishti does not import: #2229's rewrite is contained to an entrypoint drishti has no edge to. `typecheck` is green on both platforms, which is what would have caught a miss.

## CI

Full pipeline, both platforms, strict mode (`nix run github:juspay/odu -- run`) at `606fc0c`:

```
24 ok · 0 failed · 0 errored · 0 skipped · 0 cancelled — OK
```

Every lane green on **`x86_64-linux`** and **`aarch64-darwin`**: `nix`, `typecheck`, `fmt-check`, `bun-nix-fresh`, `flake-check`, `home-manager`, `drv-stability`, `agent-boots`, `test-daemon`.
 (`test-daemon@aarch64-darwin` is the pipeline's declared Darwin skip — the heavy pool e2e is odu-linux only, so it returns in 0s.) The bun suite itself: **394 pass, 0 fail** (1123 assertions, 57 files).

Venue: `x86_64-linux` was pinned to **`pureintent`** (`--host x86_64-linux=pureintent`) to keep the run off `kolu-ci-8`, whose odu-runner has been dropping the keep-alive; `aarch64-darwin` ran on the pool's `ci@petit`.

_Generated by [/be](https://github.com/srid/agency) on Claude Code (model claude-opus-5)._

