### PR TITLE
Pin kolu#2229 — the upgrade's header allowlist can follow the live row

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "surface-app-live-upgrade-headers",
       "submodules": false,
-      "revision": "e4701318deadee895c156ada172e37d38eae929d",
-      "url": "https://github.com/juspay/kolu/archive/e4701318deadee895c156ada172e37d38eae929d.tar.gz",
-      "hash": "sha256-WPjW+Gq+zrmYg+TPOGvvEd2LUxQBVyARL09spJS79fQ="
+      "revision": "fea23365f09dbfb51c6aec7ca4c7aeb2ae877acb",
+      "url": "https://github.com/juspay/kolu/archive/fea23365f09dbfb51c6aec7ca4c7aeb2ae877acb.tar.gz",
+      "hash": "sha256-u9J7uMn/l6+LuXWY82yIaQPho72+jsFt9giZc/jqObc="
     },
     "nixpkgs": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -7,11 +7,11 @@
         "owner": "juspay",
         "repo": "kolu"
       },
-      "branch": "master",
+      "branch": "surface-app-live-upgrade-headers",
       "submodules": false,
-      "revision": "4de72349061cc3aee414a52df91f72a4b33d9882",
-      "url": "https://github.com/juspay/kolu/archive/4de72349061cc3aee414a52df91f72a4b33d9882.tar.gz",
-      "hash": "sha256-oeYJEQ5o2kkiaknWS88OaTvwk3N3rrbbkpmN5IaatmI="
+      "revision": "e4701318deadee895c156ada172e37d38eae929d",
+      "url": "https://github.com/juspay/kolu/archive/e4701318deadee895c156ada172e37d38eae929d.tar.gz",
+      "hash": "sha256-WPjW+Gq+zrmYg+TPOGvvEd2LUxQBVyARL09spJS79fQ="
     },
     "nixpkgs": {
       "type": "Git",


### PR DESCRIPTION
The consumer half of [juspay/kolu#2229](https://github.com/juspay/kolu/pull/2229), which makes `serveSurfaceApp`'s `upgradeHeaders` readable **per accept** instead of once at the bind, and adds an `UpgradeHeadersRefused` arm to `SurfaceAppEvent`.

**Nothing in drishti changes but the pin.** Drishti consumes `@kolu/surface-app` from `/server` (the hand-built `acceptSurfaceSocket` + `serveSurfaceSocket` path its per-host `?host=` dispatch requires), `/solid`, `/surface`, `/notify`, `/lifecycle` and `/bun` — it names none of `serveSurfaceApp`, `upgradeHeaders`, `SurfaceAppEvent` or `SurfaceAppConnection`, so neither the new option arm nor the new event arm reaches its tree.

This PR exists to *prove* that rather than assert it: the gate is satisfied by drishti's CI being green against the new surface API, not by a grep. The pin also carries kolu master forward from `4de7234` to `e470131`, so #2224, #2225 and #2226 land with it.

Pinned to kolu `e4701318deadee895c156ada172e37d38eae929d`. Re-pinned to final kolu HEAD if the review gauntlet moves the API.